### PR TITLE
Log when a process is exited abnormally

### DIFF
--- a/src/Agent.Sdk/ProcessInvoker.cs
+++ b/src/Agent.Sdk/ProcessInvoker.cs
@@ -457,6 +457,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
         private void ProcessExitedHandler(object sender, EventArgs e)
         {
+            Trace.Info($"Exited process {_proc.Id} with exit code {_proc.ExitCode}");
             if ((_proc.StartInfo.RedirectStandardError || _proc.StartInfo.RedirectStandardOutput) && _asyncStreamReaderCount != 0)
             {
                 _waitingOnStreams = true;


### PR DESCRIPTION
While investigating an issue in which it appears the worker process is being killed, there is nothing in the agent log to indicate that this happened since we never wrote to the log to say that the process was killed.