### PR TITLE
Scrub PII data from the job request message in the diag log

### DIFF
--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -187,6 +187,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             "Release.RequestedForEmail",
         };
 
+        public static readonly string PiiArtifactVariablePrefix = "Release.Artifacts";
+
+        public static readonly List<string> PiiArtifactVariableSuffixes = new List<string>()
+        {
+            "SourceBranch",
+            "SourceBranchName",
+            "SourceVersion",
+            "RequestedFor"
+        };
+
         public void ExpandValues(IDictionary<string, string> target)
         {
             _trace.Entering();

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -180,7 +180,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             "Build.SourceTfvcShelveset",
             "Build.SourceVersion",
             "Build.SourceVersionAuthor",
-            "Job.AuthorizeAs"
+            "Job.AuthorizeAs",
+            "Release.Deployment.RequestedFor",
+            "Release.Deployment.RequestedForEmail",
+            "Release.RequestedFor",
+            "Release.RequestedForEmail",
         };
 
         public void ExpandValues(IDictionary<string, string> target)

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -169,6 +169,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public string System_TFCollectionUrl => Get(WellKnownDistributedTaskVariables.TFCollectionUrl);
 
+        public static readonly HashSet<string> PiiVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Build.AuthorizeAs",
+            "Build.QueuedBy",
+            "Build.RequestedFor",
+            "Build.RequestedForEmail",
+            "Build.SourceBranch",
+            "Build.SourceBranchName",
+            "Build.SourceTfvcShelveset",
+            "Build.SourceVersion",
+            "Build.SourceVersionAuthor",
+            "Job.AuthorizeAs"
+        };
+
         public void ExpandValues(IDictionary<string, string> target)
         {
             _trace.Entering();

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -2,7 +2,6 @@ using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -59,9 +58,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Initialize the secret masker and set the thread culture.
                 InitializeSecretMasker(jobMessage);
                 SetCulture(jobMessage);
-                
+
                 // Start the job.
-                Trace.Info($"Job message:{Environment.NewLine} {ScrubPiiData(jobMessage)}");
+                Trace.Info($"Job message:{Environment.NewLine} {StringUtil.ConvertToJson(WorkerUtilities.ScrubPiiData(jobMessage))}");
                 Task<TaskResult> jobRunnerTask = jobRunner.RunAsync(jobMessage, jobRequestCancellationToken.Token);
 
                 // Start listening for a cancel message from the channel.
@@ -101,61 +100,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Await the job.
                 return TaskResultUtil.TranslateToReturnCode(await jobRunnerTask);
             }
-        }
-
-        private string ScrubPiiData(Pipelines.AgentJobRequestMessage message)
-        {
-            ArgUtil.NotNull(message, nameof(message));
-
-            var scrubbedVariables = new Dictionary<string, VariableValue>();
-
-            // Scrub the known PII variables
-            foreach (var variable in message.Variables)
-            {
-                if (Variables.PiiVariables.Contains(variable.Key))
-                {
-                    scrubbedVariables[variable.Key] = "***";
-                }
-                else
-                {
-                    scrubbedVariables[variable.Key] = variable.Value;
-                }
-            }
-
-            var scrubbedRepositories = new List<Pipelines.RepositoryResource>();
-
-            // Scrub the repository resources
-            foreach (var repository in message.Resources.Repositories)
-            {
-                Pipelines.RepositoryResource scrubbedRepository = repository.Clone();
-
-                scrubbedRepository.Properties.Set("VersionInfo", "***");
-                scrubbedRepositories.Add(scrubbedRepository);
-            }
-
-            var scrubbedJobResources = new Pipelines.JobResources();
-
-            scrubbedJobResources.Containers.AddRange(message.Resources.Containers);
-            scrubbedJobResources.Endpoints.AddRange(message.Resources.Endpoints);
-            scrubbedJobResources.Repositories.AddRange(scrubbedRepositories);
-            scrubbedJobResources.SecureFiles.AddRange(message.Resources.SecureFiles);
-
-            // Reconstitute a new agent job request message from the scrubbed parts
-            var scrubbedJobMessage = new Pipelines.AgentJobRequestMessage(
-                plan: message.Plan,
-                timeline: message.Timeline,
-                jobId: message.JobId,
-                jobDisplayName: message.JobDisplayName,
-                jobName: message.JobName,
-                jobContainer: message.JobContainer,
-                jobSidecarContainers: message.JobSidecarContainers,
-                variables: scrubbedVariables,
-                maskHints: message.MaskHints,
-                jobResources: scrubbedJobResources,
-                workspaceOptions: message.Workspace,
-                steps: message.Steps);
-
-            return StringUtil.ConvertToJson(scrubbedJobMessage);
         }
 
         private void InitializeSecretMasker(Pipelines.AgentJobRequestMessage message)

--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -2,7 +2,9 @@
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
+using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
@@ -22,6 +24,73 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(credentials, nameof(credentials));
             VssConnection connection = VssUtil.CreateConnection(systemConnection.Url, credentials);
             return connection;
+        }
+
+        public static Pipelines.AgentJobRequestMessage ScrubPiiData(Pipelines.AgentJobRequestMessage message)
+        {
+            ArgUtil.NotNull(message, nameof(message));
+
+            var scrubbedVariables = new Dictionary<string, VariableValue>();
+
+            // Scrub the known PII variables
+            foreach (var variable in message.Variables)
+            {
+                if (Variables.PiiVariables.Contains(variable.Key) ||
+                    (variable.Key.StartsWith(Variables.PiiArtifactVariablePrefix, StringComparison.OrdinalIgnoreCase)
+                    && Variables.PiiArtifactVariableSuffixes.Any(varSuffix => variable.Key.EndsWith(varSuffix, StringComparison.OrdinalIgnoreCase))))
+                {
+                    scrubbedVariables[variable.Key] = "[PII]";
+                }
+                else
+                {
+                    scrubbedVariables[variable.Key] = variable.Value;
+                }
+            }
+
+            var scrubbedRepositories = new List<Pipelines.RepositoryResource>();
+
+            // Scrub the repository resources
+            foreach (var repository in message.Resources.Repositories)
+            {
+                Pipelines.RepositoryResource scrubbedRepository = repository.Clone();
+
+                var versionInfo = repository.Properties.Get<Pipelines.VersionInfo>(Pipelines.RepositoryPropertyNames.VersionInfo);
+
+                if (versionInfo != null)
+                {
+                    scrubbedRepository.Properties.Set(
+                        Pipelines.RepositoryPropertyNames.VersionInfo,
+                        new Pipelines.VersionInfo()
+                        {
+                            Author = "[PII]",
+                            Message = versionInfo.Message
+                        });
+                }
+
+                scrubbedRepositories.Add(scrubbedRepository);
+            }
+
+            var scrubbedJobResources = new Pipelines.JobResources();
+
+            scrubbedJobResources.Containers.AddRange(message.Resources.Containers);
+            scrubbedJobResources.Endpoints.AddRange(message.Resources.Endpoints);
+            scrubbedJobResources.Repositories.AddRange(scrubbedRepositories);
+            scrubbedJobResources.SecureFiles.AddRange(message.Resources.SecureFiles);
+
+            // Reconstitute a new agent job request message from the scrubbed parts
+            return new Pipelines.AgentJobRequestMessage(
+                plan: message.Plan,
+                timeline: message.Timeline,
+                jobId: message.JobId,
+                jobDisplayName: message.JobDisplayName,
+                jobName: message.JobName,
+                jobContainer: message.JobContainer,
+                jobSidecarContainers: message.JobSidecarContainers,
+                variables: scrubbedVariables,
+                maskHints: message.MaskHints,
+                jobResources: scrubbedJobResources,
+                workspaceOptions: message.Workspace,
+                steps: message.Steps);
         }
     }
 }


### PR DESCRIPTION
There are some agent environmental variables (build and release), and a property in the repository info, which may contain PII (Personal Identifiable Information) data. Scrub those places from the agent diagnostics log.

Example of how the scrub looks like in practice:

**Build:**
```
    "build.requestedForEmail": {
      "value": "***"
    }
```

**Release:**
```
    "release.requestedForEmail": {
      "value": "***"
    },
```

