### PR TITLE
Updated to remove task level variables so that the previous tasks var…

### DIFF
--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -321,6 +321,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             // Run the task.
             await handler.RunAsync();
+
+            ExecutionContext.Variables.Unset(Constants.Variables.Task.DisplayName);
+            ExecutionContext.Variables.Unset(WellKnownDistributedTaskVariables.TaskInstanceId);
+            ExecutionContext.Variables.Unset(WellKnownDistributedTaskVariables.TaskDisplayName);
+            ExecutionContext.Variables.Unset(WellKnownDistributedTaskVariables.TaskInstanceName);
         }
 
         private string TranslateFilePathInput(string inputValue)

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -312,6 +312,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return null;
         }
 
+        public void Unset(string name)
+        {
+            // Validate the args.
+            ArgUtil.NotNullOrEmpty(name, nameof(name));
+
+            // Remove the variable.
+            lock (_setLock)
+            {
+                Variable dummy;
+                 _expanded.Remove(name, out dummy);
+                _nonexpanded.Remove(name, out dummy);
+                _trace.Verbose($"Unset '{name}'");
+            }
+        }
+
         public void Set(string name, string val, bool secret = false)
         {
             // Validate the args.

--- a/src/Test/L0/Worker/VariablesL0.cs
+++ b/src/Test/L0/Worker/VariablesL0.cs
@@ -751,5 +751,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 Assert.Equal("bar", variables.Get("foo"));
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Unset()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                List<string> warnings;
+                var variables = new Variables(hc, new Dictionary<string, VariableValue>(), out warnings);
+
+                variables.Set("foo", "bar");
+
+                Assert.Equal("bar", variables.Get("foo"));
+                variables.Unset("foo");
+                Assert.Equal(null, variables.Get("foo"));
+            }
+        }
     }
 }


### PR DESCRIPTION
…iables are not hydrated in the next tasks variables

For reference, this is a fix related to: https://developercommunity.visualstudio.com/content/problem/691478/when-a-stage-sets-taskdisplayname-in-a-different-v.html

The issue is that $(Task.DisplayName) is being hydrated to the previous task's display name, when it should never have been hydrated in that context to begin with.