### PR TITLE
Agent service rename

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -22,7 +22,7 @@ From src:
 
 Normal dev flow:
 ```bash
-git clone https://github.com/microsoft/vsts-agent
+git clone https://github.com/microsoft/azure-pipelines-agent
 cd ./src
 ./dev.(sh/cmd) layout # the agent that build from source is in {root}/_layout
 <make code changes>

--- a/src/Agent.Listener/Configuration/OsxServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/OsxServiceControlManager.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
     {
         // This is the name you would see when you do `systemctl list-units | grep vsts`
         private const string _svcNamePattern = "vsts.agent.{0}.{1}";
-        private const string _svcDisplayPattern = "VSTS Agent ({0}.{1})";
+        private const string _svcDisplayPattern = "Azure Pipelines Agent ({0}.{1})";
         private const string _shTemplate = "darwin.svc.sh.template";
         private const string _svcShName = "svc.sh";
 

--- a/src/Agent.Listener/Configuration/SystemdControlManager.cs
+++ b/src/Agent.Listener/Configuration/SystemdControlManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
     {
         // This is the name you would see when you do `systemctl list-units | grep vsts`
         private const string _svcNamePattern = "vsts.agent.{0}.{1}.service";
-        private const string _svcDisplayPattern = "VSTS Agent ({0}.{1})";
+        private const string _svcDisplayPattern = "Azure Pipelines Agent ({0}.{1})";
 
         private const int MaxUserNameLength = 32;
         private const string VstsAgentServiceTemplate = "vsts.agent.service.template";

--- a/src/Agent.Listener/Configuration/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/WindowsServiceControlManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         public const string WindowsServiceControllerName = "AgentService.exe";
 
         private const string ServiceNamePattern = "vstsagent.{0}.{1}";
-        private const string ServiceDisplayNamePattern = "VSTS Agent ({0}.{1})";
+        private const string ServiceDisplayNamePattern = "Azure Pipelines Agent ({0}.{1})";
 
         private INativeWindowsServiceHelper _windowsServiceHelper;
         private ITerminal _term;


### PR DESCRIPTION
Update the service display name to match current branding. This will not change existing agent services, but at least moves us in the right direction.