### PR TITLE
Retry agent update download on failure

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         public static string TFBuild = "TF_BUILD";
         public static string ProcessLookupId = "VSTS_PROCESS_LOOKUP_ID";
         public static string PluginTracePrefix = "##[plugin.trace]";
-        public static readonly int AgentDownloadRetryMaxAttempts = 5;
+        public static readonly int AgentDownloadRetryMaxAttempts = 3;
 
         // This enum is embedded within the Constants class to make it easier to reference and avoid
         // ambiguous type reference with System.Runtime.InteropServices.OSPlatform and System.Runtime.InteropServices.Architecture

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -50,6 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         public static string TFBuild = "TF_BUILD";
         public static string ProcessLookupId = "VSTS_PROCESS_LOOKUP_ID";
         public static string PluginTracePrefix = "##[plugin.trace]";
+        public static readonly int AgentDownloadRetryMaxAttempts = 5;
 
         // This enum is embedded within the Constants class to make it easier to reference and avoid
         // ambiguous type reference with System.Runtime.InteropServices.OSPlatform and System.Runtime.InteropServices.Architecture


### PR DESCRIPTION
Retry up to 3 times to make updates more resilient against any networking or CDN issues. Also set a configurable 15-minute download timeout per attempt.

Tested:
- [X] Exercise timeout/retry mechanism, set timeout really low
- [X] Happy path, agent zip downloads in one attempt