### PR TITLE
Failing PublishTestResults task on failed test outcome

### DIFF
--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -311,7 +311,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         {
             foreach(var testCaseResultData in testRunData.Results)
             {
-                if(testCaseResultData.Outcome == TestOutcome.Failed.ToString())
+                if(testCaseResultData.Outcome == TestOutcome.Failed.ToString() || testCaseResultData.Outcome == TestOutcome.Aborted.ToString())
                 {
                     return true;
                 }

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Services.WebApi;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 {
@@ -22,6 +23,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private string _runTitle;
         private bool _publishRunLevelAttachments;
         private int _runCounter = 0;
+
+        private bool _failTaskOnFailedTests;
+
+        private bool _isTestRunOutcomeFailed = false;
         private readonly object _sync = new object();
         private string _testRunSystem;
         private const string _testRunSystemCustomFieldName = "TestRunSystem";
@@ -94,6 +99,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 commandContext.Task = PublishToNewTestRunPerTestResultFileAsync(_testResultFiles, publisher, runContext, resultReader.Name, PublishBatchSize, context.CancellationToken);
             }
             _executionContext.AsyncCommands.Add(commandContext);
+
+            if(_isTestRunOutcomeFailed)
+            {
+                _executionContext.Result = TaskResult.Failed;
+                _executionContext.Error(StringUtil.Loc("FailedTestsInResults"));
+            }
         }
 
         /// <summary>
@@ -119,6 +130,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     //test case results
                     _executionContext.Debug(StringUtil.Format("Reading test results from file '{0}'", resultFile));
                     TestRunData resultFileRunData = publisher.ReadResultsFromFile(runContext, resultFile);
+
+                    if(_failTaskOnFailedTests)
+                    {
+                        _isTestRunOutcomeFailed = GetTestRunOutcome(resultFileRunData);
+                    }
 
                     if (resultFileRunData != null && resultFileRunData.Results != null && resultFileRunData.Results.Length > 0)
                     {
@@ -249,6 +265,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                         _executionContext.Debug(StringUtil.Format("Reading test results from file '{0}'", resultFile));
                         TestRunData testRunData = publisher.ReadResultsFromFile(runContext, resultFile, runName);
 
+                        if(_failTaskOnFailedTests)
+                        {
+                            _isTestRunOutcomeFailed = GetTestRunOutcome(testRunData);
+                        }
+
                         cancellationToken.ThrowIfCancellationRequested();
 
                         if (testRunData != null && testRunData.Results != null && testRunData.Results.Length > 0)
@@ -279,6 +300,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             {
                 return StringUtil.Format("{0}_{1}", _runTitle, ++_runCounter);
             }
+        }
+
+        /// <summary>
+        /// Reads a list testRunData Object and returns true if any test case outcome is failed
+        /// </summary>
+        /// <param name="testRunDataList"></param>
+        /// <returns></returns>
+        private bool GetTestRunOutcome(TestRunData testRunData)
+        {
+            foreach(var testCaseResultData in testRunData.Results)
+            {
+                if(testCaseResultData.Outcome == TestOutcome.Failed.ToString())
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private IResultReader GetTestResultReader(string testRunner)
@@ -368,6 +406,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 _testRunSystem = string.Empty;
             }
 
+            string failTaskInput;
+            eventProperties.TryGetValue(PublishTestResultsEventProperties.FailTaskOnFailedTests, out failTaskInput);
+            if (string.IsNullOrEmpty(failTaskInput) || !bool.TryParse(failTaskInput, out _failTaskOnFailedTests))
+            {
+                // if no proper input is provided by default fail task is false
+                _failTaskOnFailedTests = false;
+            }
+
             string publishRunAttachmentsInput;
             eventProperties.TryGetValue(PublishTestResultsEventProperties.PublishRunAttachments, out publishRunAttachmentsInput);
             if (string.IsNullOrEmpty(publishRunAttachmentsInput) || !bool.TryParse(publishRunAttachmentsInput, out _publishRunLevelAttachments))
@@ -404,5 +450,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         public static readonly string PublishRunAttachments = "publishRunAttachments";
         public static readonly string ResultFiles = "resultFiles";
         public static readonly string TestRunSystem = "testRunSystem";
+        public static readonly string FailTaskOnFailedTests = "failTaskOnFailedTests";
     }
 }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -260,6 +260,7 @@
   "ExpectedMappingServerPath": "Expected mapping[{0}] server path: '{1}'. Actual: '{2}'",
   "Failed": "Failed: ",
   "FailedDeletingTempDirectory0Message1": "Failed to delete temporary directory '{0}'. {1}",
+  "FailedTestsInResults": "There are one or more test failures detected in result files. Detailed summary of published test results can be viewed in the Tests tab.",
   "FailedToAddTags": "Failed to apply tags to agent. Try again or ctrl-c to quit. Alternatively you may go to deployment group web page to add tags",
   "FailedToConnect": "Failed to connect.  Try again or ctrl-c to quit",
   "FailedToDeleteTempScript": "Failed to delete temporary inline script file '{0}'. {1}",

--- a/src/Test/L0/Worker/TestResults/ResultsCommandExtensionTests.cs
+++ b/src/Test/L0/Worker/TestResults/ResultsCommandExtensionTests.cs
@@ -179,6 +179,141 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "PublishTestResults")]
+        public void VerifyPublishTaskErrorIfFailTaskIsTrueAndThereAreFailedTests()
+        {
+            SetupMocks();
+            var resultCommand = new ResultsCommandExtension();
+            resultCommand.Initialize(_hc);
+            var command = new Command("results", "publish");
+            command.Properties.Add("resultFiles", "file1.trx,file2.trx");
+            command.Properties.Add("type", "NUnit");
+            command.Properties.Add("mergeResults", bool.TrueString);
+            command.Properties.Add("failTaskOnFailedTests", bool.TrueString);
+            var resultsFiles = new List<string> { "file1.trx", "file2.trx" };
+
+            var testRunData = new TestRunData();
+
+            var passedTest = new TestCaseResultData();
+            passedTest.Outcome = TestOutcome.Passed.ToString();
+
+            var failedTest = new TestCaseResultData();
+            failedTest.Outcome = TestOutcome.Failed.ToString();
+
+            testRunData.Results = new TestCaseResultData[] { passedTest, failedTest };
+            testRunData.Attachments = new string[] { "attachment1", "attachment2" };
+
+            _mockTestRunPublisher.Setup(q => q.StartTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRunData trd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Attachments.Length, trd.Attachments.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.AddResultsAsync(It.IsAny<TestRun>(), It.IsAny<TestCaseResultData[]>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRun testRun, TestCaseResultData[] tcrd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Results.Length, tcrd.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.ReadResultsFromFile(It.IsAny<TestRunContext>(), It.IsAny<string>()))
+                .Returns(testRunData);
+            _mockTestRunPublisher.Setup(q => q.EndTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            resultCommand.ProcessCommand(_ec.Object, command);
+
+            Assert.Equal(1, _errors.Count());
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyNoPublishTaskErrorIfFailTaskIsTrueAndThereAreNoneFailedTests()
+        {
+            SetupMocks();
+            var resultCommand = new ResultsCommandExtension();
+            resultCommand.Initialize(_hc);
+            var command = new Command("results", "publish");
+            command.Properties.Add("resultFiles", "file1.trx,file2.trx");
+            command.Properties.Add("type", "NUnit");
+            command.Properties.Add("mergeResults", bool.TrueString);
+            command.Properties.Add("failTaskOnFailedTests", bool.TrueString);
+            var resultsFiles = new List<string> { "file1.trx", "file2.trx" };
+
+            var testRunData = new TestRunData();
+
+            var passedTest = new TestCaseResultData();
+            passedTest.Outcome = TestOutcome.Passed.ToString();
+
+            testRunData.Results = new TestCaseResultData[] { passedTest };
+            testRunData.Attachments = new string[] { "attachment1", "attachment2" };
+
+            _mockTestRunPublisher.Setup(q => q.StartTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRunData trd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Attachments.Length, trd.Attachments.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.AddResultsAsync(It.IsAny<TestRun>(), It.IsAny<TestCaseResultData[]>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRun testRun, TestCaseResultData[] tcrd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Results.Length, tcrd.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.ReadResultsFromFile(It.IsAny<TestRunContext>(), It.IsAny<string>()))
+                .Returns(testRunData);
+            _mockTestRunPublisher.Setup(q => q.EndTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            resultCommand.ProcessCommand(_ec.Object, command);
+
+            Assert.Equal(0, _errors.Count());
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void VerifyNoPublishTaskErrorIfFailTaskIsFalseAndThereAreFailedTests()
+        {
+            SetupMocks();
+            var resultCommand = new ResultsCommandExtension();
+            resultCommand.Initialize(_hc);
+            var command = new Command("results", "publish");
+            command.Properties.Add("resultFiles", "file1.trx,file2.trx");
+            command.Properties.Add("type", "NUnit");
+            command.Properties.Add("mergeResults", bool.TrueString);
+            command.Properties.Add("failTaskOnFailedTests", bool.FalseString);
+            var resultsFiles = new List<string> { "file1.trx", "file2.trx" };
+
+            var testRunData = new TestRunData();
+            
+            var passedTest = new TestCaseResultData();
+            passedTest.Outcome = TestOutcome.Passed.ToString();
+
+            var failedTest = new TestCaseResultData();
+            failedTest.Outcome = TestOutcome.Failed.ToString();
+
+            testRunData.Results = new TestCaseResultData[] { passedTest, failedTest };
+            testRunData.Attachments = new string[] { "attachment1", "attachment2" };
+
+            _mockTestRunPublisher.Setup(q => q.StartTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRunData trd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Attachments.Length, trd.Attachments.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.AddResultsAsync(It.IsAny<TestRun>(), It.IsAny<TestCaseResultData[]>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRun testRun, TestCaseResultData[] tcrd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Results.Length, tcrd.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.ReadResultsFromFile(It.IsAny<TestRunContext>(), It.IsAny<string>()))
+                .Returns(testRunData);
+            _mockTestRunPublisher.Setup(q => q.EndTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            resultCommand.ProcessCommand(_ec.Object, command);
+
+            Assert.Equal(0, _errors.Count());
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
         public void VerifyResultsAreMergedWhenPublishingToSingleTestRun()
         {
             SetupMocks();

--- a/src/Test/L0/Worker/TestResults/ResultsCommandExtensionTests.cs
+++ b/src/Test/L0/Worker/TestResults/ResultsCommandExtensionTests.cs
@@ -225,6 +225,52 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "PublishTestResults")]
+        public void VerifyPublishTaskErrorIfFailTaskIsTrueAndThereAreAbortedTests()
+        {
+            SetupMocks();
+            var resultCommand = new ResultsCommandExtension();
+            resultCommand.Initialize(_hc);
+            var command = new Command("results", "publish");
+            command.Properties.Add("resultFiles", "file1.trx,file2.trx");
+            command.Properties.Add("type", "NUnit");
+            command.Properties.Add("mergeResults", bool.TrueString);
+            command.Properties.Add("failTaskOnFailedTests", bool.TrueString);
+            var resultsFiles = new List<string> { "file1.trx", "file2.trx" };
+
+            var testRunData = new TestRunData();
+
+            var passedTest = new TestCaseResultData();
+            passedTest.Outcome = TestOutcome.Passed.ToString();
+
+            var abortedTest = new TestCaseResultData();
+            abortedTest.Outcome = TestOutcome.Aborted.ToString();
+
+            testRunData.Results = new TestCaseResultData[] { passedTest, abortedTest };
+            testRunData.Attachments = new string[] { "attachment1", "attachment2" };
+
+            _mockTestRunPublisher.Setup(q => q.StartTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRunData trd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Attachments.Length, trd.Attachments.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.AddResultsAsync(It.IsAny<TestRun>(), It.IsAny<TestCaseResultData[]>(), It.IsAny<CancellationToken>()))
+                .Callback((TestRun testRun, TestCaseResultData[] tcrd, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(resultsFiles.Count * testRunData.Results.Length, tcrd.Length);
+                });
+            _mockTestRunPublisher.Setup(q => q.ReadResultsFromFile(It.IsAny<TestRunContext>(), It.IsAny<string>()))
+                .Returns(testRunData);
+            _mockTestRunPublisher.Setup(q => q.EndTestRunAsync(It.IsAny<TestRunData>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            resultCommand.ProcessCommand(_ec.Object, command);
+
+            Assert.Equal(1, _errors.Count());
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
         public void VerifyNoPublishTaskErrorIfFailTaskIsTrueAndThereAreNoneFailedTests()
         {
             SetupMocks();


### PR DESCRIPTION
Issue related : https://github.com/Microsoft/azure-pipelines-tasks/issues/1268
Adding a checkbox option : Fail if there are test failures.
![image](https://user-images.githubusercontent.com/13175100/49723461-dc831800-fc8c-11e8-86f7-0bdaab7b0eaf.png)

This PR relates to setting the task result to failed if the option is marked and there are test failures.