### PR TITLE
Updated to work on VSCode

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFrameworkVersion>2.1.5</RuntimeFrameworkVersion>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm;rhel.6-x64;osx-x64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <AssetTargetFallback>portable-net45+win8</AssetTargetFallback>


### PR DESCRIPTION
Updated to include RuntimeFrameworkVersion in Common.props

This is needed to build in OmniSharp in Vscode on OS X (maybe other platforms, but was having the issue specifically on OS X)