### PR TITLE
Add PoolName to agent service name

### DIFF
--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -242,7 +242,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             {
                 try
                 {
-                    await agentProvider.GetPoolId(agentSettings, command);
+                    await agentProvider.GetPoolIdAndName(agentSettings, command);
                     break;
                 }
                 catch (Exception e) when (!command.Unattended)

--- a/src/Agent.Listener/Configuration/ConfigurationProvider.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
         Task TestConnectionAsync(AgentSettings agentSettings, VssCredentials creds, bool isHosted);
 
-        Task GetPoolId(AgentSettings agentSettings, CommandSettings command);
+        Task GetPoolIdAndName(AgentSettings agentSettings, CommandSettings command);
 
         string GetFailedToFindPoolErrorString();
 
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             // Collection name is not required for Build/Release agent
         }
 
-        public virtual async Task GetPoolId(AgentSettings agentSettings, CommandSettings command)
+        public virtual async Task GetPoolIdAndName(AgentSettings agentSettings, CommandSettings command)
         {
             string poolName = command.GetPool();
 
@@ -73,8 +73,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
             else
             {
-                Trace.Info("Found pool {0} with id {1}", poolName, agentPool.Id);
+                Trace.Info("Found pool {0} with id {1} and name {2}", poolName, agentPool.Id, agentPool.Name);
                 agentSettings.PoolId = agentPool.Id;
+                agentSettings.PoolName = agentPool.Name;
             }
         }
 
@@ -147,7 +148,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
         }
 
-        public async Task GetPoolId(AgentSettings agentSettings, CommandSettings command)
+        public async Task GetPoolIdAndName(AgentSettings agentSettings, CommandSettings command)
         {
             _projectName = command.GetProjectName(_projectName);
             var deploymentGroupName = command.GetDeploymentGroupName();
@@ -157,6 +158,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             Trace.Info($"Project id for deployment group '{deploymentGroupName}' is '{deploymentGroup.Project.Id.ToString()}'.");
 
             agentSettings.PoolId = deploymentGroup.Pool.Id;
+            agentSettings.PoolName = deploymentGroup.Pool.Name;
             agentSettings.DeploymentGroupId = deploymentGroup.Id;
             agentSettings.ProjectId = deploymentGroup.Project.Id.ToString();
         }
@@ -348,7 +350,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         public new string ConfigurationProviderType
             => Constants.Agent.AgentConfigurationProvider.SharedDeploymentAgentConfiguration;
 
-        public override async Task GetPoolId(AgentSettings agentSettings, CommandSettings command)
+        public override async Task GetPoolIdAndName(AgentSettings agentSettings, CommandSettings command)
         {
             string poolName = command.GetDeploymentPoolName();
 
@@ -359,8 +361,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
             else
             {
-                Trace.Info("Found deployment pool {0} with id {1}", poolName, agentPool.Id);
+                Trace.Info("Found deployment pool {0} with id {1} and name {2}", poolName, agentPool.Id, agentPool.Name);
                 agentSettings.PoolId = agentPool.Id;
+                agentSettings.PoolName = agentPool.Name;
             }
         }
     }

--- a/src/Agent.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/ServiceControlManager.cs
@@ -52,8 +52,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 throw new InvalidOperationException(StringUtil.Loc("CannotFindHostName", settings.ServerUrl));
             }
 
-            serviceName = StringUtil.Format(serviceNamePattern, accountName, settings.AgentName);
-            serviceDisplayName = StringUtil.Format(serviceDisplayNamePattern, accountName, settings.AgentName);
+            serviceName = StringUtil.Format(serviceNamePattern, accountName, settings.PoolName, settings.AgentName);
+            serviceDisplayName = StringUtil.Format(serviceDisplayNamePattern, accountName, settings.PoolName, settings.AgentName);
 
             Trace.Info($"Service name '{serviceName}' display name '{serviceDisplayName}' will be used for service configuration.");
         }

--- a/src/Agent.Listener/Configuration/SystemdControlManager.cs
+++ b/src/Agent.Listener/Configuration/SystemdControlManager.cs
@@ -11,8 +11,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
     public class SystemDControlManager : ServiceControlManager, ILinuxServiceControlManager
     {
         // This is the name you would see when you do `systemctl list-units | grep vsts`
-        private const string _svcNamePattern = "vsts.agent.{0}.{1}.service";
-        private const string _svcDisplayPattern = "Azure Pipelines Agent ({0}.{1})";
+        private const string _svcNamePattern = "vsts.agent.{0}.{1}.{2}.service";
+        private const string _svcDisplayPattern = "Azure Pipelines Agent ({0}.{1}.{2})";
 
         private const int MaxUserNameLength = 32;
         private const string VstsAgentServiceTemplate = "vsts.agent.service.template";

--- a/src/Agent.Listener/Configuration/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/WindowsServiceControlManager.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
     {
         public const string WindowsServiceControllerName = "AgentService.exe";
 
-        private const string ServiceNamePattern = "vstsagent.{0}.{1}";
-        private const string ServiceDisplayNamePattern = "Azure Pipelines Agent ({0}.{1})";
+        private const string ServiceNamePattern = "vstsagent.{0}.{1}.{2}";
+        private const string ServiceDisplayNamePattern = "Azure Pipelines Agent ({0}.{1}.{2})";
 
         private INativeWindowsServiceHelper _windowsServiceHelper;
         private ITerminal _term;


### PR DESCRIPTION
- Populate the `PoolName` settings property, which was previously left unused
- Configure both Windows and systemd services so they use PoolName as part of their service names

Configured service names now look like this: `vstsagent.{AccountName}.{PoolName}.{AgentName}`

Fixes #2223