### PR TITLE
Report last time build/release directory times as UTC time

### DIFF
--- a/src/Agent.Worker/Build/TrackingManager.cs
+++ b/src/Agent.Worker/Build/TrackingManager.cs
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     {
                         Trace.Verbose($"{trackingFile} is a new format tracking file.");
                         ArgUtil.NotNull(newTracking.LastRunOn, nameof(newTracking.LastRunOn));
-                        executionContext.Output(StringUtil.Loc("BuildDirLastUseTIme", Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newTracking.BuildDirectory), newTracking.LastRunOnString));
+                        executionContext.Output(StringUtil.Loc("BuildDirLastUseTIme", Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newTracking.BuildDirectory), newTracking.LastRunOn?.ToString("u")));
                         if (DateTime.UtcNow - expiration > newTracking.LastRunOn)
                         {
                             executionContext.Output(StringUtil.Loc("GCUnusedTrackingFile", trackingFile, expiration.TotalDays));

--- a/src/Agent.Worker/Release/ReleaseTrackingManager.cs
+++ b/src/Agent.Worker/Release/ReleaseTrackingManager.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
                     {
                         Trace.Verbose($"{trackingFile} is a new format tracking file.");
                         ArgUtil.NotNull(tracking.LastRunOn, nameof(tracking.LastRunOn));
-                        executionContext.Output(StringUtil.Loc("ReleaseDirLastUseTIme", Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), tracking.ReleaseDirectory), tracking.LastRunOnString));
+                        executionContext.Output(StringUtil.Loc("ReleaseDirLastUseTIme", Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), tracking.ReleaseDirectory), tracking.LastRunOn?.ToString("u")));
                         if (DateTime.UtcNow - expiration > tracking.LastRunOn)
                         {
                             executionContext.Output(StringUtil.Loc("GCUnusedTrackingFile", trackingFile, expiration.TotalDays));


### PR DESCRIPTION
Example:

```
Enqueue web console line queue: The last time build directory 'E:\ap-agent\_layout\_work\1' been used is: 2019-06-07 14:42:27Z
```

Fixes #2315