### PR TITLE
Convert loginserver url to lowercase for ACR

### DIFF
--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -192,6 +192,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 {
                     string loginServer = string.Empty;
                     registryEndpoint.Authorization?.Parameters?.TryGetValue("loginServer", out loginServer);
+                    if (loginServer != null) {
+                        loginServer = loginServer.ToLower();
+                    }
+                    
                     registryEndpoint.Authorization?.Parameters?.TryGetValue("serviceprincipalid", out username);
                     registryEndpoint.Authorization?.Parameters?.TryGetValue("serviceprincipalkey", out password);
 


### PR DESCRIPTION
This is to fix the auth error during container initialization. The error is happening because of uppercase characters in the registry url.