### PR TITLE
Update docs to mention Win x86 and Linux ARM support

### DIFF
--- a/docs/start/envlinux.md
+++ b/docs/start/envlinux.md
@@ -3,15 +3,21 @@
 # ![Linux](../res/linux_med.png) Linux System Prerequisites [2.125.0 or above]
 
 ## Supported Distributions and Versions
-  - Red Hat Enterprise Linux 7
+
+x64
+  - Red Hat Enterprise Linux 7, 6
   - CentOS 7
   - Oracle Linux 7
-  - Fedora 25, Fedora 26
-  - Debian 8.7 or later versions
-  - Ubuntu 17.04, Ubuntu 16.04, Ubuntu 14.04
-  - Linux Mint 18, Linux Mint 17
-  - openSUSE 42.2 or later versions
+  - Fedora 28, 27
+  - Debian 9, 8.7 or later versions
+  - Ubuntu 18.04, Ubuntu 16.04, Ubuntu 14.04
+  - Linux Mint 18, 17
+  - openSUSE 42.3 or later versions
   - SUSE Enterprise Linux (SLES) 12 SP2 or later versions
+
+ARM32
+  - Debian 9 or later versions
+  - Ubuntu 18.04 or later versions
 
 ## Install .Net Core 2.x Linux Dependencies
 
@@ -21,8 +27,8 @@ You might see something like this which indicate a dependencies missing.
 ./config.sh
     libunwind.so.8 => not found
     libunwind-x86_64.so.8 => not found
-Dependencies is missing for Dotnet Core 2.0
-Execute ./bin/installdependencies.sh to install any missing Dotnet Core 2.0 dependencies.
+Dependencies is missing for Dotnet Core 2.1
+Execute ./bin/installdependencies.sh to install any missing Dotnet Core 2.1 dependencies.
 ```
 You can easily correct the problem by executing `./bin/installdependencies.sh`.  
 The `installdependencies.sh` script should install all required dependencies on all supported Linux versions   
@@ -32,10 +38,10 @@ The `installdependencies.sh` script should install all required dependencies on 
 
 If you use git, git >= 2.9.0 is a pre-requisite for Linux agents.
 
-## Optionally Java if Tfvc
+## Optionally Java if using TFVC
 
-The agent distributes team explorer everywhere.
+The agent distributes Team Explorer Everywhere.
 
-But, if you are using Tfvc, install Oracle Java 1.8+ as TEE uses Java.
+But, if you are using TFVC, install Oracle Java 1.8+ as TEE uses Java.
 
 ## [More .Net Core Prerequisites Information](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x)

--- a/docs/start/envubuntu.md
+++ b/docs/start/envubuntu.md
@@ -4,18 +4,18 @@
 
 ## Versions
 
-Tested on 16.04 LTS (Xenial) and 14.04 LTS (Trusty).  Not domain joined.  
+Tested on 18.04 LTS (Bionic), 16.04 LTS (Xenial) and 14.04 LTS (Trusty).  Not domain joined.  
 
-16.04 is recommended since latest and supports SystemD for runnings as a service.
+18.04 is recommended since it's the latest and supports SystemD for running as a service.
 
 ## Dependency Packages
 
-### Ubuntu 16.04 (64-bit only)
+### Ubuntu 18.04 (x64, ARM32), 16.04 (x64 only)
 ```bash
 sudo apt-get install -y libunwind8 libcurl3
 ```
 
-### Ubuntu 14.04 (64-bit only)
+### Ubuntu 14.04 (x64 only)
 ```bash
 sudo apt-get install -y libunwind8 libcurl3 libicu52
 ```
@@ -35,11 +35,11 @@ $ sudo apt-get update
 $ sudo apt-get install git
 ```
 
-## Optionally Java if Tfvc
+## Optionally Java if using TFVC
 
-The agent distributes team explorer everywhere.
+The agent distributes Team Explorer Everywhere.
 
-But, if you are using Tfvc, install Oracle Java 1.8+ as TEE uses Java.
+But, if you are using TFVC, install Oracle Java 1.8+ as TEE uses Java.
 
 ## Etc
 

--- a/docs/start/envwin.md
+++ b/docs/start/envwin.md
@@ -1,10 +1,10 @@
 # ![win](../res/win_med.png) Windows System Prerequisites
 
-## Windows 10 and Windows Server 2016 (64-bit)
+## Windows 10 and Windows Server 2016 (64-bit, 32-bit)
 
 No known system prerequisites are known at this time.
 
-## Windows 7 to Windows 8.1, Windows Server 2008 R2 SP1 to Windows Server 2012 R2 (64-bit)
+## Windows 7 to Windows 8.1, Windows Server 2008 R2 SP1 to Windows Server 2012 R2 (64-bit, 32-bit)
 
 [PowerShell 3.0 or higher](https://msdn.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell)
 


### PR DESCRIPTION
- Advertise that the agent now targets .NET Core 2.1
- Update the supported Linux distributions and versions
- Advertise that we now support two new OS architectures: Windows x86, and Linux ARM (e.g Raspberry Pi)
