### PR TITLE
Fix multi-line env var logging in `containerHandlerInvoker`

### DIFF
--- a/src/Misc/layoutbin/containerHandlerInvoker.js.template
+++ b/src/Misc/layoutbin/containerHandlerInvoker.js.template
@@ -15,7 +15,7 @@ process.stdin.on('end', function () {
     console.log("##vso[task.debug]HandlerArg: " + handlerArg);
     console.log("##vso[task.debug]HandlerWorkDir: " + handlerWorkDir);
     Object.keys(stdinData.environment).forEach(function (key) {
-        console.log("##vso[task.debug]Set env: " + key + "=" + stdinData.environment[key].toString().replace('\r', '%0D').replace('\n', '%0A'));
+        console.log("##vso[task.debug]Set env: " + key + "=" + stdinData.environment[key].toString().replace(/\r/g, '%0D').replace(/\n/g, '%0A'));
         process.env[key] = stdinData.environment[key];
     });
 


### PR DESCRIPTION
This PR fixes an issue where lines 3+ of a multi-line environment variable were incorrectly being logged to regular output instead of the desired task.debug line.