### PR TITLE
Throw appropriate exception in case Git or Git LFS could not be found

### DIFF
--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -111,8 +111,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public bool EnsureGitVersion(Version requiredVersion, bool throwOnNotMatch)
         {
-            ArgUtil.NotNull(_gitPath, nameof(_gitPath));
             ArgUtil.NotNull(_gitVersion, nameof(_gitVersion));
+
+            if (_gitPath == null)
+            {
+                throw new InvalidOperationException("Could not find Git installed on the system. Please make sure GIT is installed and available in the PATH.");
+            }
 
             if (_gitVersion < requiredVersion && throwOnNotMatch)
             {
@@ -124,8 +128,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public bool EnsureGitLFSVersion(Version requiredVersion, bool throwOnNotMatch)
         {
-            ArgUtil.NotNull(_gitLfsPath, nameof(_gitLfsPath));
             ArgUtil.NotNull(_gitLfsVersion, nameof(_gitLfsVersion));
+
+            if (_gitLfsPath == null)
+            {
+                throw new InvalidOperationException("Could not find Git LFS installed on the system. Please make sure GIT LFS is installed and available in the PATH.");
+            }
 
             if (_gitLfsVersion < requiredVersion && throwOnNotMatch)
             {


### PR DESCRIPTION
As Git and Git LFS path are not passed as arguments throwing an `ArgumentNullException` is confusing. Throw an `InvalidOperationException` exception with an usable message for the user as this exception will end in the log in case Git or Git LFS could not be found on the agent.