### PR TITLE
Calculate artifact size for pipeline artifacts

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.PluginHost/Agent.PluginHost.csproj
+++ b/src/Agent.PluginHost/Agent.PluginHost.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.2" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactConstants.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactConstants.cs
@@ -3,6 +3,7 @@ namespace Agent.Plugins.PipelineArtifact
     public class PipelineArtifactConstants
     {
         public const string AzurePipelinesAgent = "AzurePipelinesAgent";
+        public const string ArtifactSize = "artifactsize";
         public const string Container = "Container";
         public const string PipelineArtifact = "PipelineArtifact";
         public const string PipelineCache = "PipelineCache";

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
@@ -1,22 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Agent.Sdk;
 using Agent.Plugins.PipelineArtifact.Telemetry;
 using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.BlobStore.Common;
 using Microsoft.VisualStudio.Services.BlobStore.Common.Telemetry;
-using Microsoft.VisualStudio.Services.Content.Common.Telemetry;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
 using Microsoft.VisualStudio.Services.BlobStore.WebApi;
-using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
-using Newtonsoft.Json;
 
 namespace Agent.Plugins.PipelineArtifact
 {
@@ -56,7 +51,7 @@ namespace Agent.Plugins.PipelineArtifact
                 Dictionary<string, string> propertiesDictionary = new Dictionary<string, string>();
                 propertiesDictionary.Add(PipelineArtifactConstants.RootId, result.RootId.ValueString);
                 propertiesDictionary.Add(PipelineArtifactConstants.ProofNodes, StringUtil.ConvertToJson(result.ProofNodes.ToArray()));
-                propertiesDictionary.Add(PipelineArtifactConstants.ArtifactSize, GetArtifactSize(source).ToString());
+                propertiesDictionary.Add(PipelineArtifactConstants.ArtifactSize, result.ContentSize.ToString());
                 var artifact = await buildHelper.AssociateArtifact(projectId, pipelineId, name, ArtifactResourceTypes.PipelineArtifact, result.ManifestId.ValueString, propertiesDictionary, cancellationToken);
                 context.Output(StringUtil.Loc("AssociateArtifactWithBuild", artifact.Id, pipelineId));
             }
@@ -299,12 +294,6 @@ namespace Agent.Plugins.PipelineArtifact
         {
             var tracer = new CallbackAppTraceSource(str => context.Output(str), System.Diagnostics.SourceLevels.Information);
             return tracer;
-        }
-
-        private static long GetArtifactSize(string path)
-        {
-            DirectoryInfo directory = new DirectoryInfo(path);
-            return directory.EnumerateFiles("*", SearchOption.AllDirectories).Select(x => x.Length).Sum();
         }
     }
 

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
@@ -56,6 +56,7 @@ namespace Agent.Plugins.PipelineArtifact
                 Dictionary<string, string> propertiesDictionary = new Dictionary<string, string>();
                 propertiesDictionary.Add(PipelineArtifactConstants.RootId, result.RootId.ValueString);
                 propertiesDictionary.Add(PipelineArtifactConstants.ProofNodes, StringUtil.ConvertToJson(result.ProofNodes.ToArray()));
+                propertiesDictionary.Add(PipelineArtifactConstants.ArtifactSize, GetArtifactSize(source).ToString());
                 var artifact = await buildHelper.AssociateArtifact(projectId, pipelineId, name, ArtifactResourceTypes.PipelineArtifact, result.ManifestId.ValueString, propertiesDictionary, cancellationToken);
                 context.Output(StringUtil.Loc("AssociateArtifactWithBuild", artifact.Id, pipelineId));
             }
@@ -298,6 +299,12 @@ namespace Agent.Plugins.PipelineArtifact
         {
             var tracer = new CallbackAppTraceSource(str => context.Output(str), System.Diagnostics.SourceLevels.Information);
             return tracer;
+        }
+
+        private static long GetArtifactSize(string path)
+        {
+            DirectoryInfo directory = new DirectoryInfo(path);
+            return directory.EnumerateFiles("*", SearchOption.AllDirectories).Select(x => x.Length).Sum();
         }
     }
 

--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
+++ b/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="vss-api-netcore" Version="0.5.122-private" />
+    <PackageReference Include="vss-api-netcore" Version="0.5.124-private" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
This adds the total artifact size (at the time of upload) to a property on the pipeline artifact. This will allow the UI to show the total artifact size without having to load the artifact.

Similar work was done for build artifacts in https://github.com/microsoft/azure-pipelines-agent/pull/2258

Tested agent locally to verify the size and that there were no changes to existing behavior.

The `artifactsize` is added as property like so:
```
    {
      "id": 10,
      "name": "executable-pipelines",
      "source": null,
      "resource": {
        "type": "PipelineArtifact",
        "data": "BCFC1DBC1F51E5328701A354F50E33EE86BF363846B6EE141FC9C0D3C9C1E2A301",
        "properties": {
          "RootId": "6DB4F6E6D53C1B52933FFAD2EBFBFE6F51FE3EEB507145420828289B98ACA48102",
          "artifactsize": "3467173"
        },
        "url": "...",
        "downloadUrl": "..."
      }
```