### PR TITLE
Disable console writing in testing

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/HostTraceListener.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostTraceListener.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             if (!_diagErrorDetected && !DisableConsoleReporting && eventType < TraceEventType.Warning)
             {
-                Console.WriteLine(StringUtil.Loc("FoundErrorInTrace", eventType.ToString(), _logFilePath)); 
+                Console.WriteLine(StringUtil.Loc("FoundErrorInTrace", eventType.ToString(), _logFilePath));
                 _diagErrorDetected = true;
             }
         }

--- a/src/Microsoft.VisualStudio.Services.Agent/HostTraceListener.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostTraceListener.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 {
     public sealed class HostTraceListener : TextWriterTraceListener
     {
+        public bool DisableConsoleReporting { get; set; } 
         private const string _logFileNamingPattern = "{0}_{1:yyyyMMdd-HHmmss}-utc.log";
         private string _logFileDirectory;
         private string _logFilePrefix;
@@ -69,9 +70,9 @@ namespace Microsoft.VisualStudio.Services.Agent
             WriteLine(message);
             WriteFooter(eventCache);
 
-            if (!_diagErrorDetected && eventType < TraceEventType.Warning)
+            if (!_diagErrorDetected && !DisableConsoleReporting && eventType < TraceEventType.Warning)
             {
-                Console.WriteLine(StringUtil.Loc("FoundErrorInTrace", eventType.ToString(), _logFilePath));
+                Console.WriteLine(StringUtil.Loc("FoundErrorInTrace", eventType.ToString(), _logFilePath)); 
                 _diagErrorDetected = true;
             }
         }

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -55,6 +55,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
 
             var traceListener = new HostTraceListener(TraceFileName);
+            traceListener.DisableConsoleReporting = true;
             _secretMasker = new SecretMasker();
             _secretMasker.AddValueEncoder(ValueEncoders.JsonStringEscape);
             _secretMasker.AddValueEncoder(ValueEncoders.UriDataEscape);

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -157,7 +157,7 @@ function package ()
         echo "You must build first.  Expecting to find ${LAYOUT_DIR}/bin"
     fi
 
-    agent_ver=$("${LAYOUT_DIR}/bin/Agent.Listener" --version) || failed "version"
+    agent_ver=$("${LAYOUT_DIR}/bin/Agent.Listener" --version | tail -n 1) || failed "version"
     agent_pkg_name="vsts-agent-${RUNTIME_ID}-${agent_ver}"
 
     heading "Packaging ${agent_pkg_name}"


### PR DESCRIPTION
No need to print out nudge to look at trace logs in test bench