### PR TITLE
Allow testing of pre-release agent zip in hosted pools

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/AgentServer.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/AgentServer.cs
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         public Task<List<TaskAgent>> GetAgentsAsync(int agentPoolId, string agentName = null)
         {
             CheckConnection(AgentConnectionType.Generic);
-            return _genericTaskAgentClient.GetAgentsAsync(agentPoolId, agentName, false);
+            return _genericTaskAgentClient.GetAgentsAsync(agentPoolId, agentName, includeCapabilities: true);
         }
 
         public Task<TaskAgent> UpdateAgentAsync(int agentPoolId, TaskAgent agent)


### PR DESCRIPTION
For quick iteration of performance testing, we need to run custom bits in the actual production environment.  This PR allows a contributor to store their agent.zip in a publicly accessible HTTP endpoint and the agent will update to it.