### PR TITLE
Agent changes to use HTTP 1.1 on Linux and OSX

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     messageQueueLoopTokenSource.Dispose();
                 }
             }
-            catch (TaskAgentAccessTokeExpiredException)
+            catch (TaskAgentAccessTokenExpiredException)
             {
                 Trace.Info("Agent OAuth token has been revoked. Shutting down.");
             }

--- a/src/Agent.Listener/MessageListener.cs
+++ b/src/Agent.Listener/MessageListener.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     Trace.Info("Session creation has been cancelled.");
                     throw;
                 }
-                catch (TaskAgentAccessTokeExpiredException)
+                catch (TaskAgentAccessTokenExpiredException)
                 {
                     Trace.Info("Agent OAuth token has been revoked. Session creation failed.");
                     throw;
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     Trace.Info("Get next message has been cancelled.");
                     throw;
                 }
-                catch (TaskAgentAccessTokeExpiredException)
+                catch (TaskAgentAccessTokenExpiredException)
                 {
                     Trace.Info("Agent OAuth token has been revoked. Unable to pull message.");
                     throw;

--- a/src/Agent.PluginHost/Agent.PluginHost.csproj
+++ b/src/Agent.PluginHost/Agent.PluginHost.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" /> -->
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -228,7 +228,9 @@ namespace Agent.Plugins.Repository
             {
                 // the endpoint should either be the SystemVssConnection (id = guild.empty, name = SystemVssConnection)
                 // or a real service endpoint to external service which has a real id
-                endpoint = executionContext.Endpoints.Single(x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) || (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name, StringComparison.OrdinalIgnoreCase)));
+                endpoint = executionContext.Endpoints.Single(
+                    x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
+                    (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
             }
 
             if (endpoint != null && endpoint.Data.TryGetValue(EndpointData.AcceptUntrustedCertificates, out string endpointAcceptUntrustedCerts))

--- a/src/Agent.Plugins/SvnCliManager.cs
+++ b/src/Agent.Plugins/SvnCliManager.cs
@@ -37,7 +37,9 @@ namespace Agent.Plugins.Repository
             ArgUtil.Equal(true, repository.Url.IsAbsoluteUri, nameof(repository.Url.IsAbsoluteUri));
 
             ArgUtil.NotNull(repository.Endpoint, nameof(repository.Endpoint));
-            ServiceEndpoint endpoint = context.Endpoints.Single(x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) || (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name, StringComparison.OrdinalIgnoreCase)));
+            ServiceEndpoint endpoint = context.Endpoints.Single(
+                x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
+                (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
             ArgUtil.NotNull(endpoint.Data, nameof(endpoint.Data));
             ArgUtil.NotNull(endpoint.Authorization, nameof(endpoint.Authorization));
             ArgUtil.NotNull(endpoint.Authorization.Parameters, nameof(endpoint.Authorization.Parameters));

--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -47,7 +47,9 @@ namespace Agent.Plugins.Repository
             {
                 // the endpoint should either be the SystemVssConnection (id = guild.empty, name = SystemVssConnection)
                 // or a real service endpoint to external service which has a real id
-                var endpoint = executionContext.Endpoints.Single(x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) || (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name, StringComparison.OrdinalIgnoreCase)));
+                var endpoint = executionContext.Endpoints.Single(
+                    x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
+                    (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
                 ArgUtil.NotNull(endpoint, nameof(endpoint));
                 tf.Endpoint = endpoint;
             }
@@ -445,7 +447,9 @@ namespace Agent.Plugins.Repository
                 {
                     // the endpoint should either be the SystemVssConnection (id = guild.empty, name = SystemVssConnection)
                     // or a real service endpoint to external service which has a real id
-                    var endpoint = executionContext.Endpoints.Single(x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) || (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name, StringComparison.OrdinalIgnoreCase)));
+                    var endpoint = executionContext.Endpoints.Single(
+                        x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
+                        (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
                     ArgUtil.NotNull(endpoint, nameof(endpoint));
                     tf.Endpoint = endpoint;
                 }

--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
   </ItemGroup>

--- a/src/Agent.Sdk/CommandPlugin.cs
+++ b/src/Agent.Sdk/CommandPlugin.cs
@@ -129,6 +129,13 @@ namespace Agent.Sdk
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
 
+#if OS_LINUX || OS_OSX
+            // The .NET Core 2.1 runtime switched its HTTP default from HTTP 1.1 to HTTP 2.
+            // This causes problems with some versions of the Curl handler.
+            // See GitHub issue https://github.com/dotnet/corefx/issues/32376
+            VssClientHttpRequestSettings.Default.UseHttp11 = true;
+#endif
+
             var certSetting = GetCertConfiguration();
             if (certSetting != null)
             {

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -69,6 +69,13 @@ namespace Agent.Sdk
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
 
+#if OS_LINUX || OS_OSX
+            // The .NET Core 2.1 runtime switched its HTTP default from HTTP 1.1 to HTTP 2.
+            // This causes problems with some versions of the Curl handler.
+            // See GitHub issue https://github.com/dotnet/corefx/issues/32376
+            VssClientHttpRequestSettings.Default.UseHttp11 = true;
+#endif
+
             var certSetting = GetCertConfiguration();
             if (certSetting != null)
             {

--- a/src/Agent.Sdk/Util/VssUtil.cs
+++ b/src/Agent.Sdk/Util/VssUtil.cs
@@ -27,6 +27,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
             VssClientHttpRequestSettings.Default.ClientCertificateManager = clientCert;
+#if OS_LINUX
+            // The .NET Core 2.1 runtime switched its HTTP default from HTTP 1.1 to HTTP 2.
+            // This causes problems with some versions of the Curl handler on Linux.
+            // See GitHub issue https://github.com/dotnet/corefx/issues/32376
+            VssClientHttpRequestSettings.Default.UseHttp11 = true;
+#endif
+
             VssHttpMessageHandler.DefaultWebProxy = proxy;
         }
 

--- a/src/Agent.Sdk/Util/VssUtil.cs
+++ b/src/Agent.Sdk/Util/VssUtil.cs
@@ -27,9 +27,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
             VssClientHttpRequestSettings.Default.UserAgent = headerValues;
             VssClientHttpRequestSettings.Default.ClientCertificateManager = clientCert;
-#if OS_LINUX
+#if OS_LINUX || OS_OSX
             // The .NET Core 2.1 runtime switched its HTTP default from HTTP 1.1 to HTTP 2.
-            // This causes problems with some versions of the Curl handler on Linux.
+            // This causes problems with some versions of the Curl handler.
             // See GitHub issue https://github.com/dotnet/corefx/issues/32376
             VssClientHttpRequestSettings.Default.UseHttp11 = true;
 #endif

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
   </ItemGroup>

--- a/src/Agent.Worker/Build/BuildServer.cs
+++ b/src/Agent.Worker/Build/BuildServer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 },
             };
 
-            return await _buildHttpClient.UpdateBuildAsync(build, _projectId, buildId, cancellationToken: cancellationToken);
+            return await _buildHttpClient.UpdateBuildAsync(build, cancellationToken: cancellationToken);
         }
 
         public async Task<IEnumerable<string>> AddBuildTag(

--- a/src/Agent.Worker/Build/SvnCommandManager.cs
+++ b/src/Agent.Worker/Build/SvnCommandManager.cs
@@ -142,7 +142,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             ArgUtil.Equal(true, repository.Url.IsAbsoluteUri, nameof(repository.Url.IsAbsoluteUri));
 
             ArgUtil.NotNull(repository.Endpoint, nameof(repository.Endpoint));
-            ServiceEndpoint endpoint = context.Endpoints.Single(x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) || (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name, StringComparison.OrdinalIgnoreCase)));
+            ServiceEndpoint endpoint = context.Endpoints.Single(
+                x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
+                (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
 
             ArgUtil.NotNull(endpoint.Data, nameof(endpoint.Data));
             ArgUtil.NotNull(endpoint.Authorization, nameof(endpoint.Authorization));

--- a/src/Agent.Worker/Build/TfsVCSourceProvider.cs
+++ b/src/Agent.Worker/Build/TfsVCSourceProvider.cs
@@ -507,7 +507,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 var tf = HostContext.CreateService<ITfsVCCommandManager>();
                 tf.CancellationToken = CancellationToken.None;
                 tf.Repository = repository;
-                tf.Endpoint = executionContext.Endpoints.Single(x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) || (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name, StringComparison.OrdinalIgnoreCase)));
+                tf.Endpoint = executionContext.Endpoints.Single(
+                    x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
+                    (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
                 tf.ExecutionContext = executionContext;
 
                 // Attempt to resolve the path.

--- a/src/Agent.Worker/Release/Artifacts/GitHubHttpClient.cs
+++ b/src/Agent.Worker/Release/Artifacts/GitHubHttpClient.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             request.Headers.Add("Authorization", "Token " + accessToken);
             request.Headers.Add("User-Agent", "VSTS-Agent/" + Constants.Agent.Version);
 
-#if OS_LINUX
+#if OS_LINUX || OS_OSX
             request.Version = HttpVersion.Version11;
 #endif
 

--- a/src/Agent.Worker/Release/Artifacts/GitHubHttpClient.cs
+++ b/src/Agent.Worker/Release/Artifacts/GitHubHttpClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -40,6 +41,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             request.Headers.Add("Accept", "application/vnd.GitHubData.V3+json");
             request.Headers.Add("Authorization", "Token " + accessToken);
             request.Headers.Add("User-Agent", "VSTS-Agent/" + Constants.Agent.Version);
+
+#if OS_LINUX
+            request.Version = HttpVersion.Version11;
+#endif
 
             int httpRequestTimeoutSeconds;
             if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_HTTP_TIMEOUT") ?? string.Empty, out httpRequestTimeoutSeconds))

--- a/src/Agent.Worker/Release/ContainerFetchEngine/HttpRetryOnTimeoutHandler.cs
+++ b/src/Agent.Worker/Release/ContainerFetchEngine/HttpRetryOnTimeoutHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-#if OS_LINUX
+#if OS_LINUX || OS_OSX
             request.Version = HttpVersion.Version11;
 #endif            
             // Potential improvements:

--- a/src/Agent.Worker/Release/ContainerFetchEngine/HttpRetryOnTimeoutHandler.cs
+++ b/src/Agent.Worker/Release/ContainerFetchEngine/HttpRetryOnTimeoutHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,6 +27,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+#if OS_LINUX
+            request.Version = HttpVersion.Version11;
+#endif            
             // Potential improvements:
             // 1. Calculate a max time across attempts, to avoid retries (this class) on top of retries (VssHttpRetryMessageHandler) 
             //    causing more time to pass than expected in degenerative cases.

--- a/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
+++ b/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,6 +40,10 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+#if OS_LINUX
+            request.Version = HttpVersion.Version11;
+#endif                
+
             // Call the inner handler.
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
@@ -40,10 +40,6 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-#if OS_LINUX
-            request.Version = HttpVersion.Version11;
-#endif                
-
             // Call the inner handler.
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ThrottlingReportHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.85-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.88-private" />
     <PackageReference Include="Moq" Version="4.6.36-alpha" />
   </ItemGroup>
 


### PR DESCRIPTION
The .NET Core 2.1 runtime switched its HTTP default from HTTP 1.1 to HTTP 2.
This causes problems with some versions of the Curl handler.
See https://github.com/dotnet/corefx/issues/32376 for more details.