### PR TITLE
Handle empty LaunchAgents folder correctly on MacOS

### DIFF
--- a/src/Misc/layoutbin/darwin.svc.sh.template
+++ b/src/Misc/layoutbin/darwin.svc.sh.template
@@ -36,7 +36,7 @@ function install()
     echo "Creating launch agent in ${PLIST_PATH}"
 
     if [ ! -d  "${LAUNCH_PATH}" ]; then
-        failed "${LAUNCH_PATH} does not exist.  OSX system dir expected"
+        mkdir ${LAUNCH_PATH}
     fi
 
     if [ -f "${PLIST_PATH}" ]; then


### PR DESCRIPTION
Update template script for svc.sh to account for an empty ~/Library/LaunchAgents folder.

This folder doesn't seem to exist by default in macOS 10.13, so instead of erroring out, we should create it.