### PR TITLE
Recursively clean and reset git submodules

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -312,7 +312,7 @@ namespace Agent.Plugins.Repository
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url --push {remoteName} {remoteUrl}"));
         }
 
-        // git submodule foreach git clean -ffdx
+        // git submodule foreach --recursive "git clean -ffdx"
         public async Task<int> GitSubmoduleClean(AgentTaskPluginExecutionContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for submodules at {repositoryPath}.");
@@ -328,14 +328,14 @@ namespace Agent.Plugins.Repository
                 options = "-fdx";
             }
 
-            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", $"foreach git clean {options}");
+            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", $"foreach --recursive \"git clean {options}\"");
         }
 
-        // git submodule foreach git reset --hard HEAD
+        // git submodule foreach --recursive "git reset --hard HEAD"
         public async Task<int> GitSubmoduleReset(AgentTaskPluginExecutionContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for submodules at {repositoryPath}.");
-            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach git reset --hard HEAD");
+            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach --recursive \"git reset --hard HEAD\"");
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -595,7 +595,7 @@ namespace Agent.Plugins.Repository
                             int exitCode_submoduleclean = await gitCommandManager.GitSubmoduleClean(executionContext, targetPath);
                             if (exitCode_submoduleclean != 0)
                             {
-                                executionContext.Debug($"'git submodule foreach git clean -ffdx' failed with exit code {exitCode_submoduleclean}\nFor futher investigation, manually run 'git submodule foreach git clean -ffdx' on repo root: {targetPath} after each build.");
+                                executionContext.Debug($"'git submodule foreach --recursive \"git clean -ffdx\"' failed with exit code {exitCode_submoduleclean}\nFor futher investigation, manually run 'git submodule foreach --recursive \"git clean -ffdx\"' on repo root: {targetPath} after each build.");
                                 softCleanSucceed = false;
                             }
                         }
@@ -605,7 +605,7 @@ namespace Agent.Plugins.Repository
                             int exitCode_submodulereset = await gitCommandManager.GitSubmoduleReset(executionContext, targetPath);
                             if (exitCode_submodulereset != 0)
                             {
-                                executionContext.Debug($"'git submodule foreach git reset --hard HEAD' failed with exit code {exitCode_submodulereset}\nFor futher investigation, manually run 'git submodule foreach git reset --hard HEAD' on repo root: {targetPath} after each build.");
+                                executionContext.Debug($"'git submodule foreach --recursive \"git reset --hard HEAD\"' failed with exit code {exitCode_submodulereset}\nFor futher investigation, manually run 'git submodule foreach --recursive \"git reset --hard HEAD\"' on repo root: {targetPath} after each build.");
                                 softCleanSucceed = false;
                             }
                         }

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -47,10 +47,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         // get remote set-url --push <origin> <url>
         Task<int> GitRemoteSetPushUrl(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
 
-        // git submodule foreach git clean -ffdx
+        // git submodule foreach --recursive "git clean -ffdx"
         Task<int> GitSubmoduleClean(IExecutionContext context, string repositoryPath);
 
-        // git submodule foreach git reset --hard HEAD
+        // git submodule foreach --recursive "git reset --hard HEAD"
         Task<int> GitSubmoduleReset(IExecutionContext context, string repositoryPath);
 
         // git submodule update --init --force [--depth=15] [--recursive]
@@ -306,7 +306,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url --push {remoteName} {remoteUrl}"));
         }
 
-        // git submodule foreach git clean -ffdx
+        // git submodule foreach --recursive "git clean -ffdx"
         public async Task<int> GitSubmoduleClean(IExecutionContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for submodules at {repositoryPath}.");
@@ -322,14 +322,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 options = "-fdx";
             }
 
-            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", $"foreach git clean {options}");
+            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", $"foreach --recursive \"git clean {options}\"");
         }
 
-        // git submodule foreach git reset --hard HEAD
+        // git submodule foreach --recursive "git reset --hard HEAD"
         public async Task<int> GitSubmoduleReset(IExecutionContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for submodules at {repositoryPath}.");
-            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach git reset --hard HEAD");
+            return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach --recursive \"git reset --hard HEAD\"");
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -549,7 +549,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                             int exitCode_submoduleclean = await _gitCommandManager.GitSubmoduleClean(executionContext, targetPath);
                             if (exitCode_submoduleclean != 0)
                             {
-                                executionContext.Debug($"'git submodule foreach git clean -ffdx' failed with exit code {exitCode_submoduleclean}\nFor futher investigation, manually run 'git submodule foreach git clean -ffdx' on repo root: {targetPath} after each build.");
+                                executionContext.Debug($"'git submodule foreach --recursve \"git clean -ffdx\"' failed with exit code {exitCode_submoduleclean}\nFor futher investigation, manually run 'git submodule foreach --recursive \"git clean -ffdx\"' on repo root: {targetPath} after each build.");
                                 softCleanSucceed = false;
                             }
                         }
@@ -559,7 +559,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                             int exitCode_submodulereset = await _gitCommandManager.GitSubmoduleReset(executionContext, targetPath);
                             if (exitCode_submodulereset != 0)
                             {
-                                executionContext.Debug($"'git submodule foreach git reset --hard HEAD' failed with exit code {exitCode_submodulereset}\nFor futher investigation, manually run 'git submodule foreach git reset --hard HEAD' on repo root: {targetPath} after each build.");
+                                executionContext.Debug($"'git submodule foreach --recursive \"git reset --hard HEAD\"' failed with exit code {exitCode_submodulereset}\nFor futher investigation, manually run 'git submodule foreach --recursive \"git reset --hard HEAD\"' on repo root: {targetPath} after each build.");
                                 softCleanSucceed = false;
                             }
                         }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/azure-pipelines-agent/issues/2301

If a submodule clean and reset is requested, the default behavior should
be to clean and reset every nested submodule that can be found.