### PR TITLE
Making 's' the root for multi-repo checkout

### DIFF
--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -132,6 +132,7 @@ namespace Agent.Plugins.Repository
             ArgUtil.NotNullOrEmpty(tempDirectory, nameof(tempDirectory));
 
             // Determine the path that we should clone/move the repository into
+            const string sourcesDirectory = "s"; //Constants.Build.Path.SourcesDirectory
             string expectRepoPath;
             var path = executionContext.GetInput("path");
             if (!string.IsNullOrEmpty(path))
@@ -146,12 +147,12 @@ namespace Agent.Plugins.Repository
             else if (HasMultipleCheckouts(executionContext))
             {
                 // When there are multiple checkout tasks (and this one didn't set the path), default to directory 1/s/<repoName>
-                expectRepoPath = Path.Combine(buildDirectory, "s", RepositoryUtil.GetCloneDirectory(repo));
+                expectRepoPath = Path.Combine(buildDirectory, sourcesDirectory, RepositoryUtil.GetCloneDirectory(repo));
             }
             else
             {
                 // When there's a single checkout task that doesn't have path set, default to sources directory 1/s
-                expectRepoPath = Path.Combine(buildDirectory, "s");
+                expectRepoPath = Path.Combine(buildDirectory, sourcesDirectory);
             }
 
             // Don't update the repository path for every checkout task (it should only be updated once)

--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -145,8 +145,8 @@ namespace Agent.Plugins.Repository
             }
             else if (HasMultipleCheckouts(executionContext))
             {
-                // When there are multiple checkout tasks (and this one didn't set the path), default to directory 1/<repoName>
-                expectRepoPath = Path.Combine(buildDirectory, RepositoryUtil.GetCloneDirectory(repo));
+                // When there are multiple checkout tasks (and this one didn't set the path), default to directory 1/s/<repoName>
+                expectRepoPath = Path.Combine(buildDirectory, "s", RepositoryUtil.GetCloneDirectory(repo));
             }
             else
             {

--- a/src/Agent.Worker/PluginInternalCommandExtension.cs
+++ b/src/Agent.Worker/PluginInternalCommandExtension.cs
@@ -50,19 +50,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var currentPath = repository.Properties.Get<string>(RepositoryPropertyNames.Path);
             if (!string.Equals(data.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), currentPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), IOUtil.FilePathStringComparison))
             {
-                repository.Properties.Set<string>(RepositoryPropertyNames.Path, data.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                string repositoryPath = data.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                repository.Properties.Set<string>(RepositoryPropertyNames.Path, repositoryPath);
 
                 var directoryManager = HostContext.GetService<IBuildDirectoryManager>();
-                var trackingConfig = directoryManager.UpdateDirectory(context, repository);
-
-                // Set the directory variables.
                 string _workDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
-                context.SetVariable(Constants.Variables.Build.SourcesDirectory, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
-                context.SetVariable(Constants.Variables.Build.RepoLocalPath, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
 
-                // Only set the working directory here if we are NOT in Multi-checkout
-                if (!RepositoryUtil.HasMultipleCheckouts(context.JobSettings))
+                if (RepositoryUtil.HasMultipleCheckouts(context.JobSettings))
                 {
+                    // In Multi-checkout, we don't want to reset sources dir or default working dir.
+                    // So, we will just reset the repo local path
+                    string buildDirectory = context.Variables.Get(Constants.Variables.Pipeline.Workspace);
+                    string repoRelativePath = directoryManager.GetRelativeRepositoryPath(buildDirectory, repositoryPath);
+                    context.SetVariable(Constants.Variables.Build.RepoLocalPath, Path.Combine(_workDirectory, repoRelativePath), isFilePath: true);
+                }
+                else
+                {
+                    // If we only have a single repository, then update all the paths to point to it.
+                    var trackingConfig = directoryManager.UpdateDirectory(context, repository);
+
+                    // Set the directory variables.
+                    context.SetVariable(Constants.Variables.Build.SourcesDirectory, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
+                    context.SetVariable(Constants.Variables.Build.RepoLocalPath, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
                     context.SetVariable(Constants.Variables.System.DefaultWorkingDirectory, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
                 }
             }

--- a/src/Test/L0/Util/RepositoryUtilL0.cs
+++ b/src/Test/L0/Util/RepositoryUtilL0.cs
@@ -77,6 +77,47 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
+        public void GetPrimaryRepository_should_return_correct_value_when_called()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                Tracing trace = hc.GetTrace();
+
+                var repo1 = new RepositoryResource
+                {
+                    Alias = "repo1",
+                    Id = "repo1",
+                    Type = "git",
+                };
+
+                var repo2 = new RepositoryResource
+                {
+                    Alias = "repo2",
+                    Id = "repo2",
+                    Type = "git",
+                };
+
+                var repoSelf = new RepositoryResource
+                {
+                    Alias = "self",
+                    Id = "repo3",
+                    Type = "git",
+                };
+
+                Assert.Equal(null, RepositoryUtil.GetPrimaryRepository(null));
+                Assert.Equal(repo1, RepositoryUtil.GetPrimaryRepository(new[] { repo1 }));
+                Assert.Equal(repo2, RepositoryUtil.GetPrimaryRepository(new[] { repo2 }));
+                Assert.Equal(repoSelf, RepositoryUtil.GetPrimaryRepository(new[] { repoSelf }));
+                Assert.Equal(null, RepositoryUtil.GetPrimaryRepository(new[] { repo1, repo2 }));
+                Assert.Equal(repoSelf, RepositoryUtil.GetPrimaryRepository(new[] { repoSelf, repo1, repo2 }));
+                Assert.Equal(repoSelf, RepositoryUtil.GetPrimaryRepository(new[] { repo1, repoSelf, repo2 }));
+                Assert.Equal(repoSelf, RepositoryUtil.GetPrimaryRepository(new[] { repo1, repo2, repoSelf }));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
         public void GetRepository_should_return_correct_value_when_called()
         {
             using (TestHostContext hc = new TestHostContext(this))
@@ -104,16 +145,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
                     Type = "git",
                 };
 
-                Assert.Equal(null, RepositoryUtil.GetRepository(null));
-                Assert.Equal(repo1, RepositoryUtil.GetRepository(new[] { repo1 }));
-                Assert.Equal(repo2, RepositoryUtil.GetRepository(new[] { repo2 }));
-                Assert.Equal(repoSelf, RepositoryUtil.GetRepository(new[] { repoSelf }));
-                Assert.Equal(null, RepositoryUtil.GetRepository(new[] { repo1, repo2 }));
                 Assert.Equal(repo1, RepositoryUtil.GetRepository(new[] { repo1, repo2 }, "repo1"));
                 Assert.Equal(repo2, RepositoryUtil.GetRepository(new[] { repo1, repo2 }, "repo2"));
-                Assert.Equal(repoSelf, RepositoryUtil.GetRepository(new[] { repoSelf, repo1, repo2 }));
-                Assert.Equal(repoSelf, RepositoryUtil.GetRepository(new[] { repo1, repoSelf, repo2 }));
-                Assert.Equal(repoSelf, RepositoryUtil.GetRepository(new[] { repo1, repo2, repoSelf }));
                 Assert.Equal(repo1, RepositoryUtil.GetRepository(new[] { repoSelf, repo1, repo2 }, "repo1"));
                 Assert.Equal(repo2, RepositoryUtil.GetRepository(new[] { repoSelf, repo1, repo2 }, "repo2"));
                 Assert.Equal(repoSelf, RepositoryUtil.GetRepository(new[] { repoSelf, repo1, repo2 }, "self"));


### PR DESCRIPTION
Changes to the [spec](https://github.com/microsoft/azure-pipelines-yaml/pull/358/files) are in progress. This is the first approximation of those changes which make 's' the root of all repositories by default.

There is also a small amount of refactoring based on comments on the last PR.

**Testing**
All tests are passing (some where updated)