### PR TITLE
Add TF_BUILD to container environment

### DIFF
--- a/src/Agent.Worker/Container/ContainerInfo.cs
+++ b/src/Agent.Worker/Container/ContainerInfo.cs
@@ -33,7 +33,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             this.ContainerCreateOptions = container.Properties.Get<string>("options");
             this.SkipContainerImagePull = container.Properties.Get<bool>("localimage");
             _environmentVariables = container.Environment;
-            this.ContainerEnvironmentVariables.TryAdd(Constants.TFBuild, "True");
             this.ContainerCommand = container.Properties.Get<string>("command", defaultValue: "");
             this.IsJobContainer = isJobContainer;
 

--- a/src/Agent.Worker/Container/ContainerInfo.cs
+++ b/src/Agent.Worker/Container/ContainerInfo.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             this.ContainerCreateOptions = container.Properties.Get<string>("options");
             this.SkipContainerImagePull = container.Properties.Get<bool>("localimage");
             _environmentVariables = container.Environment;
+            this.ContainerEnvironmentVariables.TryAdd(Constants.TFBuild, "True");
             this.ContainerCommand = container.Properties.Get<string>("command", defaultValue: "");
             this.IsJobContainer = isJobContainer;
 

--- a/src/Misc/layoutbin/containerHandlerInvoker.js.template
+++ b/src/Misc/layoutbin/containerHandlerInvoker.js.template
@@ -52,6 +52,7 @@ process.stdin.on('end', function () {
         console.log("##vso[task.debug]Prepend Path: " + process.env['PATH']);
     }
 
+    process.env['TF_BUILD'] = 'True';
     var launch = spawn(handler, [handlerArg], options);
     launch.on('exit', function (code) {
         console.log("##vso[task.debug]Handler exit code: " + code);


### PR DESCRIPTION
Adds TF_BUILD to container job environment

~~If container env is given in the build, it will not be overwritten, and otherwise follows standard precedence order, ie can be overwritten with `env: ` in the step, or `env:` in the container resource definition~~ 

~~Outcome is job container is created with:  `docker create ... -e "TF_BUILD=True" ..."` as in non-container jobs~~

Will fix #2039 

Per offline discussion, set the variable directly in the process invoker. This makes the value immutable which mirrors the existing out-of-container process invocation, adhering to the existing spec