### PR TITLE
Consider `svcNamePattern` when calculating final service name length

### DIFF
--- a/src/Agent.Listener/Configuration/OsxServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/OsxServiceControlManager.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
     public class OsxServiceControlManager : ServiceControlManager, ILinuxServiceControlManager
     {
         // This is the name you would see when you do `systemctl list-units | grep vsts`
-        private const string _svcNamePattern = "vsts.agent.{0}.{1}";
-        private const string _svcDisplayPattern = "Azure Pipelines Agent ({0}.{1})";
+        private const string _svcNamePattern = "vsts.agent.{0}.{1}.{2}";
+        private const string _svcDisplayPattern = "Azure Pipelines Agent ({0}.{1}.{2})";
         private const string _shTemplate = "darwin.svc.sh.template";
         private const string _svcShName = "svc.sh";
 

--- a/src/Agent.Listener/Configuration/ServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration/ServiceControlManager.cs
@@ -58,9 +58,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             {
                 Trace.Verbose($"Calculated service name is too long (> 80 chars). Trying again by calculating a shorter name.");
 
-                string accountNameSubstring = StringUtil.SubstringPrefix(accountName, 30);
-                string poolNameSubstring = StringUtil.SubstringPrefix(settings.PoolName, 30);
-                string agentNameSubstring = StringUtil.SubstringPrefix(settings.AgentName, 20);
+                int exceededCharLength = serviceName.Length - 80;
+                string accountNameSubstring = StringUtil.SubstringPrefix(accountName, 25);
+
+                exceededCharLength -= accountName.Length - accountNameSubstring.Length;
+
+                string poolNameSubstring = StringUtil.SubstringPrefix(settings.PoolName, 25);
+
+                exceededCharLength -= settings.PoolName.Length - poolNameSubstring.Length;
+
+                string agentNameSubstring = settings.AgentName;
+
+                // Only trim agent name if it's really necessary
+                if (exceededCharLength > 0)
+                {
+                    agentNameSubstring = StringUtil.SubstringPrefix(settings.AgentName, settings.AgentName.Length - exceededCharLength);
+                }
 
                 serviceName = StringUtil.Format(serviceNamePattern, accountNameSubstring, poolNameSubstring, agentNameSubstring);
             }


### PR DESCRIPTION
Also, use the same `svcNamePattern` hierarchy for OSX as for systemd and Windows service names.