### PR TITLE
Preserve timestamp on file share artifacts

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/FileShareArtifact.cs
@@ -42,11 +42,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                         string filePathRelativeToDrop = filePath.Replace(dropLocation, string.Empty).Trim(trimChars);
                         using (StreamReader fileReader = fileSystemManager.GetFileReader(filePath))
                         {
+                            var fileInfo = fileSystemManager.GetFileInfo(filePath);
                             await
                                 fileSystemManager.WriteStreamToFile(
                                     fileReader.BaseStream,
                                     Path.Combine(localFolderPath, filePathRelativeToDrop),
-                                    executionContext.CancellationToken);
+                                    executionContext.CancellationToken,
+                                    fileInfo);
                         }
                     }
                     else

--- a/src/Agent.Worker/Release/ContainerFetchEngine/FetchEngine.cs
+++ b/src/Agent.Worker/Release/ContainerFetchEngine/FetchEngine.cs
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
 
                     using (Stream stream = await getFileTask.ConfigureAwait(false))
                     {
-                        await FileSystemManager.WriteStreamToFile(stream, tmpDownloadPath, cancellationToken);
+                        await FileSystemManager.WriteStreamToFile(stream, tmpDownloadPath, cancellationToken, null);
                     }
 
                     break;

--- a/src/Agent.Worker/Release/ZipStreamDownloader.cs
+++ b/src/Agent.Worker/Release/ZipStreamDownloader.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
                         path = path.Substring(normalizedRelativePath.Length);
                     }
 
-                    await fileSystemManager.WriteStreamToFile(stream.ZipStream, Path.Combine(localFolderPath, path), executionContext.CancellationToken);
+                    await fileSystemManager.WriteStreamToFile(stream.ZipStream, Path.Combine(localFolderPath, path), executionContext.CancellationToken, null);
 
                     streamsDownloaded++;
                 }


### PR DESCRIPTION
This certainly isn't commit ready. It's not even been run once, but before I go any father I wanted to know if this would even be eligible for a merge. It's convenient for us to preserve time stamps on our files. When the artifacts are downloaded from the file share they are reset to the current time, not the time they were built. This proposal would preserve them.