### PR TITLE
Fixing issue with DownloadArtifact using project Id

### DIFF
--- a/src/Agent.Plugins/PipelineArtifact/BuildServer.cs
+++ b/src/Agent.Plugins/PipelineArtifact/BuildServer.cs
@@ -55,7 +55,10 @@ namespace Agent.Plugins.PipelineArtifact
             return await _buildHttpClient.GetArtifactAsync(projectId, buildId, name, cancellationToken: cancellationToken);
         }
 
-        public Task<List<BuildArtifact>> GetArtifactsAsync(Guid project, int buildId, CancellationToken cancellationToken)
+        public Task<List<BuildArtifact>> GetArtifactsAsync(
+            Guid project,
+            int buildId,
+            CancellationToken cancellationToken)
         {
             return _buildHttpClient.GetArtifactsAsync(project, buildId, userState: null, cancellationToken: cancellationToken);
         }
@@ -68,6 +71,14 @@ namespace Agent.Plugins.PipelineArtifact
             CancellationToken cancellationToken)
         {
             return await _buildHttpClient.GetArtifactAsync(project, buildId, name, cancellationToken: cancellationToken);
+        }
+
+        public Task<List<BuildArtifact>> GetArtifactsWithProjectNameAsync(
+            string project,
+            int buildId,
+            CancellationToken cancellationToken)
+        {
+            return _buildHttpClient.GetArtifactsAsync(project, buildId, userState: null, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
@@ -83,7 +83,27 @@ namespace Agent.Plugins.PipelineArtifact
             // download all pipeline artifacts if artifact name is missing
             if (string.IsNullOrEmpty(downloadParameters.ArtifactName))
             {
-                List<BuildArtifact> artifacts = await buildHelper.GetArtifactsAsync(downloadParameters.ProjectId, downloadParameters.BuildId, cancellationToken);
+                List<BuildArtifact> artifacts;
+                if (downloadParameters.ProjectRetrievalOptions == BuildArtifactRetrievalOptions.RetrieveByProjectId)
+                {
+                    artifacts = await buildHelper.GetArtifactsAsync(downloadParameters.ProjectId, downloadParameters.BuildId, cancellationToken);
+                }
+                else if (downloadParameters.ProjectRetrievalOptions == BuildArtifactRetrievalOptions.RetrieveByProjectName)
+                {
+                    if (string.IsNullOrEmpty(downloadParameters.ProjectName))
+                    {
+                        throw new InvalidOperationException("Project name can't be empty when trying to fetch build artifacts!");
+                    }
+                    else
+                    {
+                        artifacts = await buildHelper.GetArtifactsWithProjectNameAsync(downloadParameters.ProjectName, downloadParameters.BuildId, cancellationToken);
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unreachable code!");
+                }
+
                 IEnumerable<BuildArtifact> pipelineArtifacts = artifacts.Where(a => a.Resource.Type == PipelineArtifactTypeName);
                 if (pipelineArtifacts.Count() == 0)
                 {


### PR DESCRIPTION
In the case where a user wants to download an artifact from another project's build, we have project name but not project Id. We try to use project Id to get the artifact though which results in an exception that the project Id can't be an empty Guid. I made changes similar to further down in the code that checks if we have project Id or name and have it use the right one