### PR TITLE
Bump up bundled node 6 version to 6.16.0

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -4,7 +4,7 @@ PRECACHE=$2
 
 CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
-NODE_VERSION="6.10.3"
+NODE_VERSION="6.16.0"
 NODE10_VERSION="10.13.0"
 
 get_abs_path() {


### PR DESCRIPTION
Fixes #1551. Node 6.16.0 is the latest version as of Feb 15, 2019.