### PR TITLE
Add a link to the Resource Utilization page whenever builds get throttled

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -1,14 +1,16 @@
-using Microsoft.TeamFoundation.DistributedTask.WebApi;
-using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
-using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
 using Microsoft.VisualStudio.Services.Agent.Worker.Container;
 using Microsoft.VisualStudio.Services.WebApi;
-using System.Threading.Tasks;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using Microsoft.VisualStudio.Services.Agent.Util;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -578,6 +580,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             if (!_throttlingReported)
             {
                 this.Warning(StringUtil.Loc("ServerTarpit"));
+
+                if (this.Variables.System_TFCollectionUrl != null)
+                {
+                    // Construct a URL to the resource utilization page, to aid the user debug throttling issues
+                    UriBuilder uriBuilder = new UriBuilder(Variables.System_TFCollectionUrl);
+                    NameValueCollection query = HttpUtility.ParseQueryString(uriBuilder.Query);
+                    DateTime endTime = DateTime.UtcNow;
+                    string queryDate = endTime.AddHours(-1).ToString("s") + "," + endTime.ToString("s");
+
+                    uriBuilder.Path += (Variables.System_TFCollectionUrl.EndsWith("/") ? "" : "/") + "_usersSettings/usage";
+                    query["tab"] = "pipelines";
+                    query["queryDate"] = queryDate;
+
+                    uriBuilder.Query = query.ToString();
+
+                    this.Warning(StringUtil.Loc("ServerTarpitUrl", uriBuilder.ToString()));
+                }
+
                 _throttlingReported = true;
             }
         }

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -581,7 +581,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 this.Warning(StringUtil.Loc("ServerTarpit"));
 
-                if (this.Variables.System_TFCollectionUrl != null)
+                if (!String.IsNullOrEmpty(this.Variables.System_TFCollectionUrl))
                 {
                     // Construct a URL to the resource utilization page, to aid the user debug throttling issues
                     UriBuilder uriBuilder = new UriBuilder(Variables.System_TFCollectionUrl);

--- a/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
@@ -45,13 +45,16 @@ namespace Microsoft.VisualStudio.Services.Agent
             // Inspect whether response has throttling information
             IEnumerable<string> vssRequestDelayed = null;
             IEnumerable<string> vssRequestQuotaReset = null;
+
             if (response.Headers.TryGetValues(HttpHeaders.VssRateLimitDelay, out vssRequestDelayed) &&
                 response.Headers.TryGetValues(HttpHeaders.VssRateLimitReset, out vssRequestQuotaReset) &&
                 !string.IsNullOrEmpty(vssRequestDelayed.FirstOrDefault()) &&
                 !string.IsNullOrEmpty(vssRequestQuotaReset.FirstOrDefault()))
             {
-                TimeSpan delay = TimeSpan.FromMilliseconds(int.Parse(vssRequestDelayed.First()));
-                DateTime expiration = DateTime.Parse(vssRequestQuotaReset.First());
+                TimeSpan delay = TimeSpan.FromMilliseconds(double.Parse(vssRequestDelayed.First()));
+                int expirationEpoch = int.Parse(vssRequestQuotaReset.First());
+                DateTime expiration = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(expirationEpoch);
+
                 _throttlingReporter.ReportThrottling(delay, expiration);
             }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 !string.IsNullOrEmpty(vssRequestDelayed.FirstOrDefault()) &&
                 !string.IsNullOrEmpty(vssRequestQuotaReset.FirstOrDefault()))
             {
-                TimeSpan delay = TimeSpan.FromMilliseconds(double.Parse(vssRequestDelayed.First()));
+                TimeSpan delay = TimeSpan.FromSeconds(double.Parse(vssRequestDelayed.First()));
                 int expirationEpoch = int.Parse(vssRequestQuotaReset.First());
                 DateTime expiration = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(expirationEpoch);
 

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -498,6 +498,7 @@
   "ScreenSaverPolicyWarning": "Screensaver policy is defined on the machine. This may lead to screensaver being enabled again. Active screensaver may impact UI operations, for e.g., automated UI tests may fail.",
   "SelfManageGitCreds": "You are in self manage git creds mode. Make sure your agent host machine can bypass any git authentication challenge.",
   "ServerTarpit": "The job is currently being throttled by the server. You may experience delays in console line output, job status reporting, and task log uploads.",
+  "ServerTarpitUrl": "Link to resource utilization page: {0}.",
   "ServerUrl": "server URL",
   "ServiceAlreadyExists": "The service already exists: {0}, it will be replaced",
   "ServiceConfigured": "Service {0} successfully configured",


### PR DESCRIPTION
Also, fix two additional bugs with the way the rate limit HTTP request headers were parsed, which prevented the throttling report process to work altogether.

The link is shown as a warning in the build results page:

![image](https://user-images.githubusercontent.com/2474119/46894776-a6b7e380-ce43-11e8-9f46-eafd16e93a75.png)
