### PR TITLE
1. Stop serializing 3 EstablishVssConnection calls to speed up time t…

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/AgentServer.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/AgentServer.cs
@@ -70,9 +70,16 @@ namespace Microsoft.VisualStudio.Services.Agent
                 return;
             }
 
-            _genericConnection = await EstablishVssConnection(serverUrl, credentials, TimeSpan.FromSeconds(100));
-            _messageConnection = await EstablishVssConnection(serverUrl, credentials, TimeSpan.FromSeconds(60));
-            _requestConnection = await EstablishVssConnection(serverUrl, credentials, TimeSpan.FromSeconds(60));
+            // Perf: Kick off these 3 outbound calls in parallel and wait for all of them to finish.
+            Task<VssConnection> task1 = EstablishVssConnection(serverUrl, credentials, TimeSpan.FromSeconds(60));
+            Task<VssConnection> task2 = EstablishVssConnection(serverUrl, credentials, TimeSpan.FromSeconds(60));
+            Task<VssConnection> task3 = EstablishVssConnection(serverUrl, credentials, TimeSpan.FromSeconds(60));
+
+            await Task.WhenAll(task1, task2, task3);
+
+            _genericConnection = task1.Result;
+            _messageConnection = task2.Result;
+            _requestConnection = task3.Result;
 
             _genericTaskAgentClient = _genericConnection.GetClient<TaskAgentHttpClient>();
             _messageTaskAgentClient = _messageConnection.GetClient<TaskAgentHttpClient>();

--- a/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                         stepRecordIds.Add(lineInfo.StepRecordId);
                     }
 
-                    if (!string.IsNullOrEmpty(lineInfo.Line) && lineInfo.Line.Length > 1024)
+                    if (lineInfo.Line?.Length > 1024)
                     {
                         Trace.Verbose("Web console line is more than 1024 chars, truncate to first 1024 chars");
                         lineInfo.Line = $"{lineInfo.Line.Substring(0, 1024)}...";
@@ -272,7 +272,9 @@ namespace Microsoft.VisualStudio.Services.Agent
                     linesCounter++;
 
                     // process at most about 500 lines of web console line during regular timer dequeue task.
-                    if (!runOnce && linesCounter > 500)
+                    // Send the first line of output to the customer right away
+                    // It might take a while to reach 500 line outputs, which would cause delays before customers see the first line
+                    if ((!runOnce && linesCounter > 500) || _firstConsoleOutputs)
                     {
                         break;
                     }
@@ -323,8 +325,8 @@ namespace Microsoft.VisualStudio.Services.Agent
                                 await _jobServer.AppendTimelineRecordFeedAsync(_scopeIdentifier, _hubName, _planId, _jobTimelineId, _jobTimelineRecordId, stepRecordId, batch, default(CancellationToken));
                                 if (_firstConsoleOutputs)
                                 {
-                                    HostContext.WritePerfCounter($"WorkerJobServerQueueAppendFirstConsoleOutput_{_planId.ToString()}");
                                     _firstConsoleOutputs = false;
+                                    HostContext.WritePerfCounter("WorkerJobServerQueueAppendFirstConsoleOutput");
                                 }
                             }
                             catch (Exception ex)


### PR DESCRIPTION
…o first console output.

2. Send the first console output to user right away to avoid delays