### PR TITLE
Agentdir fix permissions

### DIFF
--- a/src/Misc/layoutroot/config.cmd
+++ b/src/Misc/layoutroot/config.cmd
@@ -35,4 +35,9 @@ if /i "%~1" equ "remove" (
     rem Configure the agent.
     rem ********************************************************************************
     "%~dp0bin\Agent.Listener.exe" configure %*
+
+    rem ********************************************************************************
+    rem Restrict access to root folder and don't allow regular users to create files
+    rem ********************************************************************************
+    powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$acl = Get-Acl '%~dp0'; $rule = New-Object System.Security.Acc$
 )

--- a/src/Misc/layoutroot/config.cmd
+++ b/src/Misc/layoutroot/config.cmd
@@ -39,5 +39,5 @@ if /i "%~1" equ "remove" (
     rem ********************************************************************************
     rem Restrict access to root folder and don't allow regular users to create files
     rem ********************************************************************************
-    powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$acl = Get-Acl '%~dp0'; $rule = New-Object System.Security.Acc$
+    powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$acl = Get-Acl '%~dp0'; $rule = New-Object System.Security.AccessControl.FileSystemAccessRule('Authenticated Users','CreateFiles','Deny'); $acl.setAccessRule($rule); Set-Acl '%~dp0' $acl"
 )


### PR DESCRIPTION
Lock-down permissions and don't allow regular users to create files in the agent's root folder.