### PR TITLE
Cleanup of Agent.Worker #ifs

### DIFF
--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -77,6 +77,19 @@ namespace Agent.Sdk
             get => PlatformUtil.RunningOnOS == PlatformUtil.OS.Linux;
         }
 
+        public static bool RunningOnRHEL6
+        {
+            get
+            {
+                // TODO: make this a runtime check
+#if OS_RHEL6
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+
         public static Architecture BuiltOnArchitecture
         {
             get

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -1075,16 +1075,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             // Initialize git command manager
             _gitCommandManager = HostContext.GetService<IGitCommandManager>();
-            if (PlatformUtil.RunningOnWindows)
-            {
-                // On Windows, we will always find git from externals
-                await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit: true);
-            }
-            else
-            {
-                // On linux/OSX, we will always find git from the path
-                await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit: false);
-            }
+
+            // On Windows, always find Git from externals
+            // On Linux/macOS, always find Git from the path
+            bool useBuiltInGit = PlatformUtil.RunningOnWindows;
+            await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit);
 
             // if the folder is missing, skip it
             if (!Directory.Exists(repositoryPath) || !Directory.Exists(Path.Combine(repositoryPath, ".git")))

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
@@ -22,14 +23,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public override void RequirementCheck(IExecutionContext executionContext, ServiceEndpoint endpoint)
         {
-#if OS_WINDOWS
-            // check git version for SChannel SSLBackend (Windows Only)
-            bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
-            if (schannelSslBackend)
+            if (PlatformUtil.RunningOnWindows)
             {
-                _gitCommandManager.EnsureGitVersion(_minGitVersionSupportSSLBackendOverride, throwOnNotMatch: true);
+                // check git version for SChannel SSLBackend (Windows Only)
+                bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
+                if (schannelSslBackend)
+                {
+                    _gitCommandManager.EnsureGitVersion(_minGitVersionSupportSSLBackendOverride, throwOnNotMatch: true);
+                }
             }
-#endif
         }
 
         public override string GenerateAuthHeader(string username, string password)
@@ -63,14 +65,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         public override void RequirementCheck(IExecutionContext executionContext, ServiceEndpoint endpoint)
         {
-#if OS_WINDOWS
-            // check git version for SChannel SSLBackend (Windows Only)
-            bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
-            if (schannelSslBackend)
+            if (PlatformUtil.RunningOnWindows)
             {
-                _gitCommandManager.EnsureGitVersion(_minGitVersionSupportSSLBackendOverride, throwOnNotMatch: true);
+                // check git version for SChannel SSLBackend (Windows Only)
+                bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
+                if (schannelSslBackend)
+                {
+                    _gitCommandManager.EnsureGitVersion(_minGitVersionSupportSSLBackendOverride, throwOnNotMatch: true);
+                }
             }
-#endif
         }
 
         public override string GenerateAuthHeader(string username, string password)
@@ -165,14 +168,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 }
             }
 
-#if OS_WINDOWS
-            // check git version for SChannel SSLBackend (Windows Only)
-            bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
-            if (schannelSslBackend)
+            if (PlatformUtil.RunningOnWindows)
             {
-                _gitCommandManager.EnsureGitVersion(_minGitVersionSupportSSLBackendOverride, throwOnNotMatch: true);
+                // check git version for SChannel SSLBackend (Windows Only)
+                bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
+                if (schannelSslBackend)
+                {
+                    _gitCommandManager.EnsureGitVersion(_minGitVersionSupportSSLBackendOverride, throwOnNotMatch: true);
+                }
             }
-#endif
         }
 
         public override string GenerateAuthHeader(string username, string password)
@@ -203,15 +207,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         protected IGitCommandManager _gitCommandManager;
 
-        // min git version that support add extra auth header.
+        // Minimum Git version that supports adding the extra auth header
         protected Version _minGitVersionSupportAuthHeader = new Version(2, 9);
 
-#if OS_WINDOWS
-        // min git version that support override sslBackend setting.
+        // Minimum Git for Windows version that supports overriding the sslBackend setting
         protected Version _minGitVersionSupportSSLBackendOverride = new Version(2, 14, 2);
-#endif
 
-        // min git-lfs version that support add extra auth header.
+        // Minimum git-lfs version that supports adding the extra auth header
         protected Version _minGitLfsVersionSupportAuthHeader = new Version(2, 1);
 
         public abstract bool GitUseAuthHeaderCmdlineArg { get; }
@@ -299,27 +301,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             Trace.Info($"gitLfsSupport={gitLfsSupport}");
             Trace.Info($"acceptUntrustedCerts={acceptUntrustedCerts}");
 
-            bool preferGitFromPath;
-#if OS_WINDOWS
-            bool schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
-            Trace.Info($"schannelSslBackend={schannelSslBackend}");
+            bool preferGitFromPath = true;
+            bool schannelSslBackend = false;
+            
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // on Windows, we must check for SChannel and PreferGitFromPath
+                schannelSslBackend = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions()?.GitUseSecureChannel ?? false;
+                Trace.Info($"schannelSslBackend={schannelSslBackend}");
 
-            // Determine which git will be use
-            // On windows, we prefer the built-in portable git within the agent's externals folder,
-            // set system.prefergitfrompath=true can change the behavior, agent will find git.exe from %PATH%
-            var definitionSetting = executionContext.Variables.GetBoolean(Constants.Variables.System.PreferGitFromPath);
-            if (definitionSetting != null)
-            {
-                preferGitFromPath = definitionSetting.Value;
+                // Determine which git will be use
+                // On windows, we prefer the built-in portable git within the agent's externals folder, 
+                // set system.prefergitfrompath=true can change the behavior, agent will find git.exe from %PATH%
+                var definitionSetting = executionContext.Variables.GetBoolean(Constants.Variables.System.PreferGitFromPath);
+                if (definitionSetting != null)
+                {
+                    preferGitFromPath = definitionSetting.Value;
+                }
+                else
+                {
+                    bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.System.PreferGitFromPath), out preferGitFromPath);
+                }
             }
-            else
-            {
-                bool.TryParse(Environment.GetEnvironmentVariable(Constants.Variables.System.PreferGitFromPath), out preferGitFromPath);
-            }
-#else
-            // On Linux, we will always use git find in %PATH% regardless of system.prefergitfrompath
-            preferGitFromPath = true;
-#endif
 
             // Determine do we need to provide creds to git operation
             _selfManageGitCreds = executionContext.Variables.GetBoolean(Constants.Variables.System.SelfManageGitCreds) ?? false;
@@ -432,29 +435,30 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                         askPass.Add($"echo \"{agentCert.ClientCertificatePassword}\"");
                         File.WriteAllLines(_clientCertPrivateKeyAskPassFile, askPass);
 
-#if !OS_WINDOWS
-                        string toolPath = WhichUtil.Which("chmod", true);
-                        string argLine = $"775 {_clientCertPrivateKeyAskPassFile}";
-                        executionContext.Command($"chmod {argLine}");
-
-                        var processInvoker = HostContext.CreateService<IProcessInvoker>();
-                        processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs args) =>
+                        if (!PlatformUtil.RunningOnWindows)
                         {
-                            if (!string.IsNullOrEmpty(args.Data))
-                            {
-                                executionContext.Output(args.Data);
-                            }
-                        };
-                        processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs args) =>
-                        {
-                            if (!string.IsNullOrEmpty(args.Data))
-                            {
-                                executionContext.Output(args.Data);
-                            }
-                        };
+                            string toolPath = WhichUtil.Which("chmod", true);
+                            string argLine = $"775 {_clientCertPrivateKeyAskPassFile}";
+                            executionContext.Command($"chmod {argLine}");
 
-                        await processInvoker.ExecuteAsync(HostContext.GetDirectory(WellKnownDirectory.Work), toolPath, argLine, null, true, CancellationToken.None);
-#endif
+                            var processInvoker = HostContext.CreateService<IProcessInvoker>();
+                            processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs args) =>
+                            {
+                                if (!string.IsNullOrEmpty(args.Data))
+                                {
+                                    executionContext.Output(args.Data);
+                                }
+                            };
+                            processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs args) =>
+                            {
+                                if (!string.IsNullOrEmpty(args.Data))
+                                {
+                                    executionContext.Output(args.Data);
+                                }
+                            };
+
+                            await processInvoker.ExecuteAsync(HostContext.GetDirectory(WellKnownDirectory.Work), toolPath, argLine, null, true, CancellationToken.None);
+                        }
                     }
                 }
             }
@@ -696,14 +700,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                         additionalLfsFetchArgs.Add($"-c http.sslcert=\"{agentCert.ClientCertificateFile}\" -c http.sslkey=\"{agentCert.ClientCertificatePrivateKeyFile}\"");
                     }
                 }
-#if OS_WINDOWS
-                if (schannelSslBackend)
+
+                if (PlatformUtil.RunningOnWindows && schannelSslBackend)
                 {
                     executionContext.Debug("Use SChannel SslBackend for git fetch.");
                     additionalFetchArgs.Add("-c http.sslbackend=\"schannel\"");
                     additionalLfsFetchArgs.Add("-c http.sslbackend=\"schannel\"");
                 }
-#endif
+
                 // Prepare gitlfs url for fetch and checkout
                 if (gitLfsSupport)
                 {
@@ -864,13 +868,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                             additionalSubmoduleUpdateArgs.Add($"-c http.{authorityUrl}.sslcert=\"{agentCert.ClientCertificateFile}\" -c http.{authorityUrl}.sslkey=\"{agentCert.ClientCertificatePrivateKeyFile}\"");
                         }
                     }
-#if OS_WINDOWS
-                    if (schannelSslBackend)
+
+                    if (PlatformUtil.RunningOnWindows && schannelSslBackend)
                     {
                         executionContext.Debug("Use SChannel SslBackend for git submodule update.");
                         additionalSubmoduleUpdateArgs.Add("-c http.sslbackend=\"schannel\"");
                     }
-#endif
                 }
 
                 int exitCode_submoduleUpdate = await _gitCommandManager.GitSubmoduleUpdate(executionContext, targetPath, fetchDepth, string.Join(" ", additionalSubmoduleUpdateArgs), checkoutNestedSubmodules, cancellationToken);
@@ -1072,13 +1075,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             // Initialize git command manager
             _gitCommandManager = HostContext.GetService<IGitCommandManager>();
-#if OS_WINDOWS
-            // On Windows, we will always find git from externals
-            await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit: true);
-#else
-            // On linux/OSX, we will always find git from %PATH%
-            await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit: false);
-#endif
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // On Windows, we will always find git from externals
+                await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit: true);
+            }
+            else
+            {
+                // On linux/OSX, we will always find git from the path
+                await _gitCommandManager.LoadGitExecutionInfo(executionContext, useBuiltInGit: false);
+            }
 
             // if the folder is missing, skip it
             if (!Directory.Exists(repositoryPath) || !Directory.Exists(Path.Combine(repositoryPath, ".git")))

--- a/src/Agent.Worker/Build/LocalRunSourceProvider.cs
+++ b/src/Agent.Worker/Build/LocalRunSourceProvider.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
@@ -23,13 +24,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             ArgUtil.NotNull(endpoint, nameof(endpoint));
 
-            bool preferGitFromPath;
-#if OS_WINDOWS
-            preferGitFromPath = false;
-#else
-            preferGitFromPath = true;
-#endif
-            if (!preferGitFromPath)
+            if (PlatformUtil.RunningOnWindows)
             {
                 // Add git to the PATH.
                 string gitPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "git", "cmd", $"git{IOUtil.ExeExtension}");

--- a/src/Agent.Worker/Build/TeeCommandManager.cs
+++ b/src/Agent.Worker/Build/TeeCommandManager.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.Collections.Generic;
@@ -175,27 +176,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             string homeDirectory = Environment.GetEnvironmentVariable("HOME");
             if (!string.IsNullOrEmpty(homeDirectory) && Directory.Exists(homeDirectory))
             {
-#if OS_OSX
+                string tfDataDirectory = (PlatformUtil.RunningOnMacOS)
+                    ? Path.Combine("Library", "Application Support", "Microsoft")
+                    : ".microsoft";
+
                 string xmlFile = Path.Combine(
                     homeDirectory,
-                    "Library",
-                    "Application Support",
-                    "Microsoft",
+                    tfDataDirectory,
                     "Team Foundation",
                     "4.0",
                     "Configuration",
                     "TEE-Mementos",
                     "com.microsoft.tfs.client.productid.xml");
-#else
-                string xmlFile = Path.Combine(
-                    homeDirectory,
-                    ".microsoft",
-                    "Team Foundation",
-                    "4.0",
-                    "Configuration",
-                    "TEE-Mementos",
-                    "com.microsoft.tfs.client.productid.xml");
-#endif
+
                 if (File.Exists(xmlFile))
                 {
                     // Load and deserialize the XML.

--- a/src/Agent.Worker/Build/TfsVCCommandManager.cs
+++ b/src/Agent.Worker/Build/TfsVCCommandManager.cs
@@ -9,11 +9,10 @@ using Microsoft.TeamFoundation.DistributedTask.Pipelines;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
-#if OS_WINDOWS
-    [ServiceLocator(Default = typeof(TFCommandManager))]
-#else
-    [ServiceLocator(Default = typeof(TeeCommandManager))]
-#endif
+    [ServiceLocator(
+        PreferredOnWindows = typeof(TFCommandManager),
+        Default = typeof(TeeCommandManager)
+    )]
     public interface ITfsVCCommandManager : IAgentService
     {
         CancellationToken CancellationToken { set; }

--- a/src/Agent.Worker/Build/TfsVCSourceProvider.cs
+++ b/src/Agent.Worker/Build/TfsVCSourceProvider.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
@@ -29,13 +30,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             ArgUtil.NotNull(endpoint, nameof(endpoint));
 
-#if OS_WINDOWS
-            // Validate .NET Framework 4.6 or higher is installed.
-            if (!NetFrameworkUtil.Test(new Version(4, 6), Trace))
+            if (PlatformUtil.RunningOnWindows)
             {
-                throw new Exception(StringUtil.Loc("MinimumNetFramework46"));
+                // Validate .NET Framework 4.6 or higher is installed.
+                if (!NetFrameworkUtil.Test(new Version(4, 6), Trace))
+                {
+                    throw new Exception(StringUtil.Loc("MinimumNetFramework46"));
+                }
             }
-#endif
 
             // Create the tf command manager.
             var tf = HostContext.CreateService<ITfsVCCommandManager>();
@@ -55,11 +57,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             var agentCertManager = HostContext.GetService<IAgentCertificateManager>();
             if (agentCertManager.SkipServerCertificateValidation)
             {
-#if OS_WINDOWS
-                executionContext.Debug("TF.exe does not support ignore SSL certificate validation error.");
-#else
                 executionContext.Debug("TF does not support ignore SSL certificate validation error.");
-#endif
             }
 
             var configUrl = new Uri(HostContext.GetService<IConfigurationStore>().GetSettings().ServerUrl);
@@ -77,14 +75,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             PathUtil.PrependPath(Path.GetDirectoryName(tfPath));
             executionContext.Debug($"{Constants.PathVariable}: '{Environment.GetEnvironmentVariable(Constants.PathVariable)}'");
 
-#if OS_WINDOWS
-            // Set TFVC_BUILDAGENT_POLICYPATH
-            string policyDllPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.ServerOM), "Microsoft.TeamFoundation.VersionControl.Controls.dll");
-            ArgUtil.File(policyDllPath, nameof(policyDllPath));
-            const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";
-            executionContext.Output(StringUtil.Loc("SetEnvVar", policyPathEnvKey));
-            Environment.SetEnvironmentVariable(policyPathEnvKey, policyDllPath);
-#endif
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // Set TFVC_BUILDAGENT_POLICYPATH
+                string policyDllPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.ServerOM), "Microsoft.TeamFoundation.VersionControl.Controls.dll");
+                ArgUtil.File(policyDllPath, nameof(policyDllPath));
+                const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";
+                executionContext.Output(StringUtil.Loc("SetEnvVar", policyPathEnvKey));
+                Environment.SetEnvironmentVariable(policyPathEnvKey, policyDllPath);
+            }
 
             // Check if the administrator accepted the license terms of the TEE EULA when configuring the agent.
             AgentSettings settings = HostContext.GetService<IConfigurationStore>().GetSettings();

--- a/src/Agent.Worker/Build/TrackingManager.cs
+++ b/src/Agent.Worker/Build/TrackingManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.TeamFoundation.DistributedTask.WebApi;
+﻿using Agent.Sdk;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Newtonsoft.Json;
 using System;
@@ -333,11 +334,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 var workDirectoryDrive = new DriveInfo(HostContext.GetDirectory(WellKnownDirectory.Work));
                 long freeSpace = workDirectoryDrive.AvailableFreeSpace;
                 long totalSpace = workDirectoryDrive.TotalSize;
-#if OS_WINDOWS
-                context.Output($"Working directory belongs to drive: '{workDirectoryDrive.Name}'");
-#else
-                context.Output($"Information about file system on which working directory resides.");
-#endif
+                if (PlatformUtil.RunningOnWindows)
+                {
+                    context.Output($"Working directory belongs to drive: '{workDirectoryDrive.Name}'");
+                }
+                else
+                {
+                    context.Output($"Information about file system on which working directory resides.");
+                }
                 context.Output($"Total size: '{totalSpace / 1024.0 / 1024.0} MB'");
                 context.Output($"Available space: '{freeSpace / 1024.0 / 1024.0} MB'");
             }

--- a/src/Agent.Worker/Container/ContainerInfo.cs
+++ b/src/Agent.Worker/Container/ContainerInfo.cs
@@ -78,10 +78,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         public Guid ContainerRegistryEndpoint { get; private set; }
         public string ContainerCreateOptions { get; private set; }
         public bool SkipContainerImagePull { get; private set; }
-#if !OS_WINDOWS
         public string CurrentUserName { get; set; }
         public string CurrentUserId { get; set; }
-#endif
         public bool IsJobContainer { get; set; }
 
         public IDictionary<string, string> ContainerEnvironmentVariables

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -84,12 +85,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 
         public async Task<int> DockerLogin(IExecutionContext context, string server, string username, string password)
         {
-#if OS_WINDOWS
-            // Wait for 17.07 to switch using stdin for docker registry password.
-            return await ExecuteDockerCommandAsync(context, "login", $"--username \"{username}\" --password \"{password.Replace("\"", "\\\"")}\" {server}", new List<string>() { password }, context.CancellationToken);
-#else
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // Wait for 17.07 to switch using stdin for docker registry password.
+                return await ExecuteDockerCommandAsync(context, "login", $"--username \"{username}\" --password \"{password.Replace("\"", "\\\"")}\" {server}", new List<string>() { password }, context.CancellationToken);
+            }
+
             return await ExecuteDockerCommandAsync(context, "login", $"--username \"{username}\" --password-stdin {server}", new List<string>() { password }, context.CancellationToken);
-#endif
         }
 
         public async Task<int> DockerLogout(IExecutionContext context, string server)
@@ -186,11 +188,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 
         public async Task<int> DockerNetworkCreate(IExecutionContext context, string network)
         {
-#if OS_WINDOWS
-            return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} --driver nat", context.CancellationToken);
-#else
+            if (PlatformUtil.RunningOnWindows)
+            {
+                return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} --driver nat", context.CancellationToken);
+            }
+            
             return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network}", context.CancellationToken);
-#endif
         }
 
         public async Task<int> DockerNetworkRemove(IExecutionContext context, string network)

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -44,63 +45,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             // Check whether we are inside a container.
             // Our container feature requires to map working directory from host to the container.
-            // If we are already inside a container, we will not able to find out the real working direcotry path on the host.
-#if OS_WINDOWS
-            // service CExecSvc is Container Execution Agent.
-            ServiceController[] scServices = ServiceController.GetServices();
-            if (scServices.Any(x => String.Equals(x.ServiceName, "cexecsvc", StringComparison.OrdinalIgnoreCase) && x.Status == ServiceControllerStatus.Running))
-            {
-                throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
-            }
-#elif OS_RHEL6
-            // Red Hat and CentOS 6 do not support the container feature
-            throw new NotSupportedException(StringUtil.Loc("AgentDoesNotSupportContainerFeatureRhel6"));
-#else
-            try 
-            {
-                var initProcessCgroup = File.ReadLines("/proc/1/cgroup");
-                if (initProcessCgroup.Any(x => x.IndexOf(":/docker/", StringComparison.OrdinalIgnoreCase) >= 0))
-                {
-                    throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
-                }
-            }
-            catch (Exception ex ) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
-            {
-                // if /proc/1/cgroup doesn't exist, we are not inside a container
-            }
-#endif
+            // If we're already inside a container, we won't be able to find the working directory path on the host.
+            ThrowIfAgentInContainer();
 
-#if OS_WINDOWS
-            // Check OS version (Windows server 1803 is required)
-            object windowsInstallationType = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "InstallationType", defaultValue: null);
-            ArgUtil.NotNull(windowsInstallationType, nameof(windowsInstallationType));
-            object windowsReleaseId = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", defaultValue: null);
-            ArgUtil.NotNull(windowsReleaseId, nameof(windowsReleaseId));
-            executionContext.Debug($"Current Windows version: '{windowsReleaseId} ({windowsInstallationType})'");
-
-            if (int.TryParse(windowsReleaseId.ToString(), out int releaseId))
-            {
-                if (!windowsInstallationType.ToString().StartsWith("Server", StringComparison.OrdinalIgnoreCase) || releaseId < 1803)
-                {
-                    throw new NotSupportedException(StringUtil.Loc("ContainerWindowsVersionRequirement"));
-                }
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ReleaseId");
-            }
-#endif
+            ThrowIfWindowsTooOld(executionContext);
 
             // Check docker client/server version
             DockerVersion dockerVersion = await _dockerManger.DockerVersion(executionContext);
             ArgUtil.NotNull(dockerVersion.ServerVersion, nameof(dockerVersion.ServerVersion));
             ArgUtil.NotNull(dockerVersion.ClientVersion, nameof(dockerVersion.ClientVersion));
 
-#if OS_WINDOWS
-            Version requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-EE version 17.6
-#else
             Version requiredDockerEngineAPIVersion = new Version(1, 35); // Docker-CE version 17.12
-#endif
+            if (PlatformUtil.RunningOnWindows)
+            {
+                requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-EE version 17.6
+            }
 
             if (dockerVersion.ServerVersion < requiredDockerEngineAPIVersion)
             {
@@ -269,32 +228,35 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
 
                 // Mount folder into container
-#if OS_WINDOWS
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals))));
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
-#else
-                string defaultWorkingDirectory = executionContext.Variables.Get(Constants.Variables.System.DefaultWorkingDirectory);
-                if (string.IsNullOrEmpty(defaultWorkingDirectory))
+                if (PlatformUtil.RunningOnWindows)
                 {
-                    throw new NotSupportedException(StringUtil.Loc("ContainerJobRequireSystemDefaultWorkDir"));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals))));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
                 }
-
-                string workingDirectory = Path.GetDirectoryName(defaultWorkingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-                container.MountVolumes.Add(new MountVolume(container.TranslateToHostPath(workingDirectory), workingDirectory));
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tasks), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tasks))));
-                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals)), true));
-
-                // Ensure .taskkey file exist so we can mount it.
-                string taskKeyFile = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), ".taskkey");
-                if (!File.Exists(taskKeyFile))
+                else
                 {
-                    File.WriteAllText(taskKeyFile, string.Empty);
+                    string defaultWorkingDirectory = executionContext.Variables.Get(Constants.Variables.System.DefaultWorkingDirectory);
+                    if (string.IsNullOrEmpty(defaultWorkingDirectory))
+                    {
+                        throw new NotSupportedException(StringUtil.Loc("ContainerJobRequireSystemDefaultWorkDir"));
+                    }
+
+                    string workingDirectory = Path.GetDirectoryName(defaultWorkingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                    container.MountVolumes.Add(new MountVolume(container.TranslateToHostPath(workingDirectory), workingDirectory));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tasks), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tasks))));
+                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals)), true));
+
+                    // Ensure .taskkey file exist so we can mount it.
+                    string taskKeyFile = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), ".taskkey");
+                    if (!File.Exists(taskKeyFile))
+                    {
+                        File.WriteAllText(taskKeyFile, string.Empty);
+                    }
+                    container.MountVolumes.Add(new MountVolume(taskKeyFile, container.TranslateToContainerPath(taskKeyFile)));
                 }
-                container.MountVolumes.Add(new MountVolume(taskKeyFile, container.TranslateToContainerPath(taskKeyFile)));
-#endif
 
                 if (container.IsJobContainer)
                 {
@@ -379,8 +341,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
             }
 
-#if !OS_WINDOWS
-            if (container.IsJobContainer)
+            if (!PlatformUtil.RunningOnWindows && container.IsJobContainer)
             {
                 // Ensure bash exist in the image
                 int execWhichBashExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"sh -c \"command -v bash\"");
@@ -524,7 +485,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                 }
             }
-#endif
         }
 
         private async Task StopContainerAsync(IExecutionContext executionContext, ContainerInfo container)
@@ -545,7 +505,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-#if !OS_WINDOWS
         private async Task<List<string>> ExecuteCommandAsync(IExecutionContext context, string command, string arg)
         {
             context.Command($"{command} {arg}");
@@ -591,7 +550,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return outputs;
         }
-#endif
 
         private async Task CreateContainerNetworkAsync(IExecutionContext executionContext, string network)
         {
@@ -648,6 +606,66 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             else
             {
                 throw new InvalidOperationException($"Failed to initialize, {container.ContainerNetworkAlias} service is {serviceHealth}.");
+            }
+        }
+
+        private static void ThrowIfAgentInContainer()
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // service CExecSvc is Container Execution Agent.
+                ServiceController[] scServices = ServiceController.GetServices();
+                if (scServices.Any(x => String.Equals(x.ServiceName, "cexecsvc", StringComparison.OrdinalIgnoreCase) && x.Status == ServiceControllerStatus.Running))
+                {
+                    throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
+                }
+            }
+            else if (PlatformUtil.RunningOnRHEL6)
+            {
+                // Red Hat and CentOS 6 do not support the container feature
+                throw new NotSupportedException(StringUtil.Loc("AgentDoesNotSupportContainerFeatureRhel6"));
+            }
+            else
+            {
+                try
+                {
+                    var initProcessCgroup = File.ReadLines("/proc/1/cgroup");
+                    if (initProcessCgroup.Any(x => x.IndexOf(":/docker/", StringComparison.OrdinalIgnoreCase) >= 0))
+                    {
+                        throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
+                    }
+                }
+                catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+                {
+                    // if /proc/1/cgroup doesn't exist, we are not inside a container
+                }
+            }
+        }
+
+        private static void ThrowIfWindowsTooOld(IExecutionContext executionContext)
+        {
+            if (!PlatformUtil.RunningOnWindows)
+            {
+                return;
+            }
+
+            // Check OS version (Windows server 1803 is required)
+            object windowsInstallationType = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "InstallationType", defaultValue: null);
+            ArgUtil.NotNull(windowsInstallationType, nameof(windowsInstallationType));
+            object windowsReleaseId = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", defaultValue: null);
+            ArgUtil.NotNull(windowsReleaseId, nameof(windowsReleaseId));
+            executionContext.Debug($"Current Windows version: '{windowsReleaseId} ({windowsInstallationType})'");
+
+            if (int.TryParse(windowsReleaseId.ToString(), out int releaseId))
+            {
+                if (!windowsInstallationType.ToString().StartsWith("Server", StringComparison.OrdinalIgnoreCase) || releaseId < 1803)
+                {
+                    throw new NotSupportedException(StringUtil.Loc("ContainerWindowsVersionRequirement"));
+                }
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ReleaseId");
             }
         }
     }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -1,4 +1,3 @@
-using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -45,21 +44,63 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             // Check whether we are inside a container.
             // Our container feature requires to map working directory from host to the container.
-            // If we're already inside a container, we won't be able to find the working directory path on the host.
-            ThrowIfAgentInContainer();
+            // If we are already inside a container, we will not able to find out the real working direcotry path on the host.
+#if OS_WINDOWS
+            // service CExecSvc is Container Execution Agent.
+            ServiceController[] scServices = ServiceController.GetServices();
+            if (scServices.Any(x => String.Equals(x.ServiceName, "cexecsvc", StringComparison.OrdinalIgnoreCase) && x.Status == ServiceControllerStatus.Running))
+            {
+                throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
+            }
+#elif OS_RHEL6
+            // Red Hat and CentOS 6 do not support the container feature
+            throw new NotSupportedException(StringUtil.Loc("AgentDoesNotSupportContainerFeatureRhel6"));
+#else
+            try 
+            {
+                var initProcessCgroup = File.ReadLines("/proc/1/cgroup");
+                if (initProcessCgroup.Any(x => x.IndexOf(":/docker/", StringComparison.OrdinalIgnoreCase) >= 0))
+                {
+                    throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
+                }
+            }
+            catch (Exception ex ) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+            {
+                // if /proc/1/cgroup doesn't exist, we are not inside a container
+            }
+#endif
 
-            ThrowIfWindowsTooOld(executionContext);
+#if OS_WINDOWS
+            // Check OS version (Windows server 1803 is required)
+            object windowsInstallationType = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "InstallationType", defaultValue: null);
+            ArgUtil.NotNull(windowsInstallationType, nameof(windowsInstallationType));
+            object windowsReleaseId = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", defaultValue: null);
+            ArgUtil.NotNull(windowsReleaseId, nameof(windowsReleaseId));
+            executionContext.Debug($"Current Windows version: '{windowsReleaseId} ({windowsInstallationType})'");
+
+            if (int.TryParse(windowsReleaseId.ToString(), out int releaseId))
+            {
+                if (!windowsInstallationType.ToString().StartsWith("Server", StringComparison.OrdinalIgnoreCase) || releaseId < 1803)
+                {
+                    throw new NotSupportedException(StringUtil.Loc("ContainerWindowsVersionRequirement"));
+                }
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ReleaseId");
+            }
+#endif
 
             // Check docker client/server version
             DockerVersion dockerVersion = await _dockerManger.DockerVersion(executionContext);
             ArgUtil.NotNull(dockerVersion.ServerVersion, nameof(dockerVersion.ServerVersion));
             ArgUtil.NotNull(dockerVersion.ClientVersion, nameof(dockerVersion.ClientVersion));
 
+#if OS_WINDOWS
+            Version requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-EE version 17.6
+#else
             Version requiredDockerEngineAPIVersion = new Version(1, 35); // Docker-CE version 17.12
-            if (PlatformUtil.RunningOnWindows)
-            {
-                requiredDockerEngineAPIVersion = new Version(1, 30);  // Docker-EE version 17.6
-            }
+#endif
 
             if (dockerVersion.ServerVersion < requiredDockerEngineAPIVersion)
             {
@@ -228,35 +269,32 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
 
                 // Mount folder into container
-                if (PlatformUtil.RunningOnWindows)
+#if OS_WINDOWS
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
+#else
+                string defaultWorkingDirectory = executionContext.Variables.Get(Constants.Variables.System.DefaultWorkingDirectory);
+                if (string.IsNullOrEmpty(defaultWorkingDirectory))
                 {
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals))));
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
+                    throw new NotSupportedException(StringUtil.Loc("ContainerJobRequireSystemDefaultWorkDir"));
                 }
-                else
+
+                string workingDirectory = Path.GetDirectoryName(defaultWorkingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                container.MountVolumes.Add(new MountVolume(container.TranslateToHostPath(workingDirectory), workingDirectory));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tasks), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tasks))));
+                container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals)), true));
+
+                // Ensure .taskkey file exist so we can mount it.
+                string taskKeyFile = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), ".taskkey");
+                if (!File.Exists(taskKeyFile))
                 {
-                    string defaultWorkingDirectory = executionContext.Variables.Get(Constants.Variables.System.DefaultWorkingDirectory);
-                    if (string.IsNullOrEmpty(defaultWorkingDirectory))
-                    {
-                        throw new NotSupportedException(StringUtil.Loc("ContainerJobRequireSystemDefaultWorkDir"));
-                    }
-
-                    string workingDirectory = Path.GetDirectoryName(defaultWorkingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-                    container.MountVolumes.Add(new MountVolume(container.TranslateToHostPath(workingDirectory), workingDirectory));
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tools), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tools))));
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tasks), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tasks))));
-                    container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Externals), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Externals)), true));
-
-                    // Ensure .taskkey file exist so we can mount it.
-                    string taskKeyFile = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), ".taskkey");
-                    if (!File.Exists(taskKeyFile))
-                    {
-                        File.WriteAllText(taskKeyFile, string.Empty);
-                    }
-                    container.MountVolumes.Add(new MountVolume(taskKeyFile, container.TranslateToContainerPath(taskKeyFile)));
+                    File.WriteAllText(taskKeyFile, string.Empty);
                 }
+                container.MountVolumes.Add(new MountVolume(taskKeyFile, container.TranslateToContainerPath(taskKeyFile)));
+#endif
 
                 if (container.IsJobContainer)
                 {
@@ -341,7 +379,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
             }
 
-            if (!PlatformUtil.RunningOnWindows && container.IsJobContainer)
+#if !OS_WINDOWS
+            if (container.IsJobContainer)
             {
                 // Ensure bash exist in the image
                 int execWhichBashExitCode = await _dockerManger.DockerExec(executionContext, container.ContainerId, string.Empty, $"sh -c \"command -v bash\"");
@@ -485,6 +524,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                 }
             }
+#endif
         }
 
         private async Task StopContainerAsync(IExecutionContext executionContext, ContainerInfo container)
@@ -505,6 +545,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
+#if !OS_WINDOWS
         private async Task<List<string>> ExecuteCommandAsync(IExecutionContext context, string command, string arg)
         {
             context.Command($"{command} {arg}");
@@ -550,6 +591,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return outputs;
         }
+#endif
 
         private async Task CreateContainerNetworkAsync(IExecutionContext executionContext, string network)
         {
@@ -606,66 +648,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             else
             {
                 throw new InvalidOperationException($"Failed to initialize, {container.ContainerNetworkAlias} service is {serviceHealth}.");
-            }
-        }
-
-        private static void ThrowIfAgentInContainer()
-        {
-            if (PlatformUtil.RunningOnWindows)
-            {
-                // service CExecSvc is Container Execution Agent.
-                ServiceController[] scServices = ServiceController.GetServices();
-                if (scServices.Any(x => String.Equals(x.ServiceName, "cexecsvc", StringComparison.OrdinalIgnoreCase) && x.Status == ServiceControllerStatus.Running))
-                {
-                    throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
-                }
-            }
-            else if (PlatformUtil.RunningOnRHEL6)
-            {
-                // Red Hat and CentOS 6 do not support the container feature
-                throw new NotSupportedException(StringUtil.Loc("AgentDoesNotSupportContainerFeatureRhel6"));
-            }
-            else
-            {
-                try
-                {
-                    var initProcessCgroup = File.ReadLines("/proc/1/cgroup");
-                    if (initProcessCgroup.Any(x => x.IndexOf(":/docker/", StringComparison.OrdinalIgnoreCase) >= 0))
-                    {
-                        throw new NotSupportedException(StringUtil.Loc("AgentAlreadyInsideContainer"));
-                    }
-                }
-                catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
-                {
-                    // if /proc/1/cgroup doesn't exist, we are not inside a container
-                }
-            }
-        }
-
-        private static void ThrowIfWindowsTooOld(IExecutionContext executionContext)
-        {
-            if (!PlatformUtil.RunningOnWindows)
-            {
-                return;
-            }
-
-            // Check OS version (Windows server 1803 is required)
-            object windowsInstallationType = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "InstallationType", defaultValue: null);
-            ArgUtil.NotNull(windowsInstallationType, nameof(windowsInstallationType));
-            object windowsReleaseId = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ReleaseId", defaultValue: null);
-            ArgUtil.NotNull(windowsReleaseId, nameof(windowsReleaseId));
-            executionContext.Debug($"Current Windows version: '{windowsReleaseId} ({windowsInstallationType})'");
-
-            if (int.TryParse(windowsReleaseId.ToString(), out int releaseId))
-            {
-                if (!windowsInstallationType.ToString().StartsWith("Server", StringComparison.OrdinalIgnoreCase) || releaseId < 1803)
-                {
-                    throw new NotSupportedException(StringUtil.Loc("ContainerWindowsVersionRequirement"));
-                }
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ReleaseId");
             }
         }
     }

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -69,11 +70,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             executionContext.Debug("Creating diagnostic log environment file.");
             string environmentFile = Path.Combine(supportFilesFolder, "environment.txt");
-#if OS_WINDOWS            
             string content = await GetEnvironmentContent(agentId, agentName, message.Steps);
-#else            
-            string content = GetEnvironmentContent(agentId, agentName, message.Steps);
-#endif            
             File.WriteAllText(environmentFile, content);
 
             // Create the capabilities file
@@ -233,8 +230,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return agentLogFiles;
         }
 
-#if OS_WINDOWS
         private async Task<string> GetEnvironmentContent(int agentId, string agentName, IList<Pipelines.JobStep> steps)
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                return await GetEnvironmentContentWindows(agentId, agentName, steps);
+            }
+            return GetEnvironmentContentNonWindows(agentId, agentName, steps);
+        }
+
+        private async Task<string> GetEnvironmentContentWindows(int agentId, string agentName, IList<Pipelines.JobStep> steps)
         {
             var builder = new StringBuilder();
 
@@ -322,8 +327,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return builder.ToString();
         }
-#else
-        private string GetEnvironmentContent(int agentId, string agentName, IList<Pipelines.JobStep> steps)
+
+        private string GetEnvironmentContentNonWindows(int agentId, string agentName, IList<Pipelines.JobStep> steps)
         {
             var builder = new StringBuilder();
 
@@ -341,6 +346,5 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return builder.ToString();
         }
-#endif
     }
 }

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -502,12 +503,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var runtimeOptions = HostContext.GetService<IConfigurationStore>().GetAgentRuntimeOptions();
             if (runtimeOptions != null)
             {
-#if OS_WINDOWS
-                if (runtimeOptions.GitUseSecureChannel)
+                if (PlatformUtil.RunningOnWindows && runtimeOptions.GitUseSecureChannel)
                 {
                     Variables.Set(Constants.Variables.Agent.GitUseSChannel, runtimeOptions.GitUseSecureChannel.ToString());
                 }
-#endif                
             }
 
             // Job timeline record.

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Worker.Container;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
@@ -27,11 +28,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
     public abstract class Handler : AgentService
     {
-#if OS_WINDOWS
-        // In windows OS the maximum supported size of a environment variable value is 32k.
-        // You can set environment variable greater then 32K, but that variable will not be able to read in node.exe.
-        private const int _environmentVariableMaximumSize = 32766;
-#endif
+        // On Windows, the maximum supported size of a environment variable value is 32k.
+        // You can set environment variables greater then 32K, but Node won't be able to read them.
+        private const int _windowsEnvironmentVariableMaximumSize = 32766;
 
         protected IWorkerCommandManager CommandManager { get; private set; }
 
@@ -238,12 +237,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
             Environment[key] = value ?? string.Empty;
 
-#if OS_WINDOWS
-            if (Environment[key].Length > _environmentVariableMaximumSize)
+            if (PlatformUtil.RunningOnWindows && Environment[key].Length > _windowsEnvironmentVariableMaximumSize)
             {
-                ExecutionContext.Warning(StringUtil.Loc("EnvironmentVariableExceedsMaximumLength", key, value.Length, _environmentVariableMaximumSize));
+                ExecutionContext.Warning(StringUtil.Loc("EnvironmentVariableExceedsMaximumLength", key, value.Length, _windowsEnvironmentVariableMaximumSize));
             }
-#endif
         }
 
         protected void AddTaskVariablesToEnvironment()

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using System.IO;
 using System.Text;
@@ -48,17 +49,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             ArgUtil.NotNull(Inputs, nameof(Inputs));
             ArgUtil.Directory(TaskDirectory, nameof(TaskDirectory));
 
-#if !OS_WINDOWS
-            // Ensure compat vso-task-lib exist at the root of _work folder
-            // This will make vsts-agent works against 2015 RTM/QU1 TFS, since tasks in those version doesn't package with task lib
-            // Put the 0.5.5 version vso-task-lib into the root of _work/node_modules folder, so tasks are able to find those lib.
-            if (!File.Exists(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib", "package.json")))
+            if (!PlatformUtil.RunningOnWindows)
             {
-                string vsoTaskLibFromExternal = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "vso-task-lib");
-                string compatVsoTaskLibInWork = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib");
-                IOUtil.CopyDirectory(vsoTaskLibFromExternal, compatVsoTaskLibInWork, ExecutionContext.CancellationToken);
+                // Ensure compat vso-task-lib exist at the root of _work folder
+                // This will make vsts-agent works against 2015 RTM/QU1 TFS, since tasks in those version doesn't package with task lib
+                // Put the 0.5.5 version vso-task-lib into the root of _work/node_modules folder, so tasks are able to find those lib.
+                if (!File.Exists(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib", "package.json")))
+                {
+                    string vsoTaskLibFromExternal = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "vso-task-lib");
+                    string compatVsoTaskLibInWork = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib");
+                    IOUtil.CopyDirectory(vsoTaskLibFromExternal, compatVsoTaskLibInWork, ExecutionContext.CancellationToken);
+                }
             }
-#endif
 
             // Update the env dictionary.
             AddInputsToEnvironment();
@@ -115,13 +117,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             // file name character on Linux.
             string arguments = StepHost.ResolvePathForStepHost(StringUtil.Format(@"""{0}""", target.Replace(@"""", @"\""")));
 
-#if OS_WINDOWS
-            // It appears that node.exe outputs UTF8 when not in TTY mode.
-            Encoding outputEncoding = Encoding.UTF8;
-#else
-            // Let .NET choose the default.
+            // Let .NET choose the default, except on Windows.
             Encoding outputEncoding = null;
-#endif
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // It appears that node.exe outputs UTF8 when not in TTY mode.
+                outputEncoding = Encoding.UTF8;
+            }
 
             // Execute the process. Exit code 0 should always be returned.
             // A non-zero exit code indicates infrastructural failure.

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -99,11 +99,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             path = path.Trim('\"');
 
             // try to resolve path inside container if the request path is part of the mount volume
-#if OS_WINDOWS
-            if (Container.MountVolumes.Exists(x => path.StartsWith(x.SourceVolumePath, StringComparison.OrdinalIgnoreCase)))
-#else
-            if (Container.MountVolumes.Exists(x => path.StartsWith(x.SourceVolumePath)))
-#endif
+            StringComparison sc = (PlatformUtil.RunningOnWindows)
+                                ? StringComparison.OrdinalIgnoreCase
+                                : StringComparison.Ordinal;
+            if (Container.MountVolumes.Exists(x => path.StartsWith(x.SourceVolumePath, sc)))
             {
                 return Container.TranslateToContainerPath(path);
             }

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.VisualStudio.Services.Agent.Util;
@@ -136,11 +137,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 jobContext.Variables.Set(Constants.Variables.Agent.OS, VarUtil.OS);
                 jobContext.Variables.Set(Constants.Variables.Agent.OSArchitecture, VarUtil.OSArchitecture);
                 jobContext.SetVariable(Constants.Variables.Agent.RootDirectory, HostContext.GetDirectory(WellKnownDirectory.Work), isFilePath: true);
-#if OS_WINDOWS
-                jobContext.SetVariable(Constants.Variables.Agent.ServerOMDirectory, HostContext.GetDirectory(WellKnownDirectory.ServerOM), isFilePath: true);
-#else
-                jobContext.Variables.Set(Constants.Variables.Agent.AcceptTeeEula, settings.AcceptTeeEula.ToString());
-#endif
+                if (PlatformUtil.RunningOnWindows)
+                {
+                    jobContext.SetVariable(Constants.Variables.Agent.ServerOMDirectory, HostContext.GetDirectory(WellKnownDirectory.ServerOM), isFilePath: true);
+                }
+                if (!PlatformUtil.RunningOnWindows)
+                {
+                    jobContext.Variables.Set(Constants.Variables.Agent.AcceptTeeEula, settings.AcceptTeeEula.ToString());
+                }
                 jobContext.SetVariable(Constants.Variables.Agent.WorkFolder, HostContext.GetDirectory(WellKnownDirectory.Work), isFilePath: true);
                 jobContext.SetVariable(Constants.Variables.System.WorkFolder, HostContext.GetDirectory(WellKnownDirectory.Work), isFilePath: true);
 

--- a/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -174,9 +175,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                 || string.Equals(buildArtifact.Resource.Type, ArtifactResourceTypes.FilePath, StringComparison.OrdinalIgnoreCase))
             {
                 executionContext.Output(StringUtil.Loc("RMArtifactTypeFileShare"));
-#if !OS_WINDOWS
-                throw new NotSupportedException(StringUtil.Loc("RMFileShareArtifactErrorOnNonWindowsAgent"));
-#else
+                if (!PlatformUtil.RunningOnWindows)
+                {
+                    throw new NotSupportedException(StringUtil.Loc("RMFileShareArtifactErrorOnNonWindowsAgent"));
+                }
                 string fileShare;
                 if (buildArtifact.Id == 0)
                 {
@@ -204,7 +206,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
 
                 var fileShareArtifact = new FileShareArtifact();
                 await fileShareArtifact.DownloadArtifactAsync(executionContext, HostContext, artifactDefinition, fileShare, downloadFolderPath);
-#endif
             }
             else if (buildArtifactDetails != null
                      && string.Equals(buildArtifact.Resource.Type, ArtifactResourceTypes.Container, StringComparison.OrdinalIgnoreCase))

--- a/src/Agent.Worker/Release/Artifacts/CustomArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/CustomArtifact.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -97,14 +98,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
 
             if (string.Equals(streamType, WellKnownStreamTypes.FileShare, StringComparison.OrdinalIgnoreCase))
             {
-#if !OS_WINDOWS
-                throw new NotSupportedException(StringUtil.Loc("RMFileShareArtifactErrorOnNonWindowsAgent"));
-#else
+                if (!PlatformUtil.RunningOnWindows)
+                {
+                    throw new NotSupportedException(StringUtil.Loc("RMFileShareArtifactErrorOnNonWindowsAgent"));
+                }
+
                 var fileShareArtifact = new FileShareArtifact();
                 customArtifactDetails.RelativePath = artifact.RelativePath ?? string.Empty;
                 var location = artifact.FileShareLocation ?? artifact.DownloadUrl;
                 await fileShareArtifact.DownloadArtifactAsync(executionContext, hostContext, new ArtifactDefinition { Details = customArtifactDetails }, new Uri(location).LocalPath, localFolderPath);
-#endif
             }
             else if (string.Equals(streamType, WellKnownStreamTypes.Zip, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Agent.Worker/Release/Artifacts/GitHubHttpClient.cs
+++ b/src/Agent.Worker/Release/Artifacts/GitHubHttpClient.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -42,9 +43,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             request.Headers.Add("Authorization", "Token " + accessToken);
             request.Headers.Add("User-Agent", "VSTS-Agent/" + BuildConstants.AgentPackage.Version);
 
-#if OS_LINUX || OS_OSX
-            request.Version = HttpVersion.Version11;
-#endif
+            if (PlatformUtil.RunningOnMacOS || PlatformUtil.RunningOnLinux)
+            {
+                request.Version = HttpVersion.Version11;
+            }
 
             int httpRequestTimeoutSeconds;
             if (!int.TryParse(Environment.GetEnvironmentVariable("VSTS_HTTP_TIMEOUT") ?? string.Empty, out httpRequestTimeoutSeconds))

--- a/src/Agent.Worker/Release/ContainerFetchEngine/HttpRetryOnTimeoutHandler.cs
+++ b/src/Agent.Worker/Release/ContainerFetchEngine/HttpRetryOnTimeoutHandler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Agent.Sdk;
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
@@ -27,9 +28,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-#if OS_LINUX || OS_OSX
-            request.Version = HttpVersion.Version11;
-#endif            
+            if (PlatformUtil.RunningOnMacOS || PlatformUtil.RunningOnLinux)
+            {
+                request.Version = HttpVersion.Version11;
+            }
+
             // Potential improvements:
             // 1. Calculate a max time across attempts, to avoid retries (this class) on top of retries (VssHttpRetryMessageHandler) 
             //    causing more time to pass than expected in degenerative cases.

--- a/src/Agent.Worker/Release/ReleaseTrackingManager.cs
+++ b/src/Agent.Worker/Release/ReleaseTrackingManager.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Newtonsoft.Json;
 using System;
@@ -171,11 +172,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
                 var workDirectoryDrive = new DriveInfo(HostContext.GetDirectory(WellKnownDirectory.Work));
                 long freeSpace = workDirectoryDrive.AvailableFreeSpace;
                 long totalSpace = workDirectoryDrive.TotalSize;
-#if OS_WINDOWS
-                context.Output($"Working directory belongs to drive: '{workDirectoryDrive.Name}'");
-#else
-                context.Output($"Information about file system on which working directory resides.");
-#endif
+                if (PlatformUtil.RunningOnWindows)
+                {
+                    context.Output($"Working directory belongs to drive: '{workDirectoryDrive.Name}'");
+                }
+                else
+                {
+                    context.Output($"Information about file system on which working directory resides.");
+                }
                 context.Output($"Total size: '{totalSpace / 1024.0 / 1024.0} MB'");
                 context.Output($"Available space: '{freeSpace / 1024.0 / 1024.0} MB'");
             }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -99,11 +99,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 .FirstOrDefault();
             if (handlerData == null)
             {
-#if OS_WINDOWS
-                throw new Exception(StringUtil.Loc("SupportedTaskHandlerNotFoundWindows", $"{PlatformUtil.RunningOnOS}({PlatformUtil.RunningOnArchitecture})"));
-#else
+                if (PlatformUtil.RunningOnWindows)
+                {
+                    throw new Exception(StringUtil.Loc("SupportedTaskHandlerNotFoundWindows", $"{PlatformUtil.RunningOnOS}({PlatformUtil.RunningOnArchitecture})"));
+                }
+
                 throw new Exception(StringUtil.Loc("SupportedTaskHandlerNotFoundLinux"));
-#endif
             }
 
             Variables runtimeVariables = ExecutionContext.Variables;
@@ -327,8 +328,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         {
             Trace.Entering();
 
-#if OS_WINDOWS
-            if (!string.IsNullOrEmpty(inputValue))
+            if (PlatformUtil.RunningOnWindows && !string.IsNullOrEmpty(inputValue))
             {
                 Trace.Verbose("Trim double quotes around filepath type input on Windows.");
                 inputValue = inputValue.Trim('\"');
@@ -336,7 +336,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Trace.Verbose($"Replace any '{Path.AltDirectorySeparatorChar}' with '{Path.DirectorySeparatorChar}'.");
                 inputValue = inputValue.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             }
-#endif 
+
             // if inputValue is rooted, return full path.
             string fullPath;
             if (!string.IsNullOrEmpty(inputValue) &&

--- a/src/Agent.Worker/TempDirectoryManager.cs
+++ b/src/Agent.Worker/TempDirectoryManager.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.IO;
@@ -52,15 +53,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-#if OS_WINDOWS
-                jobContext.Debug($"SET TMP={_tempDirectory}");
-                jobContext.Debug($"SET TEMP={_tempDirectory}");
-                jobContext.SetVariable("TMP", _tempDirectory, isFilePath: true);
-                jobContext.SetVariable("TEMP", _tempDirectory, isFilePath: true);
-#else
-                jobContext.Debug($"SET TMPDIR={_tempDirectory}");
-                jobContext.SetVariable("TMPDIR", _tempDirectory, isFilePath:true);
-#endif
+                if (PlatformUtil.RunningOnWindows)
+                {
+                    jobContext.Debug($"SET TMP={_tempDirectory}");
+                    jobContext.Debug($"SET TEMP={_tempDirectory}");
+                    jobContext.SetVariable("TMP", _tempDirectory, isFilePath: true);
+                    jobContext.SetVariable("TEMP", _tempDirectory, isFilePath: true);
+                }
+                else
+                {
+                    jobContext.Debug($"SET TMPDIR={_tempDirectory}");
+                    jobContext.SetVariable("TMPDIR", _tempDirectory, isFilePath:true);
+                }
             }
         }
 

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker.Build;
@@ -140,11 +141,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public int? Release_Parallel_Download_Limit => GetInt(Constants.Variables.Release.ReleaseParallelDownloadLimit);
 
-#if OS_WINDOWS
-        public bool Retain_Default_Encoding => GetBoolean(Constants.Variables.Agent.RetainDefaultEncoding) ?? true;
-#else
-        public bool Retain_Default_Encoding => true;
-#endif
+        public bool Retain_Default_Encoding
+        {
+            get
+            {
+                if (!PlatformUtil.RunningOnWindows)
+                {
+                    return true;
+                }
+                return GetBoolean(Constants.Variables.Agent.RetainDefaultEncoding) ?? true;
+            }
+        }
 
         public string System_CollectionId => Get(Constants.Variables.System.CollectionId);
 


### PR DESCRIPTION
Remove most of the OS-specific #ifs in the worker.

Things not touched:
- ContainerInfo, which is being handled in another PR
- JobExtension, where the wrapped areas are going to be deleted anyhow
- TaskManager, which does creative things with `JsonIgnore` that need to be better understood