### PR TITLE
Bug fix for junit xml by phpunit as no name in testsuite - Failed to publish results

### DIFF
--- a/src/Agent.Worker/TestResults/JunitResultReader.cs
+++ b/src/Agent.Worker/TestResults/JunitResultReader.cs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             TimeSpan totalTestSuiteDuration = TimeSpan.Zero;
             TimeSpan totalTestCaseDuration = TimeSpan.Zero;
 
-            if (rootNode.Attributes["name"] != null && rootNode.Attributes["name"].Value != null)
+            if (rootNode.Attributes["name"] != null && rootNode.Attributes["name"].Value != null && rootNode.Attributes["name"].Value != string.Empty)
             {
                 testSuiteSummary.Name = rootNode.Attributes["name"].Value;
             }

--- a/src/Test/L0/Worker/TestResults/JunitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/JunitResultReaderTests.cs
@@ -54,6 +54,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             + "</testsuite>"
             + "</testsuite>"
             + "</testsuites>";
+
+            private const string _jUnitNestedResultsXmlWithEmptyNameAttribute = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<testsuites>"
+            + "<testsuite name=\"\" errors=\"0\" failures=\"1\" skipped=\"0\" tests=\"2\" time=\"0.006\" timestamp=\"2015-04-06T21:56:24\">"
+            + "<testsuite errors=\"0\" failures=\"1\" hostname=\"mghost\" name=\"com.contoso.billingservice.ConsoleMessageRendererTest\" skipped=\"0\" tests=\"2\" time=\"0.006\" timestamp=\"2015-04-06T21:56:24\">"
+            + "<testcase classname=\"com.contoso.billingservice.ConsoleMessageRendererTest\" name=\"testRenderNullMessage\" testType=\"asdasdas\" time=\"0.001\" />"
+            + "<testcase classname=\"com.contoso.billingservice.ConsoleMessageRendererTest\" name=\"testRenderMessage\" time=\"0.003\">"
+            + "<failure type=\"junit.framework.AssertionFailedError\">junit.framework.AssertionFailedError at com.contoso.billingservice.ConsoleMessageRendererTest.testRenderMessage(ConsoleMessageRendererTest.java:11)"
+            + "</failure>"
+            + "</testcase >"
+            + "<system-out><![CDATA[Hello World!]]>"
+            + "</system-out>"
+            + "<system-err><![CDATA[]]></system-err>"
+            + "</testsuite>"
+            + "</testsuite>"
+            + "</testsuites>";
             
         private const string _sampleJunitResultXmlInvalidTime = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
             + "<testsuite errors = \"0\" failures=\"0\" hostname=\"achalla-dev\" name=\"test.AllTests\" skipped=\"0\" tests=\"1\" time=\"NaN\" timestamp=\"2015-09-01T10:19:04\">"
@@ -394,6 +410,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             Assert.Equal(null, _testRunData.Results[0].AutomatedTestTypeId);
             Assert.Equal(1, _testRunData.Results.Count(r => r.Outcome.Equals("Failed")));
             Assert.Equal("com.contoso.billingservice.ConsoleMessageRendererTest", _testRunData.Name);
+            Assert.Equal("releaseUri", _testRunData.ReleaseUri);
+            Assert.Equal("releaseEnvironmentUri", _testRunData.ReleaseEnvironmentUri);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "PublishTestResults")]
+        public void PublishNestedJUnitResultsWithEmptyNameAttributeInTestSuite()
+        {
+            SetupMocks();
+            _junitResultsToBeRead = _jUnitNestedResultsXmlWithEmptyNameAttribute;
+            ReadResults(new TestRunContext("owner", "platform", "configuration", 1, "buildUri", "releaseUri", "releaseEnvironmentUri"));
+
+            Assert.NotNull(_testRunData);
+            Assert.Equal(2, _testRunData.Results.Length);
+            Assert.Equal(1, _testRunData.Results.Count(r => r.Outcome.Equals("Passed")));
+            Assert.Equal(null, _testRunData.Results[0].AutomatedTestId);
+            Assert.Equal(null, _testRunData.Results[0].AutomatedTestTypeId);
+            Assert.Equal(1, _testRunData.Results.Count(r => r.Outcome.Equals("Failed")));
+            Assert.Equal("JUnit", _testRunData.Name);
             Assert.Equal("releaseUri", _testRunData.ReleaseUri);
             Assert.Equal("releaseEnvironmentUri", _testRunData.ReleaseEnvironmentUri);
         }


### PR DESCRIPTION
Junit xml with no name is failing to get published.
Example junit -
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.255918">
    <testsuite name="Unit" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.126286">
      <testsuite name="Tests\Unit\ExampleTest" file="/home/vsts/work/1/s/tests/Unit/ExampleTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.126286">
        <testcase name="testBasicTest" class="Tests\Unit\ExampleTest" classname="Tests.Unit.ExampleTest" file="/home/vsts/work/1/s/tests/Unit/ExampleTest.php" line="15" assertions="1" time="0.126286"/>
      </testsuite>
    </testsuite>
    <testsuite name="Feature" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.129632">
      <testsuite name="Tests\Feature\ExampleTest" file="/home/vsts/work/1/s/tests/Feature/ExampleTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.129632">
        <testcase name="testBasicTest" class="Tests\Feature\ExampleTest" classname="Tests.Feature.ExampleTest" file="/home/vsts/work/1/s/tests/Feature/ExampleTest.php" line="15" assertions="1" time="0.129632"/>
      </testsuite>
    </testsuite>
  </testsuite>
</testsuites>
```
![image](https://user-images.githubusercontent.com/13175100/50284641-b07f4800-047f-11e9-9dab-71de640ba142.png)
