### PR TITLE
Changing vss-api-netcore version to 0.5.103-private

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.PluginHost/Agent.PluginHost.csproj
+++ b/src/Agent.PluginHost/Agent.PluginHost.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
   </ItemGroup>

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
+++ b/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.100-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
     <PackageReference Include="Moq" Version="4.6.36-alpha" />
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Changing vss-api-netcore version to 0.5.103-private. This package has the dot file fix for Download Pipeline Artifact task.