### PR TITLE
[M149] Revert "Bump up bundled node 6 version to 6.16.0 (#2111)"

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -4,7 +4,7 @@ PRECACHE=$2
 
 CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
-NODE_VERSION="6.16.0"
+NODE_VERSION="6.10.3"
 NODE10_VERSION="10.13.0"
 
 get_abs_path() {


### PR DESCRIPTION
This reverts commit 09d78f42273736258b0bf0727cab69c1fc9f4a6a.

We need to wait for the tasks to consume the new task-lib, which contains a fix that will allow to bump this node version back to 6.16.0.