### PR TITLE
Pass wildcard itemspec to scorch to handle builds without a root mapping

### DIFF
--- a/src/Agent.Worker/Build/TFCommandManager.cs
+++ b/src/Agent.Worker/Build/TFCommandManager.cs
@@ -36,6 +36,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         private string AppConfigRestoreFile => Path.Combine(ExecutionContext.Variables.Agent_ServerOMDirectory, "tf.exe.config.restore");
 
+        private string SourcesDirectoryItemSpec => Path.Combine(SourcesDirectory, "*");
+
         // TODO: Remove AddAsync after last-saved-checkin-metadata problem is fixed properly.
         public async Task AddAsync(string localPath)
         {
@@ -69,15 +71,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             return localPath?.Trim() ?? string.Empty;
         }
 
-        // TODO: Fix scorch. Scorch blows up if a root mapping does not exist.
-        //
-        // No good workaround appears to exist. Attempting to resolve by workspace fails with
-        // the same error. Switching to "*" instead of passing "SourcesDirectory" allows the
-        // command to exit zero, but causes every source file to be deleted.
-        //
-        // The current approach taken is: allow the exception to bubble. The TfsVCSourceProvider
-        // will catch the exception, log it as a warning, throw away the workspace, and re-clone.
-        public async Task ScorchAsync() => await RunCommandAsync(FormatFlags.OmitCollectionUrl, "vc", "scorch", SourcesDirectory, "/recursive", "/diff", "/unmapped");
+        public async Task ScorchAsync() => await RunCommandAsync(FormatFlags.OmitCollectionUrl, "vc", "scorch", SourcesDirectoryItemSpec, "/recursive", "/diff", "/unmapped");
 
         public void SetupProxy(string proxyUrl, string proxyUsername, string proxyPassword)
         {


### PR DESCRIPTION
Fixes #1093. `tf vc scorch` accepts wildcarded `itemspecs`, which allows repository with no root mapping to be scorched without exception. The current behavior of re-cloning the workspace every time when there is no root mapping is a big performance hit for builds with many mappings.