### PR TITLE
Improve logging around cache key/fingerprint calculation

### DIFF
--- a/src/Agent.Plugins/PipelineCache/FingerprintCreator.cs
+++ b/src/Agent.Plugins/PipelineCache/FingerprintCreator.cs
@@ -236,7 +236,7 @@ namespace Agent.Plugins.PipelineCache
                     if (type == KeySegmentType.FilePath)
                     {
                         string fileHash = matches.Length > 0 ? matches[0].Hash : null;
-                        context.Output($" - {formattedSegment} [file] --> {fileHash ?? "(NOT FOUND)"}");
+                        context.Output($" - {formattedSegment} [file] {(!string.IsNullOrWhiteSpace(fileHash) ? $"--> {fileHash}" : "(not found)")}");
                     }
                     else if (type == KeySegmentType.FilePattern)
                     {

--- a/src/Agent.Plugins/PipelineCache/FingerprintCreator.cs
+++ b/src/Agent.Plugins/PipelineCache/FingerprintCreator.cs
@@ -186,12 +186,16 @@ namespace Agent.Plugins.PipelineCache
 
             var resolvedSegments = new List<string>();
 
-            Action<string, KeySegmentType, Object> LogKeySegment = (segment, type, details) => {
-                Func<string,int,string> FormatForDisplay = (value, displayLength) => {
-                    if (value.Length > displayLength) {
+            Action<string, KeySegmentType, Object> LogKeySegment = (segment, type, details) =>
+            {
+                Func<string,int,string> FormatForDisplay = (value, displayLength) =>
+                {
+                    if (value.Length > displayLength)
+                    {
                         value = value.Substring(0, displayLength - 3) + "...";
                     }
-                    return value. PadRight(displayLength);
+
+                    return value.PadRight(displayLength);
                 };
 
                 string formattedSegment = FormatForDisplay(segment, Math.Min(keySegments.Select(s => s.Length).Max(), 50));
@@ -200,7 +204,8 @@ namespace Agent.Plugins.PipelineCache
                 {
                     context.Output($" - {formattedSegment} [string]");
                 }
-                else {
+                else
+                {
                     var matches = (details as MatchedFile[]) ?? new MatchedFile[0];
                     
                     if (type == KeySegmentType.FilePath)
@@ -210,10 +215,14 @@ namespace Agent.Plugins.PipelineCache
                     }
                     else if (type == KeySegmentType.FilePattern)
                     {
-                        context.Output($" - {formattedSegment} [file pattern; matches: {(!matches.Any() ? "none (error)" : matches.Length.ToString())}]");
-                        int filePathDisplayLength = Math.Min(matches.Select(mf => mf.DisplayPath.Length).Max(), 70);
-                        foreach (var match in matches) {
-                            context.Output($"   - {FormatForDisplay(match.DisplayPath, filePathDisplayLength)} --> {match.Hash}");
+                        context.Output($" - {formattedSegment} [file pattern; matches: {matches.Length}]");
+                        if (matches.Any())
+                        {
+                            int filePathDisplayLength = Math.Min(matches.Select(mf => mf.DisplayPath.Length).Max(), 70);
+                            foreach (var match in matches)
+                            {
+                                context.Output($"   - {FormatForDisplay(match.DisplayPath, filePathDisplayLength)} --> {match.Hash}");
+                            }
                         }
                     }   
                 }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -93,16 +93,16 @@ namespace Agent.Plugins.PipelineCache
                 context.Warning(OldKeyFormatMessage);
             }
 
-            context.Output($"Resolving key: {string.Join(" | ", keySegments)}");
+            context.Output($"Resolving key: {string.Join("|", keySegments)}");
             Fingerprint keyFp = FingerprintCreator.EvaluateKeyToFingerprint(context, worksapceRoot, keySegments);
-            context.Debug($"Resolved to `{keyFp}`.");
+            context.Output($"Resolved to: {keyFp}");
 
             Func<Fingerprint[]> restoreKeysGenerator = () => 
                 restoreKeys.Select(restoreKey => {
-                    context.Output($"Resolving restore key: {string.Join(" | ", restoreKey)}");
+                    context.Output($"Resolving restore key: {string.Join("|", restoreKey)}");
                     Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, worksapceRoot, restoreKey);
                     f.Segments = f.Segments.Concat(new [] { Fingerprint.Wildcard} ).ToArray();
-                    context.Debug($"Resolved to `{f}`.");
+                    context.Output($"Resolved to: {f}");
                     return f;
                 }).ToArray();
 

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -93,16 +93,16 @@ namespace Agent.Plugins.PipelineCache
                 context.Warning(OldKeyFormatMessage);
             }
 
-            context.Output($"Resolving key `{string.Join(" | ", keySegments)}`...");
+            context.Output($"Resolving key: {string.Join(" | ", keySegments)}");
             Fingerprint keyFp = FingerprintCreator.EvaluateKeyToFingerprint(context, worksapceRoot, keySegments);
-            context.Output($"Resolved to `{keyFp}`.");
+            context.Debug($"Resolved to `{keyFp}`.");
 
             Func<Fingerprint[]> restoreKeysGenerator = () => 
                 restoreKeys.Select(restoreKey => {
-                    context.Output($"Resolving restore key `{string.Join(" | ", restoreKey)}`...");
+                    context.Output($"Resolving restore key: {string.Join(" | ", restoreKey)}");
                     Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, worksapceRoot, restoreKey);
                     f.Segments = f.Segments.Concat(new [] { Fingerprint.Wildcard} ).ToArray();
-                    context.Output($"Resolved to `{f}`.");
+                    context.Debug($"Resolved to `{f}`.");
                     return f;
                 }).ToArray();
 

--- a/src/Test/L0/Plugin/FingerprintCreatorTests.cs
+++ b/src/Test/L0/Plugin/FingerprintCreatorTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                 {
                     $"{Path.GetDirectoryName(path1)},!{path1}",
                 };
-                Assert.Throws<FileNotFoundException>(
+                Assert.Throws<AggregateException>(
                     () => FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments)
                 );
             }
@@ -93,7 +93,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                 Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
                 
                 Assert.Equal(1, f.Segments.Length);
-                Assert.Equal(FingerprintCreator.SummarizeString($"\nSHA256({Path.GetFileName(path1)})=[{content1.Length}]{hash1.ToHex()}"), f.Segments[0]);
+
+                var matchedFile = new FingerprintCreator.MatchedFile(Path.GetFileName(path1), content1.Length, hash1.ToHex());
+                Assert.Equal(matchedFile.GetHash(), f.Segments[0]);
             }
         }
 
@@ -111,10 +113,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                     $"{path2}",
                 };
                 Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
+
+                var file1 = new FingerprintCreator.MatchedFile(Path.GetFileName(path1), content1.Length, hash1.ToHex());
+                var file2 = new FingerprintCreator.MatchedFile(Path.GetFileName(path2), content2.Length, hash2.ToHex());
                 
                 Assert.Equal(2, f.Segments.Length);
-                Assert.Equal(FingerprintCreator.SummarizeString($"\nSHA256({Path.GetFileName(path1)})=[{content1.Length}]{hash1.ToHex()}"), f.Segments[0]);
-                Assert.Equal(FingerprintCreator.SummarizeString($"\nSHA256({Path.GetFileName(path2)})=[{content2.Length}]{hash2.ToHex()}"), f.Segments[1]);
+                Assert.Equal(file1.GetHash(), f.Segments[0]);
+                Assert.Equal(file2.GetHash(), f.Segments[1]);
             }
         }
 
@@ -138,14 +143,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                 var segments = new[]
                 {
                     $"{relPath1}",
-                    $"{relPath2}",
+                    $"{relPath2}", 
                 };
 
                 Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
+
+                var file1 = new FingerprintCreator.MatchedFile(relPath1, content1.Length, hash1.ToHex());
+                var file2 = new FingerprintCreator.MatchedFile(relPath2, content2.Length, hash2.ToHex());
                 
                 Assert.Equal(2, f.Segments.Length);
-                Assert.Equal(FingerprintCreator.SummarizeString($"\nSHA256({relPath1})=[{content1.Length}]{hash1.ToHex()}"), f.Segments[0]);
-                Assert.Equal(FingerprintCreator.SummarizeString($"\nSHA256({relPath2})=[{content2.Length}]{hash2.ToHex()}"), f.Segments[1]);
+                Assert.Equal(file1.GetHash(), f.Segments[0]);
+                Assert.Equal(file2.GetHash(), f.Segments[1]);
             }
         }
 

--- a/src/Test/L0/Plugin/FingerprintCreatorTests.cs
+++ b/src/Test/L0/Plugin/FingerprintCreatorTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                 var segments = new[]
                 {
                     $"{relPath1}",
-                    $"{relPath2}", 
+                    $"{relPath2}",
                 };
 
                 Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);


### PR DESCRIPTION
This improves the logging around cache fingerprint generation by showing how each part (aka segment) of the cache key is being handled (i.e as a string literal, as a single file, or a file pattern).

Here's the current output:
```
Resolving key `Windows_NT | $(SOME_INVALID) | jest-test | packages/**/package.json | somethingelse`...
File hashes summarized as `EWGWqjif46kCyJoTwYfBxr5IUTURM8nligulkXNbYqU=` from BASE64(SHA256(`
SHA256(s\packages\babel-jest\package.json)=[895]61954B88117E66718C61B93C2AD7E28A0FFFBA263DC9A9A956277142AACC826B
SHA256(s\packages\babel-plugin-jest-hoist\package.json)=[578]05C3D16766FBDEDA1816BE5518CBEF47F55546C61928D98E16129700648F0866
SHA256(s\packages\jest-environment-jsdom\package.json)=[725]0283603B168B5AFFA9C97FEE783CA20990015BDD4117C1A9070F15EF72F7305D
SHA256(s\packages\jest-environment-node\package.json)=[636]EFED80B5571BE3572EC639F287B1ADB5F401CC7A320FFD3AE01FCC5A95DB7C20
...
SHA256(s\packages\pretty-format\package.json)=[1023]E13E68F67BC57E9E76B53F3A3D42FF99FE35C1C5CAD72CDAEE572C799748E826
SHA256(s\packages\test-utils\package.json)=[162]32E6268E23070A0FFF1F901B313F3F602CD3A951F3340D17B16F5D35A4327016`))
Resolved to `Windows_NT|$(SOME_INVALID)|jest-test|EWGWqjif46kCyJoTwYfBxr5IUTURM8nligulkXNbYqU=|somethingelse`.
Information, Getting a pipeline cache artifact with one of the following fingerprints:
Information, Fingerprint: `Windows_NT|$(SOME_INVALID)|jest-test|EWGWqjif46kCyJoTwYfBxr5IUTURM8nligulkXNbYqU=|somethingelse`
```

Here's the output now (with this change):
```
Resolving key: Windows_NT | $(SOME_INVALID) | jest-test | packages/**/package.json | somethingelse
 - Windows_NT               [string]
 - $(SOME_INVALID)          [string]
 - jest-test                [string]
 - packages/**/package.json [file pattern; matches: 59]
   - s\packages\babel-jest\package.json                                     --> 61954B88117E66718C61B93C2AD7E28A0FFFBA263DC9A9A956277142AACC826B
   - s\packages\babel-plugin-jest-hoist\package.json                        --> 05C3D16766FBDEDA1816BE5518CBEF47F55546C61928D98E16129700648F0866
   - s\packages\babel-preset-jest\package.json                              --> A07F74DC0E46A8AC6C1CA4A906CCA9987BA130DD072D7602CEFB87B5E38E4695
   - s\packages\diff-sequences\package.json                                 --> 1F41229844B1A7EA33417FFEAA566B93F90E5D06F6138AF6A0E09DE0F9D470E4
...
   - s\packages\jest\package.json                                           --> 5B96B6D6AB6203A84C8F220BE15E9632B01F9B6DAD7BDD4E1772BCFA1C9F6422
   - s\packages\pretty-format\package.json                                  --> E13E68F67BC57E9E76B53F3A3D42FF99FE35C1C5CAD72CDAEE572C799748E826
   - s\packages\test-utils\package.json                                     --> 32E6268E23070A0FFF1F901B313F3F602CD3A951F3340D17B16F5D35A4327016
 - somethingelse            [string]
Information, Getting a pipeline cache artifact with one of the following fingerprints:
Information, Fingerprint: `Windows_NT|$(SOME_INVALID)|jest-test|EWGWqjif46kCyJoTwYfBxr5IUTURM8nligulkXNbYqU=|somethingelse`
```