### PR TITLE
Use DirectorySeparatorChar in git path

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -50,7 +50,7 @@ namespace Agent.Plugins.Repository
 
         public override string GenerateAuthHeader(AgentTaskPluginExecutionContext executionContext, string username, string password)
         {
-            // can't generate auth header for external git. 
+            // can't generate auth header for external git.
             throw new NotSupportedException(nameof(ExternalGitSourceProvider.GenerateAuthHeader));
         }
     }
@@ -83,7 +83,7 @@ namespace Agent.Plugins.Repository
 
         public override string GenerateAuthHeader(AgentTaskPluginExecutionContext executionContext, string username, string password)
         {
-            // use basic auth header with username:password in base64encoding. 
+            // use basic auth header with username:password in base64encoding.
             string authHeader = $"{username ?? string.Empty}:{password ?? string.Empty}";
             string base64encodedAuthHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes(authHeader));
 
@@ -252,7 +252,7 @@ namespace Agent.Plugins.Repository
             // input Submodules can be ['', true, false, recursive]
             // '' or false indicate don't checkout submodules
             // true indicate checkout top level submodules
-            // recursive indicate checkout submodules recursively 
+            // recursive indicate checkout submodules recursively
             bool checkoutSubmodules = false;
             bool checkoutNestedSubmodules = false;
             string submoduleInput = executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules);
@@ -308,7 +308,7 @@ namespace Agent.Plugins.Repository
             }
 
             bool exposeCred = StringUtil.ConvertToBoolean(executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.PersistCredentials));
-            
+
             // Read 'disable fetch by commit' value from the execution variable first, then from the environment variable if the first one is not set
             bool fetchByCommit = GitSupportsFetchingCommitBySha1Hash && !StringUtil.ConvertToBoolean(
                 executionContext.Variables.GetValueOrDefault("VSTS.DisableFetchByCommit")?.Value ??
@@ -332,7 +332,7 @@ namespace Agent.Plugins.Repository
             executionContext.Debug($"schannelSslBackend={schannelSslBackend}");
 
             // Determine which git will be use
-            // On windows, we prefer the built-in portable git within the agent's externals folder, 
+            // On windows, we prefer the built-in portable git within the agent's externals folder,
             // set system.prefergitfrompath=true can change the behavior, agent will find git.exe from %PATH%
             var definitionSetting = executionContext.Variables.GetValueOrDefault("system.prefergitfrompath");
             if (definitionSetting != null)
@@ -530,8 +530,9 @@ namespace Agent.Plugins.Repository
             }
             else
             {
+                char dirSeparator = Path.DirectorySeparatorChar;
                 // delete the index.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string lockFile = Path.Combine(targetPath, ".git\\index.lock");
+                string lockFile = Path.Combine(targetPath, $".git{dirSeparator}index.lock");
                 if (File.Exists(lockFile))
                 {
                     try
@@ -545,8 +546,8 @@ namespace Agent.Plugins.Repository
                     }
                 }
 
-                // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.		
-                string shallowLockFile = Path.Combine(targetPath, ".git\\shallow.lock");
+                // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.
+                string shallowLockFile = Path.Combine(targetPath, $".git{dirSeparator}shallow.lock");
                 if (File.Exists(shallowLockFile))
                 {
                     try
@@ -671,8 +672,8 @@ namespace Agent.Plugins.Repository
             List<string> additionalLfsFetchArgs = new List<string>();
             if (!selfManageGitCreds)
             {
-                // v2.9 git support provide auth header as cmdline arg. 
-                // as long 2.9 git exist, VSTS repo, TFS repo and Github repo will use this to handle auth challenge. 
+                // v2.9 git support provide auth header as cmdline arg.
+                // as long 2.9 git exist, VSTS repo, TFS repo and Github repo will use this to handle auth challenge.
                 if (gitSupportAuthHeader)
                 {
                     additionalFetchArgs.Add($"-c http.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(executionContext, username, password)}\"");
@@ -830,7 +831,7 @@ namespace Agent.Plugins.Repository
 
             // Checkout
             // sourceToBuild is used for checkout
-            // if sourceBranch is a PR branch or sourceVersion is null, make sure branch name is a remote branch. we need checkout to detached head. 
+            // if sourceBranch is a PR branch or sourceVersion is null, make sure branch name is a remote branch. we need checkout to detached head.
             // (change refs/heads to refs/remotes/origin, refs/pull to refs/remotes/pull, or leave it as it when the branch name doesn't contain refs/...)
             // if sourceVersion provide, just use that for checkout, since when you checkout a commit, it will end up in detached head.
             cancellationToken.ThrowIfCancellationRequested();
@@ -948,7 +949,7 @@ namespace Agent.Plugins.Repository
                         executionContext.Debug("Use SChannel SslBackend for git submodule update.");
                         additionalSubmoduleUpdateArgs.Add("-c http.sslbackend=\"schannel\"");
                     }
-#endif                    
+#endif
                 }
 
                 int exitCode_submoduleUpdate = await gitCommandManager.GitSubmoduleUpdate(executionContext, targetPath, fetchDepth, string.Join(" ", additionalSubmoduleUpdateArgs), checkoutNestedSubmodules, cancellationToken);

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -530,9 +530,8 @@ namespace Agent.Plugins.Repository
             }
             else
             {
-                char dirSeparator = Path.DirectorySeparatorChar;
                 // delete the index.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string lockFile = Path.Combine(targetPath, $".git{dirSeparator}index.lock");
+                string lockFile = Path.Combine(targetPath, ".git", "index.lock");
                 if (File.Exists(lockFile))
                 {
                     try
@@ -547,7 +546,7 @@ namespace Agent.Plugins.Repository
                 }
 
                 // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string shallowLockFile = Path.Combine(targetPath, $".git{dirSeparator}shallow.lock");
+                string shallowLockFile = Path.Combine(targetPath, ".git", "shallow.lock");
                 if (File.Exists(shallowLockFile))
                 {
                     try

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public override string GenerateAuthHeader(string username, string password)
         {
-            // can't generate auth header for external git. 
+            // can't generate auth header for external git.
             throw new NotSupportedException(nameof(ExternalGitSourceProvider.GenerateAuthHeader));
         }
     }
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public override string GenerateAuthHeader(string username, string password)
         {
-            // use basic auth header with username:password in base64encoding. 
+            // use basic auth header with username:password in base64encoding.
             string authHeader = $"{username ?? string.Empty}:{password ?? string.Empty}";
             string base64encodedAuthHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes(authHeader));
 
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             Trace.Info($"schannelSslBackend={schannelSslBackend}");
 
             // Determine which git will be use
-            // On windows, we prefer the built-in portable git within the agent's externals folder, 
+            // On windows, we prefer the built-in portable git within the agent's externals folder,
             // set system.prefergitfrompath=true can change the behavior, agent will find git.exe from %PATH%
             var definitionSetting = executionContext.Variables.GetBoolean(Constants.Variables.System.PreferGitFromPath);
             if (definitionSetting != null)
@@ -485,8 +485,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
             else
             {
+                char dirSeparator = Path.DirectorySeparatorChar;
                 // delete the index.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string lockFile = Path.Combine(targetPath, ".git\\index.lock");
+                string lockFile = Path.Combine(targetPath, $".git{dirSeparator}index.lock");
                 if (File.Exists(lockFile))
                 {
                     try
@@ -501,7 +502,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 }
 
                 // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string shallowLockFile = Path.Combine(targetPath, ".git\\shallow.lock");
+                string shallowLockFile = Path.Combine(targetPath, $".git{dirSeparator}shallow.lock");
                 if (File.Exists(shallowLockFile))
                 {
                     try
@@ -626,8 +627,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             List<string> additionalLfsFetchArgs = new List<string>();
             if (!_selfManageGitCreds)
             {
-                // v2.9 git support provide auth header as cmdline arg. 
-                // as long 2.9 git exist, VSTS repo, TFS repo and Github repo will use this to handle auth challenge. 
+                // v2.9 git support provide auth header as cmdline arg.
+                // as long 2.9 git exist, VSTS repo, TFS repo and Github repo will use this to handle auth challenge.
                 if (GitUseAuthHeaderCmdlineArg)
                 {
                     additionalFetchArgs.Add($"-c http.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"");
@@ -764,7 +765,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             // Checkout
             // sourceToBuild is used for checkout
-            // if sourceBranch is a PR branch or sourceVersion is null, make sure branch name is a remote branch. we need checkout to detached head. 
+            // if sourceBranch is a PR branch or sourceVersion is null, make sure branch name is a remote branch. we need checkout to detached head.
             // (change refs/heads to refs/remotes/origin, refs/pull to refs/remotes/pull, or leave it as it when the branch name doesn't contain refs/...)
             // if sourceVersion provide, just use that for checkout, since when you checkout a commit, it will end up in detached head.
             cancellationToken.ThrowIfCancellationRequested();
@@ -870,7 +871,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                         executionContext.Debug("Use SChannel SslBackend for git submodule update.");
                         additionalSubmoduleUpdateArgs.Add("-c http.sslbackend=\"schannel\"");
                     }
-#endif                    
+#endif
                 }
 
                 int exitCode_submoduleUpdate = await _gitCommandManager.GitSubmoduleUpdate(executionContext, targetPath, fetchDepth, string.Join(" ", additionalSubmoduleUpdateArgs), checkoutNestedSubmodules, cancellationToken);

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -485,9 +485,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
             else
             {
-                char dirSeparator = Path.DirectorySeparatorChar;
                 // delete the index.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string lockFile = Path.Combine(targetPath, $".git{dirSeparator}index.lock");
+                string lockFile = Path.Combine(targetPath, ".git", "index.lock");
                 if (File.Exists(lockFile))
                 {
                     try
@@ -502,7 +501,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 }
 
                 // delete the shallow.lock file left by previous canceled build or any operation cause git.exe crash last time.
-                string shallowLockFile = Path.Combine(targetPath, $".git{dirSeparator}shallow.lock");
+                string shallowLockFile = Path.Combine(targetPath, ".git", "shallow.lock");
                 if (File.Exists(shallowLockFile))
                 {
                     try


### PR DESCRIPTION
Currently, the path separator was hardcoded to using backslashes.
This causes the functionality to break when using the agent on Linux and not properly delete index.lock and shallow.lock.

This commit also removes excess whitespace in the `src/Agent.Plugins/GitSourceProvider.cs` file.

The main changes can be found in lines 533, 535, 549 and 550.

This is the first time for me doing anything in C#, so please tell me if something is incorrect. Build and test succeeded.

Fixes #2487 