### PR TITLE
Calculate artifact size for build (file container) artifacts

### DIFF
--- a/src/Agent.Worker/Build/ArtifactCommandExtension.cs
+++ b/src/Agent.Worker/Build/ArtifactCommandExtension.cs
@@ -226,7 +226,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             CancellationToken cancellationToken)
         {
             FileContainerServer fileContainerHelper = new FileContainerServer(connection, projectId, containerId, containerPath);
-            await fileContainerHelper.CopyToContainerAsync(context, source, cancellationToken);
+            long size = await fileContainerHelper.CopyToContainerAsync(context, source, cancellationToken);
+            propertiesDictionary.Add(ArtifactUploadEventProperties.ArtifactSize, size.ToString());
+
             string fileContainerFullPath = StringUtil.Format($"#/{containerId}/{containerPath}");
             context.Output(StringUtil.Loc("UploadToFileContainer", source, fileContainerFullPath));
 
@@ -333,6 +335,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
     {
         public static readonly string ContainerFolder = "containerfolder";
         public static readonly string ArtifactName = "artifactname";
+        public static readonly string ArtifactSize = "artifactsize";
         public static readonly string ArtifactType = "artifacttype";
         public static readonly string Browsable = "Browsable";
     }

--- a/src/Agent.Worker/Build/FileContainerServer.cs
+++ b/src/Agent.Worker/Build/FileContainerServer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             _fileContainerHttpClient = fileContainerClientConnection.GetClient<FileContainerHttpClient>();
         }
 
-        public async Task CopyToContainerAsync(
+        public async Task<long> CopyToContainerAsync(
             IAsyncCommandContext context,
             String source,
             CancellationToken cancellationToken)
@@ -81,17 +81,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 try
                 {
                     // try upload all files for the first time.
-                    List<string> failedFiles = await ParallelUploadAsync(context, files, maxConcurrentUploads, _uploadCancellationTokenSource.Token);
+                    UploadResult uploadResult = await ParallelUploadAsync(context, files, maxConcurrentUploads, _uploadCancellationTokenSource.Token);
 
-                    if (failedFiles.Count == 0)
+                    if (uploadResult.FailedFiles.Count == 0)
                     {
                         // all files have been upload succeed.
                         context.Output(StringUtil.Loc("FileUploadSucceed"));
-                        return;
+                        return uploadResult.TotalFileSizeUploaded;
                     }
                     else
                     {
-                        context.Output(StringUtil.Loc("FileUploadFailedRetryLater", failedFiles.Count));
+                        context.Output(StringUtil.Loc("FileUploadFailedRetryLater", uploadResult.FailedFiles.Count));
                     }
 
                     // Delay 1 min then retry failed files.
@@ -102,14 +102,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     }
 
                     // Retry upload all failed files.
-                    context.Output(StringUtil.Loc("FileUploadRetry", failedFiles.Count));
-                    failedFiles = await ParallelUploadAsync(context, failedFiles, maxConcurrentUploads, _uploadCancellationTokenSource.Token);
+                    context.Output(StringUtil.Loc("FileUploadRetry", uploadResult.FailedFiles.Count));
+                    var retryUploadResult = await ParallelUploadAsync(context, uploadResult.FailedFiles, maxConcurrentUploads, _uploadCancellationTokenSource.Token);
 
-                    if (failedFiles.Count == 0)
+                    if (retryUploadResult.FailedFiles.Count == 0)
                     {
                         // all files have been upload succeed after retry.
                         context.Output(StringUtil.Loc("FileUploadRetrySucceed"));
-                        return;
+                        return uploadResult.TotalFileSizeUploaded + retryUploadResult.TotalFileSizeUploaded;
                     }
                     else
                     {
@@ -124,15 +124,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
         }
 
-        private async Task<List<string>> ParallelUploadAsync(IAsyncCommandContext context, List<string> files, int concurrentUploads, CancellationToken token)
+        private async Task<UploadResult> ParallelUploadAsync(IAsyncCommandContext context, IReadOnlyList<string> files, int concurrentUploads, CancellationToken token)
         {
             // return files that fail to upload
-            List<string> failedFiles = new List<string>();
+            var uploadResult = new UploadResult
+            {
+                FailedFiles = new List<string>(),
+                TotalFileSizeUploaded = 0
+            };
 
             // nothing needs to upload
             if (files.Count == 0)
             {
-                return failedFiles;
+                return uploadResult;
             }
 
             // ensure the file upload queue is empty.
@@ -155,7 +159,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             Task uploadMonitor = ReportingAsync(context, files.Count(), _uploadCancellationTokenSource.Token);
 
             // Start parallel upload tasks.
-            List<Task<List<string>>> parallelUploadingTasks = new List<Task<List<string>>>();
+            List<Task<UploadResult>> parallelUploadingTasks = new List<Task<UploadResult>>();
             for (int uploader = 0; uploader < concurrentUploads; uploader++)
             {
                 parallelUploadingTasks.Add(UploadAsync(context, uploader, _uploadCancellationTokenSource.Token));
@@ -166,25 +170,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             foreach (var uploadTask in parallelUploadingTasks)
             {
                 // record all failed files.
-                failedFiles.AddRange(await uploadTask);
+                uploadResult.AddUploadResult(await uploadTask);
             }
 
             // Stop monitor task;
             _uploadFinished.TrySetResult(0);
             await uploadMonitor;
 
-            return failedFiles;
+            return uploadResult;
         }
 
-        private async Task<List<string>> UploadAsync(IAsyncCommandContext context, int uploaderId, CancellationToken token)
+        private async Task<UploadResult> UploadAsync(IAsyncCommandContext context, int uploaderId, CancellationToken token)
         {
             List<string> failedFiles = new List<string>();
+            long uploadedSize = 0;
             string fileToUpload;
             Stopwatch uploadTimer = new Stopwatch();
             while (_fileUploadQueue.TryDequeue(out fileToUpload))
             {
                 token.ThrowIfCancellationRequested();
-                try 
+                try
                 {
                     using (FileStream fs = File.Open(fileToUpload, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
@@ -240,7 +245,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                         else
                         {
                             context.Debug(StringUtil.Loc("FileUploadFinish", fileToUpload, uploadTimer.ElapsedMilliseconds));
-
+                            uploadedSize += fs.Length;
                             // debug detail upload trace for the file.
                             ConcurrentQueue<string> logQueue;
                             if (_fileUploadTraceLog.TryGetValue(itemPath, out logQueue))
@@ -262,15 +267,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     }
 
                     Interlocked.Increment(ref _filesProcessed);
-                } 
+                }
                 catch (Exception ex)
                 {
                     context.Output(StringUtil.Loc("FileUploadFileOpenFailed", ex.Message, fileToUpload));
                     throw ex;
-                } 
+                }
             }
 
-            return failedFiles;
+            return new UploadResult
+            {
+                FailedFiles = failedFiles,
+                TotalFileSizeUploaded = uploadedSize,
+            };
         }
 
         private async Task ReportingAsync(IAsyncCommandContext context, int totalFiles, CancellationToken token)

--- a/src/Agent.Worker/Build/FileContainerServer.cs
+++ b/src/Agent.Worker/Build/FileContainerServer.cs
@@ -127,11 +127,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         private async Task<UploadResult> ParallelUploadAsync(IAsyncCommandContext context, IReadOnlyList<string> files, int concurrentUploads, CancellationToken token)
         {
             // return files that fail to upload and total artifact size
-            var uploadResult = new UploadResult
-            {
-                FailedFiles = new List<string>(),
-                TotalFileSizeUploaded = 0
-            };
+            var uploadResult = new UploadResult();
 
             // nothing needs to upload
             if (files.Count == 0)
@@ -275,11 +271,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 }
             }
 
-            return new UploadResult
-            {
-                FailedFiles = failedFiles,
-                TotalFileSizeUploaded = uploadedSize,
-            };
+            return new UploadResult(failedFiles, uploadedSize);
         }
 
         private async Task ReportingAsync(IAsyncCommandContext context, int totalFiles, CancellationToken token)

--- a/src/Agent.Worker/Build/FileContainerServer.cs
+++ b/src/Agent.Worker/Build/FileContainerServer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
                     // Retry upload all failed files.
                     context.Output(StringUtil.Loc("FileUploadRetry", uploadResult.FailedFiles.Count));
-                    var retryUploadResult = await ParallelUploadAsync(context, uploadResult.FailedFiles, maxConcurrentUploads, _uploadCancellationTokenSource.Token);
+                    UploadResult retryUploadResult = await ParallelUploadAsync(context, uploadResult.FailedFiles, maxConcurrentUploads, _uploadCancellationTokenSource.Token);
 
                     if (retryUploadResult.FailedFiles.Count == 0)
                     {
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         private async Task<UploadResult> ParallelUploadAsync(IAsyncCommandContext context, IReadOnlyList<string> files, int concurrentUploads, CancellationToken token)
         {
-            // return files that fail to upload
+            // return files that fail to upload and total artifact size
             var uploadResult = new UploadResult
             {
                 FailedFiles = new List<string>(),

--- a/src/Agent.Worker/Build/UploadResult.cs
+++ b/src/Agent.Worker/Build/UploadResult.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Microsoft.VisualStudio.Services.WebApi;
+using System.Net.Http;
+using System.Net;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
+{
+    public class UploadResult
+    {
+        public List<string> FailedFiles { get; set; }
+
+        public long TotalFileSizeUploaded { get; set; }
+
+
+        public void AddUploadResult(UploadResult resultToAdd)
+        {
+            this.FailedFiles.AddRange(resultToAdd.FailedFiles);
+            this.TotalFileSizeUploaded += resultToAdd.TotalFileSizeUploaded;
+        }
+    }
+
+}

--- a/src/Agent.Worker/Build/UploadResult.cs
+++ b/src/Agent.Worker/Build/UploadResult.cs
@@ -5,6 +5,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
     public class UploadResult
     {
+        public UploadResult()
+        {
+            FailedFiles = new List<string>();
+            TotalFileSizeUploaded = 0;
+        }
+
+        public UploadResult(List<string> failedFiles, long totalFileSizeUploaded)
+        {
+            FailedFiles = failedFiles;
+            TotalFileSizeUploaded = totalFileSizeUploaded;
+        }
         public List<string> FailedFiles { get; set; }
 
         public long TotalFileSizeUploaded { get; set; }

--- a/src/Agent.Worker/Build/UploadResult.cs
+++ b/src/Agent.Worker/Build/UploadResult.cs
@@ -1,14 +1,5 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Diagnostics;
-using Microsoft.VisualStudio.Services.WebApi;
-using System.Net.Http;
-using System.Net;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
@@ -18,12 +9,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public long TotalFileSizeUploaded { get; set; }
 
-
         public void AddUploadResult(UploadResult resultToAdd)
         {
             this.FailedFiles.AddRange(resultToAdd.FailedFiles);
             this.TotalFileSizeUploaded += resultToAdd.TotalFileSizeUploaded;
         }
     }
-
 }


### PR DESCRIPTION
This adds the total artifact size (at the time of upload) to a property on the build artifact. This will allow the UI to show the total build artifact size without having to load the artifact.

Tested a local build of the agent to verify no change in behavior and that the calculated size was correct.

Example REST response with the new `artifactsize` property:
```
{
  "count": 1,
  "value": [
    {
      "id": 3,
      "name": "executable",
      "resource": {
        "type": "Container",
        "data": "#/15/executable",
        "properties": {
          "localpath": "C:\\OpenSource\\azure-pipelines-agent\\_layout\\_work\\1\\s\\Source\\Timely.Main\\bin\\",
          "artifactsize": "3467173"
        },
    }
  ]
}
```