### PR TITLE
Modifying the process working directory location for tarring.

### DIFF
--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -11,6 +11,12 @@ using Microsoft.VisualStudio.Services.PipelineCache.WebApi;
 
 namespace Agent.Plugins.PipelineCache
 {
+    public enum TarType
+    {
+        GNU,
+        BSD
+    }
+    
     public abstract class PipelineCacheTaskPluginBase : IAgentTaskPlugin
     {
         protected const string RestoreStepRanVariableName = "RESTORE_STEP_RAN";

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -11,12 +11,6 @@ using Microsoft.VisualStudio.Services.PipelineCache.WebApi;
 
 namespace Agent.Plugins.PipelineCache
 {
-    public enum TarType
-    {
-        GNU,
-        BSD
-    }
-    
     public abstract class PipelineCacheTaskPluginBase : IAgentTaskPlugin
     {
         protected const string RestoreStepRanVariableName = "RESTORE_STEP_RAN";

--- a/src/Agent.Plugins/PipelineCache/TarUtils.cs
+++ b/src/Agent.Plugins/PipelineCache/TarUtils.cs
@@ -17,8 +17,7 @@ namespace Agent.Plugins.PipelineCache
     public static class TarUtils
     {
         private readonly static bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-        private const string archiveFileName = "archive.tar";
+        private const string archive = "archive.tar";
 
         /// <summary>
         /// Will archive files in the input path into a TAR file.
@@ -29,29 +28,25 @@ namespace Agent.Plugins.PipelineCache
             string inputPath,
             CancellationToken cancellationToken)
         {
-            var archiveFile = Path.Combine(Path.GetTempPath(), archiveFileName);
-            if (File.Exists(archiveFile))
+            if(File.Exists(inputPath))
             {
-                File.Delete(archiveFile);
+                throw new InvalidOperationException($"Please specify path to a directory, File path is not allowed. {inputPath} is a file.");
             }
 
-            var processFileName = "tar";
-            var processArguments = $"-cf \"{archiveFileName}\" -C \"{inputPath}\" ."; // If given the absolute path, the GNU tar fails. The workaround is to start the tarring process in the temp directory, and simply speficy 'archive.tar'
+            var archiveFileName = CreateArchiveFileName();
+            var archiveFile = Path.Combine(Path.GetTempPath(), archiveFileName);
+
+            ProcessStartInfo processStartInfo = GetCreateTarProcessInfo(archiveFileName, inputPath);
 
             Action actionOnFailure = () =>
             {
                 // Delete archive file.
-                if (File.Exists(archiveFile))
-                {
-                    File.Delete(archiveFile);
-                }
+                TryDeleteFile(archiveFile);
             };
 
             await RunProcessAsync(
                 context,
-                processFileName,
-                processArguments,
-                Path.GetTempPath(), // Set the process working directory to TEMP.
+                processStartInfo,
                 // no additional tasks on create are required to run whilst running the TAR process
                 (Process process, CancellationToken ct) => Task.CompletedTask,
                 actionOnFailure,
@@ -78,10 +73,8 @@ namespace Agent.Plugins.PipelineCache
 
             Directory.CreateDirectory(targetDirectory);
             
-            DedupIdentifier dedupId = DedupIdentifier.Create(manifest.Items.Single(i => i.Path == $"/{archiveFileName}").Blob.Id);
-            bool does7zExists = isWindows ? CheckIf7ZExists() : false;
-            string processFileName = (does7zExists) ? "7z" : "tar";
-            string processArguments = (does7zExists) ? $"x -si -aoa -o\"{targetDirectory}\" -ttar" : $"-xf - -C ."; // Instead of targetDirectory, we are providing . to tar, because the tar process is being started from targetDirectory.
+            DedupIdentifier dedupId = DedupIdentifier.Create(manifest.Items.Single(i => i.Path.EndsWith(archive, StringComparison.OrdinalIgnoreCase)).Blob.Id);
+            ProcessStartInfo processStartInfo = GetExtractStartProcessInfo(targetDirectory);
 
             Func<Process, CancellationToken, Task> downloadTaskFunc =
                 (process, ct) =>
@@ -104,9 +97,7 @@ namespace Agent.Plugins.PipelineCache
 
             return RunProcessAsync(
                 context,
-                processFileName,
-                processArguments,
-                targetDirectory, // Set the process working directory to targetDirectory.
+                processStartInfo,
                 downloadTaskFunc,
                 () => { },
                 cancellationToken);
@@ -114,9 +105,7 @@ namespace Agent.Plugins.PipelineCache
 
         private static async Task RunProcessAsync(
             AgentTaskPluginExecutionContext context,
-            string processFileName,
-            string processArguments,
-            string processWorkingDirectory,
+            ProcessStartInfo processStartInfo,
             Func<Process, CancellationToken, Task> additionalTaskToExecuteWhilstRunningProcess,
             Action actionOnFailure,
             CancellationToken cancellationToken)
@@ -126,7 +115,7 @@ namespace Agent.Plugins.PipelineCache
             using (var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cancelSource.Token))
             using (var process = new Process())
             {
-                SetProcessStartInfo(process, processFileName, processArguments, processWorkingDirectory);
+                process.StartInfo = processStartInfo;
                 process.EnableRaisingEvents = true;
                 process.Exited += (sender, args) =>
                 {
@@ -203,23 +192,60 @@ namespace Agent.Plugins.PipelineCache
             }
         }
 
-        private static void SetProcessStartInfo(Process process, string processFileName, string processArguments, string processWorkingDirectory)
+        private static void SetProcessStartInfo(ProcessStartInfo processStartInfo, string processFileName, string processArguments, string processWorkingDirectory)
         {
-            process.StartInfo.FileName = processFileName;
-            process.StartInfo.Arguments = processArguments;
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardInput = true;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.RedirectStandardError = true;
-            process.StartInfo.WorkingDirectory = processWorkingDirectory;
+            processStartInfo.FileName = processFileName;
+            processStartInfo.Arguments = processArguments;
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.RedirectStandardInput = true;
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.RedirectStandardError = true;
+            processStartInfo.WorkingDirectory = processWorkingDirectory;
+        }
+
+        private static ProcessStartInfo GetCreateTarProcessInfo(string archiveFileName, string inputPath)
+        {
+            var processFileName = "tar";
+            inputPath = (inputPath.EndsWith(Path.DirectorySeparatorChar)) ? inputPath.TrimEnd(Path.DirectorySeparatorChar) : inputPath;
+            var processArguments = $"-cf \"{archiveFileName}\" -C \"{inputPath}\" ."; // If given the absolute path for the '-cf' option, the GNU tar fails. The workaround is to start the tarring process in the temp directory, and simply speficy 'archive.tar' for that option.
+            ProcessStartInfo processStartInfo = new ProcessStartInfo();
+            SetProcessStartInfo(processStartInfo, processFileName, processArguments, processWorkingDirectory: Path.GetTempPath()); // We want to create the archiveFile in temp folder, and hence starting the tar process from TEMP to avoid absolute paths in tar cmd line.
+            return processStartInfo;
+        }
+
+        private static ProcessStartInfo GetExtractStartProcessInfo(string targetDirectory)
+        {
+            bool does7zExists = isWindows ? CheckIf7ZExists() : false;
+            string processFileName = (does7zExists) ? "7z" : "tar";
+            string processArguments = (does7zExists) ? $"x -si -aoa -o\"{targetDirectory}\" -ttar" : $"-xf - -C ."; // Instead of targetDirectory, we are providing . to tar, because the tar process is being started from targetDirectory.
+            ProcessStartInfo processStartInfo = new ProcessStartInfo();
+            SetProcessStartInfo(processStartInfo, processFileName, processArguments, processWorkingDirectory: targetDirectory);
+            return processStartInfo;
         }
 
         private static void ValidateTarManifest(Manifest manifest)
         {
-            if (manifest == null || manifest.Items.Count() != 1 || !manifest.Items.Single().Path.Equals($"/{archiveFileName}", StringComparison.Ordinal))
+            if (manifest == null || manifest.Items.Count() != 1 || !manifest.Items.Single().Path.EndsWith(archive, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"Manifest containing a tar cannot have more than one item.");
             }
+        }
+
+        private static void TryDeleteFile(string fileName)
+        {
+            try
+            {
+                if (File.Exists(fileName))
+                {
+                    File.Delete(fileName);
+                }
+            }
+            catch {}        
+        }
+
+        private static string CreateArchiveFileName()
+        {
+            return $"{Guid.NewGuid().ToString("N")}_{archive}";
         }
 
         private static bool CheckIf7ZExists()


### PR DESCRIPTION
The tarring for pipeline caching fails if the system has GNU tar because of the absolute path specified in the tarring command. This PR modifies the process working directory of the tar along with the command to work for both GNU and BSD tar.