### PR TITLE
Fixed empty lines not flowing to log plugins

### DIFF
--- a/src/Agent.Sdk/LogPlugin.cs
+++ b/src/Agent.Sdk/LogPlugin.cs
@@ -368,7 +368,7 @@ namespace Agent.Sdk
 
         public void EnqueueOutput(string output)
         {
-            if (!String.IsNullOrEmpty(output))
+            if (output != null)
             {
                 foreach (var plugin in _plugins)
                 {

--- a/src/Agent.Sdk/ProcessInvoker.cs
+++ b/src/Agent.Sdk/ProcessInvoker.cs
@@ -471,7 +471,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                     if (completedTask == dequeueTask)
                     {
                         string input = await dequeueTask;
-                        if (!string.IsNullOrEmpty(input))
+                        if (input != null)
                         {
                             utf8Writer.WriteLine(input);
                             utf8Writer.Flush();

--- a/src/Agent.Worker/AgentLogPlugin.cs
+++ b/src/Agent.Worker/AgentLogPlugin.cs
@@ -95,14 +95,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
                 {
-                    if (!string.IsNullOrEmpty(e.Data))
+                    if (e.Data != null)
                     {
                         _outputs.Enqueue(e.Data);
                     }
                 };
                 processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
                 {
-                    if (!string.IsNullOrEmpty(e.Data))
+                    if (e.Data != null)
                     {
                         _outputs.Enqueue(e.Data);
                     }
@@ -217,12 +217,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public void Write(Guid stepId, string message)
         {
-            if (_pluginHostProcess != null && !string.IsNullOrEmpty(message))
+            if (_pluginHostProcess != null && message != null)
             {
-                var lines = message.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                var lines = message.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n', StringSplitOptions.None);
                 foreach (var line in lines)
                 {
-                    if (!String.IsNullOrEmpty(line))
+                    if (line != null)
                     {
                         _redirectedStdin.Enqueue($"{stepId}:{line}");
                     }


### PR DESCRIPTION
The empty lines are important to the way the log parsers (in this case the testresult parser) work.

There are places where newlines are part of the expected test result format. 

Additionally not passing these also messes up the diagnostic logging from the log plugins where the line numbers will not match the line numbers from the downloaded log files. 

The logs available for download via the download all logs or the task output in the build page both have the newlines intact. But the log plugins receive a modified version of the logs stripped of empty lines which sort of defeats the purpose of the log plugins working on the exact same logs. Ideally no such processing should be done.