### PR TITLE
Publish results task optimization when merge test result is opted.

### DIFF
--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -114,6 +114,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 bool dateFormatError = false;
                 TimeSpan totalTestCaseDuration = TimeSpan.Zero;
                 List<string> runAttachments = new List<string>();
+
                 InitializeTestRunAsyncLazy(publisher, buildId, runContext);
 
                 if (resultFiles.Count == 0)
@@ -160,10 +161,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                             dateFormatError = true;
                         }
 
-                        //continue to calculate duration as a fallback for case: if there is issue with format or dates are null or empty
-                        foreach (var tcResult in resultFileRunData.Results)
+                        // Continue to calculate duration as a fallback for case: if there is issue with format or dates are null or empty
+                        foreach (TestCaseResultData tcResult in resultFileRunData.Results)
                         {
-                            var durationInMs = Convert.ToInt32(tcResult.DurationInMs);
+                            int durationInMs = Convert.ToInt32(tcResult.DurationInMs);
                             totalTestCaseDuration = totalTestCaseDuration.Add(TimeSpan.FromMilliseconds(durationInMs));
                         }
 
@@ -207,7 +208,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     var testRunDataEnd =
                         new TestRunData(startedDate: minStartDate.ToString("o"),
                             completedDate: maxCompleteDate.ToString("o")) {Attachments = runAttachments.ToArray()};
-                    await publisher.EndTestRunAsync(testRunDataEnd, testRunInitializationAsyncLazy.Value.Result.Id, true, _executionContext.CancellationToken);
+                    TestRun testRun = await testRunInitializationAsyncLazy.Value;
+                    await publisher.EndTestRunAsync(testRunDataEnd, testRun.Id, true, _executionContext.CancellationToken);
                 }
             }
             catch (Exception ex) when (!(ex is OperationCanceledException))
@@ -232,7 +234,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     {
                         try
                         {
-                            await publisher.AddResultsAsync(testRunInitializationAsyncLazy.Value.Result, results,
+                            TestRun testRun = await testRunInitializationAsyncLazy.Value;
+                            await publisher.AddResultsAsync(testRun, results,
                                 _executionContext.CancellationToken);
                         }
                         finally

--- a/src/Agent.Worker/TestResults/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestRunPublisher.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.TeamFoundation.TestClient.PublishTestResults;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 {
@@ -138,6 +139,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         {
             Trace.Entering();
             RunUpdateModel updateModel = new RunUpdateModel(
+                startedDate: testRunData.StartDate,
                 completedDate: testRunData.CompleteDate,
                 state: TestRunState.Completed.ToString()
                 );


### PR DESCRIPTION
Publish results task optimization when merge test result is opted

- Publishing in parallel to a single run.
- Publishing in parallel with result file parsing.
- Controlling the number of parallel tasks to MAX 10.