### PR TITLE
React to Git 2.20 fetch tag update behavior change

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -147,21 +147,30 @@ namespace Agent.Plugins.Repository
                 refSpec = refSpec.Where(r => !string.IsNullOrEmpty(r)).ToList();
             }
 
+            // Git 2.20 changed its fetch behavior, rejecting tag updates if the --force flag is not provided
+            // See https://git-scm.com/docs/git-fetch for more details
+            string forceTag = string.Empty;
+
+            if (gitVersion >= new Version(2, 20))
+            {
+                forceTag = "--force";
+            }
+
             // default options for git fetch.
-            string options = StringUtil.Format($"--tags --prune --progress --no-recurse-submodules {remoteName} {string.Join(" ", refSpec)}");
+            string options = StringUtil.Format($"{forceTag} --tags --prune --progress --no-recurse-submodules {remoteName} {string.Join(" ", refSpec)}");
 
             // If shallow fetch add --depth arg
             // If the local repository is shallowed but there is no fetch depth provide for this build,
             // add --unshallow to convert the shallow repository to a complete repository
             if (fetchDepth > 0)
             {
-                options = StringUtil.Format($"--tags --prune --progress --no-recurse-submodules --depth={fetchDepth} {remoteName} {string.Join(" ", refSpec)}");
+                options = StringUtil.Format($"{forceTag} --tags --prune --progress --no-recurse-submodules --depth={fetchDepth} {remoteName} {string.Join(" ", refSpec)}");
             }
             else
             {
                 if (File.Exists(Path.Combine(repositoryPath, ".git", "shallow")))
                 {
-                    options = StringUtil.Format($"--tags --prune --progress --no-recurse-submodules --unshallow {remoteName} {string.Join(" ", refSpec)}");
+                    options = StringUtil.Format($"{forceTag} --tags --prune --progress --no-recurse-submodules --unshallow {remoteName} {string.Join(" ", refSpec)}");
                 }
             }
 


### PR DESCRIPTION
From [`git-fetch`](https://git-scm.com/docs/git-fetch) documentation:

```
Until Git version 2.20, and unlike when pushing with git-push[1], any updates to refs/tags/* would be
accepted without + in the refspec (or --force). When fetching, we promiscuously considered all tag
updates from a remote to be forced fetches. Since Git version 2.20, fetching to update refs/tags/* works
the same way as when pushing. I.e. any updates will be rejected without + in the refspec (or --force).
```