### PR TITLE
Increase and make configurable dedup parallelism

### DIFF
--- a/src/Agent.Plugins/PipelineArtifact/DedupManifestArtifactClientFactory.cs
+++ b/src/Agent.Plugins/PipelineArtifact/DedupManifestArtifactClientFactory.cs
@@ -21,14 +21,12 @@ namespace Agent.Plugins.PipelineArtifact
 {    
     public static class DedupManifestArtifactClientFactory
     {
-        private static readonly int DedupStoreClientMaxParallelism = 16 * Environment.ProcessorCount;
-
         public static DedupManifestArtifactClient CreateDedupManifestClient(AgentTaskPluginExecutionContext context, VssConnection connection, out BlobStoreClientTelemetry telemetry)
         {
             var dedupStoreHttpClient = connection.GetClient<DedupStoreHttpClient>();
             var tracer = new CallbackAppTraceSource(str => context.Output(str), SourceLevels.Information);
             dedupStoreHttpClient.SetTracer(tracer);
-            var client = new DedupStoreClientWithDataport(dedupStoreHttpClient, DedupStoreClientMaxParallelism);            
+            var client = new DedupStoreClientWithDataport(dedupStoreHttpClient, PipelineArtifactProvider.GetDedupStoreClientMaxParallelism(context));
             return new DedupManifestArtifactClient(telemetry = new BlobStoreClientTelemetry(tracer, dedupStoreHttpClient.BaseAddress), client, tracer);
         }
     }

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactProvider.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactProvider.cs
@@ -16,6 +16,9 @@ namespace Agent.Plugins.PipelineArtifact
 {
     internal class PipelineArtifactProvider : IArtifactProvider
     {
+        // Old default for hosted agents was 16*2 cores = 32. 
+        // In my tests of a node_modules folder, this 32x parallelism was consistently around 47 seconds.
+        // At 192x it was around 16 seconds and 256x was no faster.
         private const int DefaultDedupStoreClientMaxParallelism = 192;
 
         internal static int GetDedupStoreClientMaxParallelism(AgentTaskPluginExecutionContext context) {

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
@@ -289,7 +289,7 @@ namespace Agent.Plugins.PipelineArtifact
             var dedupStoreHttpClient = connection.GetClient<DedupStoreHttpClient>();
             var tracer = this.CreateTracer(context);
             dedupStoreHttpClient.SetTracer(tracer);
-            var client = new DedupStoreClientWithDataport(dedupStoreHttpClient, 16 * Environment.ProcessorCount);
+            var client = new DedupStoreClientWithDataport(dedupStoreHttpClient, PipelineArtifactProvider.GetDedupStoreClientMaxParallelism(context));
             var buildDropManager = new BuildDropManager(client, tracer);
             return buildDropManager;
         }


### PR DESCRIPTION
Old default for hosted agents was 16*2 cores = 32. In my tests of a node_modules folder, 32x parallelism was consistently around 47 seconds. At 192x it was around 16 seconds and 256x was no faster.