### PR TITLE
Respect Docker HEALTHCHECK(s) when starting sidecar containers

### DIFF
--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -128,6 +128,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 await StartContainerAsync(executionContext, container);
             }
+
+            foreach (var container in containers.FindAll(c => !c.IsJobContainer))
+            {
+                await ContainerHealthcheck(executionContext, container);
+            }
         }
 
         public async Task StopContainersAsync(IExecutionContext executionContext, object data)
@@ -523,6 +528,34 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             // Remove docker network from env
             executionContext.Variables.Set(Constants.Variables.Agent.ContainerNetwork, null);
+        }
+
+        private async Task ContainerHealthcheck(IExecutionContext executionContext, ContainerInfo container)
+        {
+            string healthCheck = "--format=\"{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}\"";
+            string serviceHealth = await _dockerManger.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck);
+            if (string.IsNullOrEmpty(serviceHealth))
+            {
+                // Container has no HEALTHCHECK
+                return;
+            }
+            executionContext.Output($"Waiting for {container.ContainerNetworkAlias} service to become healthy.");
+            TimeSpan backoff = TimeSpan.FromSeconds(2);
+            while (string.Equals(serviceHealth, "starting", StringComparison.OrdinalIgnoreCase))
+            {
+                executionContext.Output($"{container.ContainerNetworkAlias} service is starting, waiting {backoff.Seconds} before checking again.");
+                Thread.Sleep(backoff);
+                backoff = backoff.Multiply(2);
+                serviceHealth = await _dockerManger.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck);
+            }
+            if (string.Equals(serviceHealth, "healthy", StringComparison.OrdinalIgnoreCase))
+            {
+                executionContext.Output($"{container.ContainerNetworkAlias} service is healthy.");
+            }
+            else
+            {
+                throw new InvalidOperationException($"Failed to initialize, {container.ContainerNetworkAlias} service is {serviceHealth}.");
+            }
         }
     }
 }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 await StartContainerAsync(executionContext, container);
             }
 
-            foreach (var container in containers.FindAll(c => !c.IsJobContainer))
+            foreach (var container in containers.Where(c => !c.IsJobContainer))
             {
                 await ContainerHealthcheck(executionContext, container);
             }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -542,19 +542,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var retryCount = 0;
             while (string.Equals(serviceHealth, "starting", StringComparison.OrdinalIgnoreCase))
             {
-                try
-                {
-                    TimeSpan backoff = BackoffTimerHelper.GetExponentialBackoff(retryCount, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(2));
-                    executionContext.Output($"{container.ContainerNetworkAlias} service is starting, waiting {backoff.Seconds} seconds before checking again.");
-                    await Task.Delay(backoff, executionContext.CancellationToken);
-                    serviceHealth = await _dockerManger.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck);
-                    retryCount++;
-                }
-                catch (OperationCanceledException ex)
-                {
-                    Trace.Error($"Caught cancellation exception while waiting for container healthcheck: {ex}");
-                    return;
-                }
+                TimeSpan backoff = BackoffTimerHelper.GetExponentialBackoff(retryCount, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(2));
+                executionContext.Output($"{container.ContainerNetworkAlias} service is starting, waiting {backoff.Seconds} seconds before checking again.");
+                await Task.Delay(backoff, executionContext.CancellationToken);
+                serviceHealth = await _dockerManger.DockerInspect(context: executionContext, dockerObject: container.ContainerId, options: healthCheck);
+                retryCount++;
             }
             if (string.Equals(serviceHealth, "healthy", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -133,9 +133,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 await ContainerHealthcheck(executionContext, container);
             }
-
-            // Asynchronously check health of all sidecar containers with a HEALTHCHECK
-            await Task.WhenAll(containers.FindAll(c => !c.IsJobContainer).Select(c => ContainerHealthcheck(executionContext, c)));
         }
 
         public async Task StopContainersAsync(IExecutionContext executionContext, object data)


### PR DESCRIPTION
I wrote a sample that uses Postgres as a sidecar container. When the container starts, it takes ~10 seconds before the database will actually respond to requests, which is shorter than the fastest time it takes to start a job that pings the database, leading to a race condition error

Docker has HEALTHCHECK as a first class feature. This simply uses `docker inspect` to check if sidecar containers have a healthcheck, and if so it delays the "Initialize containers" step until the container is truly ready (healthcheck status == `healthy`), by whatever definition of ready it provides as part of the container