### PR TITLE
Expand env of containers

### DIFF
--- a/src/Agent.Worker/Container/ContainerInfo.cs
+++ b/src/Agent.Worker/Container/ContainerInfo.cs
@@ -235,6 +235,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
                 // After mount volume variables are expanded, they are final
                 MountVolumes.Add(new MountVolume(volume));
             }
+
+            // Expand env vars
+            variables.ExpandValues(ContainerEnvironmentVariables);
         }
     }
 

--- a/src/Agent.Worker/Container/ContainerInfo.cs
+++ b/src/Agent.Worker/Container/ContainerInfo.cs
@@ -238,6 +238,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 
             // Expand env vars
             variables.ExpandValues(ContainerEnvironmentVariables);
+
+            // Expand image and options strings
+            ContainerImage = variables.ExpandValue(nameof(ContainerImage), ContainerImage);
+            ContainerCreateOptions = variables.ExpandValue(nameof(ContainerCreateOptions), ContainerCreateOptions);
         }
     }
 

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -225,6 +225,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             VarUtil.ExpandValues(_hostContext, source, target);
         }
 
+        public string ExpandValue(string name, string value)
+        {
+            _trace.Entering();
+            var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (Variable variable in _expanded.Values)
+            {
+                source[variable.Name] = variable.Value;
+            }
+            var target = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [name] = value
+            };
+            VarUtil.ExpandValues(_hostContext, source, target);
+            return target[name];
+        }
+
         public JToken ExpandValues(JToken target)
         {
             _trace.Entering();


### PR DESCRIPTION
`env:` was pre-existing from job containers when I added service containers, so I did not specifically add functionality to expand these fields like I did for ports and volumes

This expands `env:` mapping values 

#2331

Before (exec into running service container during in-progress build): 

```
dakale@ubuntu:~/dev/azure-pipelines-agent/src$ docker exec -it d1b71057d0af bash
root@d1b71057d0af:/# printenv
...
MY_SECRET=$(secret)
...
```

After:
```
dakale@ubuntu:~/dev/azure-pipelines-agent/src$ docker exec -it 3aff9dc8b759 bash
root@3aff9dc8b759:/# printenv
...
MY_SECRET=password
...
```

Secret gets masked in build logs for initialize containers step: 
```
usr/bin/docker create --name nginx1_nginxlatest_9be6ce --label e8582c --network vsts_network_9e9b69821c924357af5bf9406785e78d --network-alias nginx  -e "MY_SECRET=***" -v "/home/dakale/dev/azure-pipelines-agent/_layout/_work/1":"/home/dakale/dev/azure-pipelines-agent/_layout/_work/1" -v "/home/dakale/dev/azure-pipelines-agent/_layout/_work/_temp":"/__w/_temp" -v "/home/dakale/dev/azure-pipelines-agent/_layout/_work/_tool":"/__t" -v "/home/dakale/dev/azure-pipelines-agent/_layout/_work/_tasks":"/__w/_tasks" -v "/home/dakale/dev/azure-pipelines-agent/_layout/externals":"/__a/externals":ro -v "/home/dakale/dev/azure-pipelines-agent/_layout/_work/.taskkey":"/__w/.taskkey" nginx:latest
```