### PR TITLE
Update Test result parser

### DIFF
--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
-    <PackageReference Include="azuredevops-testresultparser" Version="1.0.0" />
+    <PackageReference Include="azuredevops-testresultparser" Version="1.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
     <PackageReference Include="vss-api-netcore" Version="0.5.103-private" />
     <PackageReference Include="Moq" Version="4.6.36-alpha" />
-    <PackageReference Include="azuredevops-testresultparser" Version="1.0.0" />
+    <PackageReference Include="azuredevops-testresultparser" Version="1.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
Updating the Test result parser which latest version which contains the fix for the python regex timeout fix.