### PR TITLE
alpine container support

### DIFF
--- a/docs/design/non-glibc-containers.md
+++ b/docs/design/non-glibc-containers.md
@@ -13,10 +13,10 @@ You can start from the `node:10-alpine` image.
 
 ## Tell the agent about Node.js
 The agent will read a container label "com.azure.dev.pipelines.handler.node.path".
-If it exists, it must be the path to the directory containing Node.js.
+If it exists, it must be the path to the Node.js binary.
 For example, in an image based on `node:10-alpine`, add this line to your Dockerfile:
 ```
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 ```
 
 ## Add requirements
@@ -38,7 +38,7 @@ RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
   && apk add bash sudo which shadow \
   && apk del .pipeline-deps
 
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 
 CMD [ "node" ]
 

--- a/docs/design/non-glibc-containers.md
+++ b/docs/design/non-glibc-containers.md
@@ -1,0 +1,45 @@
+# Non-glibc Containers
+
+If you want to use a non-glibc-based container, such as Alpine Linux, you will need to arrange a few things on your own.
+First, you must supply your own copy of Node.js.
+Second, you must add a label to your image telling the agent where to find the Node.js binary.
+Finally, stock Alpine doesn't come with other dependencies that Azure Pipelines depends on:
+bash, sudo, which, and groupadd.
+
+## Bring your own Node.js
+You are responsible for adding a Node LTS binary to your container.
+As of November 2018, we expect that to be Node 10 LTS.
+You can start from the `node:10-alpine` image.
+
+## Tell the agent about Node.js
+The agent will read a container label "com.azure.dev.pipelines.handler.node.path".
+If it exists, it must be the path to the directory containing Node.js.
+For example, in an image based on `node:10-alpine`, add this line to your Dockerfile:
+```
+LABEL "com.azure.dev.pipelines.handler.node.path"="/usr/local/bin/"
+```
+
+## Add requirements
+Azure Pipelines assumes a bash-based system with common administration packages installed.
+Alpine Linux in particular doesn't come with several of the packages needed.
+Installing `bash`, `sudo`, `which`, and `shadow` will cover the basic needs.
+```
+RUN apk add bash sudo which shadow
+```
+
+If you depend on any in-box or Marketplace tasks, you'll also need to supply the binaries they require.
+
+## Full example of a Dockerfile
+
+```
+FROM node:10-alpine
+
+RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
+  && apk add bash sudo which shadow \
+  && apk del .pipeline-deps
+
+LABEL "com.azure.dev.pipelines.handler.node.path"="/usr/local/bin/"
+
+CMD [ "node" ]
+
+```

--- a/docs/design/non-glibc-containers.md
+++ b/docs/design/non-glibc-containers.md
@@ -16,7 +16,7 @@ The agent will read a container label "com.azure.dev.pipelines.handler.node.path
 If it exists, it must be the path to the directory containing Node.js.
 For example, in an image based on `node:10-alpine`, add this line to your Dockerfile:
 ```
-LABEL "com.azure.dev.pipelines.handler.node.path"="/usr/local/bin/"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/"
 ```
 
 ## Add requirements
@@ -38,7 +38,7 @@ RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam \
   && apk add bash sudo which shadow \
   && apk del .pipeline-deps
 
-LABEL "com.azure.dev.pipelines.handler.node.path"="/usr/local/bin/"
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/"
 
 CMD [ "node" ]
 

--- a/src/Agent.Worker/Container/ContainerInfo.cs
+++ b/src/Agent.Worker/Container/ContainerInfo.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         public string ContainerNetwork { get; set; }
         public string ContainerImage { get; set; }
         public string ContainerName { get; set; }
+        public string NodeJsPath { get; set; }
         public Guid ContainerRegistryEndpoint { get; private set; }
         public string ContainerCreateOptions { get; private set; }
         public bool SkipContainerImagePull { get; private set; }

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         Task<int> DockerNetworkRemove(IExecutionContext context, string network);
         Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command);
         Task<int> DockerExec(IExecutionContext context, string containerId, string options, string command, List<string> outputs);
+        Task<string> DockerInspect(IExecutionContext context, string dockerObject, string options);
     }
 
     public class DockerCommandManager : AgentService, IDockerCommandManager
@@ -120,7 +121,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
                 }
             }
 
-            string node = context.Container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin", $"node{IOUtil.ExeExtension}"));
+            string node = Path.Combine(context.Container.NodeJsPath, $"node{IOUtil.ExeExtension}");
             string sleepCommand = $"\"{node}\" -e \"setInterval(function(){{}}, 24 * 60 * 60 * 1000);\"";
 #if OS_WINDOWS
             string dockerArgs = $"--name {displayName} {options} {dockerEnvArgs} {dockerMountVolumesArgs} {image} {sleepCommand}";  // add --network={network} and -v '\\.\pipe\docker_engine:\\.\pipe\docker_engine' when they are available (17.09)
@@ -210,6 +211,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
                             requireExitCodeZero: false,
                             outputEncoding: null,
                             cancellationToken: CancellationToken.None);
+        }
+
+        public async Task<string> DockerInspect(IExecutionContext context, string dockerObject, string options)
+        {
+            string optionsAndTarget = options + " " + dockerObject;
+            context.Output("docker inspect " + optionsAndTarget);
+            string result = (await ExecuteDockerCommandAsync(context, "inspect", optionsAndTarget)).FirstOrDefault();
+            context.Output($"  result: {result}");
+            return result;
         }
 
         private Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
                 }
             }
 
-            string node = Path.Combine(context.Container.NodeJsPath, $"node{IOUtil.ExeExtension}");
+            string node = context.Container.NodeJsPath;
             string sleepCommand = $"\"{node}\" -e \"setInterval(function(){{}}, 24 * 60 * 60 * 1000);\"";
 #if OS_WINDOWS
             string dockerArgs = $"--name {displayName} {options} {dockerEnvArgs} {dockerMountVolumesArgs} {image} {sleepCommand}";  // add --network={network} and -v '\\.\pipe\docker_engine:\\.\pipe\docker_engine' when they are available (17.09)

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -216,9 +216,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         public async Task<string> DockerInspect(IExecutionContext context, string dockerObject, string options)
         {
             string optionsAndTarget = options + " " + dockerObject;
-            context.Output("docker inspect " + optionsAndTarget);
             string result = (await ExecuteDockerCommandAsync(context, "inspect", optionsAndTarget)).FirstOrDefault();
-            context.Output($"  result: {result}");
             return result;
         }
 

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
     public class ContainerOperationProvider : AgentService, IContainerOperationProvider
     {
-        private const string _nodeJsPathLabel = "com.azure.dev.pipelines.handler.node.path";
+        private const string _nodeJsPathLabel = "com.azure.dev.pipelines.agent.handler.node.path";
         private IDockerCommandManager _dockerManger;
 
         public override void Initialize(IHostContext hostContext)

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -331,21 +331,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             executionContext.Output(StringUtil.Loc("GrantContainerUserSUDOPrivilege", containerUserName));
 
             // Create a new vsts_sudo group for giving sudo permission
-            int execGroupaddExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"groupadd VSTS_Container_SUDO");
+            int execGroupaddExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"groupadd vsts_container_sudo");
             if (execGroupaddExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker exec fail with exit code {execGroupaddExitCode}");
             }
 
             // Add the new created user to the new created VSTS_SUDO group.
-            int execUsermodExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"usermod -a -G VSTS_Container_SUDO {containerUserName}");
+            int execUsermodExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"usermod -a -G vsts_container_sudo {containerUserName}");
             if (execUsermodExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker exec fail with exit code {execUsermodExitCode}");
             }
 
             // Allow the new vsts_sudo group run any sudo command without providing password.
-            int execEchoExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"su -c \"echo '%VSTS_Container_SUDO ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers\"");
+            int execEchoExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"su -c \"echo '%vsts_container_sudo ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers\"");
             if (execUsermodExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker exec fail with exit code {execEchoExitCode}");

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -320,7 +320,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             // Create a new user with same UID
             if (string.IsNullOrEmpty(containerUserName))
             {
-                containerUserName = $"{container.CurrentUserName}_VSTSContainer";
+                containerUserName = $"{container.CurrentUserName}_azpcontainer";
                 int execUseraddExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"useradd -m -u {container.CurrentUserId} {containerUserName}");
                 if (execUseraddExitCode != 0)
                 {

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                                                       dockerObject: container.ContainerImage,
                                                                       options: $"--format=\"{{{{index .Config.Labels \\\"{_nodeJsPathLabel}\\\"}}}}\"");
                 container.NodeJsPath = string.IsNullOrEmpty(nodeJsPath)
-                                     ? container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin"))
+                                     ? container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin", $"node{IOUtil.ExeExtension}"))
                                      : nodeJsPath;
 
                 container.ContainerId = await _dockerManger.DockerCreate(context: executionContext,

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -330,22 +330,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             executionContext.Output(StringUtil.Loc("GrantContainerUserSUDOPrivilege", containerUserName));
 
-            // Create a new vsts_sudo group for giving sudo permission
-            int execGroupaddExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"groupadd vsts_container_sudo");
+            // Create a new group for giving sudo permission
+            int execGroupaddExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"groupadd azure_pipelines_sudo");
             if (execGroupaddExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker exec fail with exit code {execGroupaddExitCode}");
             }
 
-            // Add the new created user to the new created VSTS_SUDO group.
-            int execUsermodExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"usermod -a -G vsts_container_sudo {containerUserName}");
+            // Add the new created user to the new created sudo group.
+            int execUsermodExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"usermod -a -G azure_pipelines_sudo {containerUserName}");
             if (execUsermodExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker exec fail with exit code {execUsermodExitCode}");
             }
 
-            // Allow the new vsts_sudo group run any sudo command without providing password.
-            int execEchoExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"su -c \"echo '%vsts_container_sudo ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers\"");
+            // Allow the new sudo group run any sudo command without providing password.
+            int execEchoExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"su -c \"echo '%azure_pipelines_sudo ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers\"");
             if (execUsermodExitCode != 0)
             {
                 throw new InvalidOperationException($"Docker exec fail with exit code {execEchoExitCode}");

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -100,7 +100,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             StepHost.OutputDataReceived += OnDataReceived;
             StepHost.ErrorDataReceived += OnDataReceived;
 
-            string file = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin", $"node{IOUtil.ExeExtension}");
+            string file;
+            if (ExecutionContext.Container == null)
+            {
+                file = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin", $"node{IOUtil.ExeExtension}");
+            }
+            else
+            {
+                file = Path.Combine(ExecutionContext.Container.NodeJsPath, $"node{IOUtil.ExeExtension}");
+            }
             // Format the arguments passed to node.
             // 1) Wrap the script file path in double quotes.
             // 2) Escape double quotes within the script file path. Double-quote is a valid

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             }
             else
             {
-                file = Path.Combine(ExecutionContext.Container.NodeJsPath, $"node{IOUtil.ExeExtension}");
+                file = ExecutionContext.Container.NodeJsPath;
             }
             // Format the arguments passed to node.
             // 1) Wrap the script file path in double quotes.

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             string tempDir = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), Constants.Path.TempDirectory);
             File.Copy(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), "containerHandlerInvoker.js.template"), Path.Combine(tempDir, "containerHandlerInvoker.js"), true);
 
-            string node = Path.Combine(Container.NodeJsPath, $"node{IOUtil.ExeExtension}");
+            string node = Container.NodeJsPath;
             string entryScript = Container.TranslateToContainerPath(Path.Combine(tempDir, "containerHandlerInvoker.js"));
 
 #if !OS_WINDOWS

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             string tempDir = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), Constants.Path.TempDirectory);
             File.Copy(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), "containerHandlerInvoker.js.template"), Path.Combine(tempDir, "containerHandlerInvoker.js"), true);
 
-            string node = Container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin", $"node{IOUtil.ExeExtension}"));
+            string node = Path.Combine(Container.NodeJsPath, $"node{IOUtil.ExeExtension}");
             string entryScript = Container.TranslateToContainerPath(Path.Combine(tempDir, "containerHandlerInvoker.js"));
 
 #if !OS_WINDOWS


### PR DESCRIPTION
Today, we can't run jobs in Alpine containers because the agent always bring its own Node.js. Our Node.js is compiled against the wrong libc (Alpine uses musl), so the one the agent brings won't even launch. This feature adds the ability for a container to bring its own Node.js and ask the agent to use it instead of the one in externals.

Putting up a PR for discussion on the merits.