### PR TITLE
Add more logging to L0 test

### DIFF
--- a/src/Test/L0/ProcessExtensionL0.cs
+++ b/src/Test/L0/ProcessExtensionL0.cs
@@ -47,10 +47,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     {
                         trace.Info($"Read env from {timeout.Id}");
                         var value = timeout.GetEnvironmentVariable(hc, envName);
+
                         if (string.Equals(value, envValue, StringComparison.OrdinalIgnoreCase))
                         {
                             trace.Info($"Find the env.");
                             return;
+                        }
+
+                        if (value != null)
+                        {
+                            trace.Error($"Env was found, but with different value. Expected: { envValue }, actual { value }");
+                        }
+                        else
+                        {
+                            trace.Error($"Env was not found");
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Add more logging to L0 test to increase our chances to find out what's causing the test to randomly fail.