### PR TITLE
Validate minimum required docker version based on docker engine API version instead of docker version.

### DIFF
--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -50,11 +50,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         {
             string serverVersionStr = (await ExecuteDockerCommandAsync(context, "version", "--format '{{.Server.APIVersion}}'")).FirstOrDefault();
             ArgUtil.NotNullOrEmpty(serverVersionStr, "Docker.Server.Version");
-            context.Output($"Docker daemon version: {serverVersionStr}");
+            context.Output($"Docker daemon API version: {serverVersionStr}");
 
             string clientVersionStr = (await ExecuteDockerCommandAsync(context, "version", "--format '{{.Client.APIVersion}}'")).FirstOrDefault();
             ArgUtil.NotNullOrEmpty(serverVersionStr, "Docker.Client.Version");
-            context.Output($"Docker client version: {clientVersionStr}");
+            context.Output($"Docker client API version: {clientVersionStr}");
 
             // we interested about major.minor.patch version
             Regex verRegex = new Regex("\\d+\\.\\d+(\\.\\d+)?", RegexOptions.IgnoreCase);

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -48,11 +48,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 
         public async Task<DockerVersion> DockerVersion(IExecutionContext context)
         {
-            string serverVersionStr = (await ExecuteDockerCommandAsync(context, "version", "--format '{{.Server.Version}}'")).FirstOrDefault();
+            string serverVersionStr = (await ExecuteDockerCommandAsync(context, "version", "--format '{{.Server.APIVersion}}'")).FirstOrDefault();
             ArgUtil.NotNullOrEmpty(serverVersionStr, "Docker.Server.Version");
             context.Output($"Docker daemon version: {serverVersionStr}");
 
-            string clientVersionStr = (await ExecuteDockerCommandAsync(context, "version", "--format '{{.Client.Version}}'")).FirstOrDefault();
+            string clientVersionStr = (await ExecuteDockerCommandAsync(context, "version", "--format '{{.Client.APIVersion}}'")).FirstOrDefault();
             ArgUtil.NotNullOrEmpty(serverVersionStr, "Docker.Client.Version");
             context.Output($"Docker client version: {clientVersionStr}");
 

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(dockerVersion.ClientVersion, nameof(dockerVersion.ClientVersion));
 
 #if OS_WINDOWS
-            Version requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-CE version 17.6
+            Version requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-EE version 17.6
 #else
             Version requiredDockerEngineAPIVersion = new Version(1, 35); // Docker-CE version 17.12
 #endif

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -95,11 +95,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             Version requiredDockerEngineAPIVersion = new Version(1, 35); // Docker-CE version 17.12
 #endif
 
-            if (dockerVersion.ServerVersion < requiredDockerVersion)
+            if (dockerVersion.ServerVersion < requiredDockerEngineAPIVersion)
             {
                 throw new NotSupportedException(StringUtil.Loc("MinRequiredDockerServerVersion", requiredDockerEngineAPIVersion, _dockerManger.DockerPath, dockerVersion.ServerVersion));
             }
-            if (dockerVersion.ClientVersion < requiredDockerVersion)
+            if (dockerVersion.ClientVersion < requiredDockerEngineAPIVersion)
             {
                 throw new NotSupportedException(StringUtil.Loc("MinRequiredDockerClientVersion", requiredDockerEngineAPIVersion, _dockerManger.DockerPath, dockerVersion.ClientVersion));
             }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -90,18 +90,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(dockerVersion.ClientVersion, nameof(dockerVersion.ClientVersion));
 
 #if OS_WINDOWS
-            Version requiredDockerVersion = new Version(17, 6);
+            Version requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-CE version 17.6
 #else
-            Version requiredDockerVersion = new Version(17, 12);
+            Version requiredDockerEngineAPIVersion = new Version(1, 35); // Docker-CE version 17.12
 #endif
 
             if (dockerVersion.ServerVersion < requiredDockerVersion)
             {
-                throw new NotSupportedException(StringUtil.Loc("MinRequiredDockerServerVersion", requiredDockerVersion, _dockerManger.DockerPath, dockerVersion.ServerVersion));
+                throw new NotSupportedException(StringUtil.Loc("MinRequiredDockerServerVersion", requiredDockerEngineAPIVersion, _dockerManger.DockerPath, dockerVersion.ServerVersion));
             }
             if (dockerVersion.ClientVersion < requiredDockerVersion)
             {
-                throw new NotSupportedException(StringUtil.Loc("MinRequiredDockerClientVersion", requiredDockerVersion, _dockerManger.DockerPath, dockerVersion.ClientVersion));
+                throw new NotSupportedException(StringUtil.Loc("MinRequiredDockerClientVersion", requiredDockerEngineAPIVersion, _dockerManger.DockerPath, dockerVersion.ClientVersion));
             }
 
             // Clean up containers left by previous runs

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -348,8 +348,8 @@
     "",
     ".NET Framework x64 4.6 or higher is required to sync TFVC repositories. It is not required to sync Git repositories."
   ],
-  "MinRequiredDockerClientVersion": "Min required docker client version is '{0}', your docker ('{1}') client version is '{2}'",
-  "MinRequiredDockerServerVersion": "Min required docker server version is '{0}', your docker ('{1}') server version is '{2}'",
+  "MinRequiredDockerClientVersion": "Min required docker engine API client version is '{0}', your docker ('{1}') client version is '{2}'",
+  "MinRequiredDockerServerVersion": "Min required docker engine API server version is '{0}', your docker ('{1}') server version is '{2}'",
   "MinRequiredGitLfsVersion": "Min required git-lfs version is '{0}', your git-lfs ('{1}') version is '{2}'",
   "MinRequiredGitVersion": "Min required git version is '{0}', your git ('{1}') version is '{2}'",
   "MissingAgent": "The agent no longer exists on the server. Please reconfigure the agent.",


### PR DESCRIPTION
We replaced Docker-CE with ms-moby on hosted Ubuntu agents and the current check fails as with ms-moby, the docker version becomes 3.0.x. 

The docker version command output does not contain anything which can differentiate between ce and ms-moby. 

[command]/usr/bin/docker version
Client:
 Version:           3.0.3
 API version:       1.40
 Go version:        go1.11.4
 Git commit:        48bd4c6d
 Built:             Wed Jan 23 16:17:56 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          3.0.4
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.11.4
  Git commit:       8ecd530
  Built:            Fri Jan 25 01:45:38 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.2.2
  GitCommit:        9754871865f7fe2f4e74d43e2fc7ccd237edcbce
 runc:
  Version:          1.0.0-rc6+dev
  GitCommit:        96ec2177ae841256168fcf76954f7177af9446eb
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683

So we are falling back to checking for installation of ms-moby package. 