### PR TITLE
First pass to refactor how task commands are specified [NEEDS MORE TESTING]

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -65,6 +65,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         // others
         void ForceTaskComplete();
+        IHostContext GetHostContext();
     }
 
     public sealed class ExecutionContext : AgentService, IExecutionContext
@@ -160,6 +161,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 await Task.Delay(TimeSpan.FromSeconds(5));
                 _forceCompleted?.TrySetResult(1);
             });
+        }
+
+        public IHostContext GetHostContext()
+        {
+            return HostContext;
         }
 
         public IExecutionContext CreateChild(Guid recordId, string displayName, string refName, Variables taskVariables = null, bool outputForward = false)

--- a/src/Agent.Worker/Release/ReleaseCommandExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseCommandExtension.cs
@@ -12,76 +12,68 @@ using Agent.Worker.Release;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
 {
-    public sealed class ReleaseCommandExtension : AgentService, IWorkerCommandExtension
+    public sealed class ReleaseCommandExtension : BaseWorkerCommandExtension
     {
-        public Type ExtensionType => typeof(IWorkerCommandExtension);
-
-        public string CommandArea => "release";
-
-        public HostTypes SupportedHostTypes => HostTypes.Release | HostTypes.Deployment;
-
-        public void ProcessCommand(IExecutionContext context, Command command)
+        public ReleaseCommandExtension()
         {
-            if (string.Equals(command.Event, WellKnownReleaseCommand.UpdateReleaseName, StringComparison.OrdinalIgnoreCase))
-            {
-                ProcessReleaseUpdateReleaseNameCommand(context, command.Data);
-            }
-            else
-            {
-                throw new Exception(StringUtil.Loc("RMCommandNotFound", command.Event));
-            }
+            CommandArea = "release";
+            SupportedHostTypes = HostTypes.Release | HostTypes.Deployment;
+            InstallWorkerCommand(new ReleaseUpdateReleaseNameCommand());
         }
 
-        private void ProcessReleaseUpdateReleaseNameCommand(IExecutionContext context, string data)
+        private class ReleaseUpdateReleaseNameCommand: IWorkerCommand
         {
-            ArgUtil.NotNull(context, nameof(context));
-            ArgUtil.NotNull(context.Endpoints, nameof(context.Endpoints));
+            public string Name => "updatereleasename";
+            public string[] Aliases => new string [] {};
 
-            Guid projectId = context.Variables.System_TeamProjectId ?? Guid.Empty;
-            ArgUtil.NotEmpty(projectId, nameof(projectId));
-            
-            string releaseId = context.Variables.Release_ReleaseId;
-            ArgUtil.NotNull(releaseId, nameof(releaseId));
-
-            if (!String.IsNullOrEmpty(data))
+            public void Execute(IExecutionContext context, Command command)
             {
-                // queue async command task to update release name.
-                context.Debug($"Update release name for release: {releaseId} to: {data} at backend.");
-                var commandContext = HostContext.CreateService<IAsyncCommandContext>();
-                commandContext.InitializeCommandContext(context, StringUtil.Loc("RMUpdateReleaseName"));
-                commandContext.Task = UpdateReleaseNameAsync(commandContext,
-                                                             context,
-                                                             WorkerUtilities.GetVssConnection(context),
-                                                             projectId,
-                                                             releaseId,
-                                                             data,
-                                                             context.CancellationToken);
-                context.AsyncCommands.Add(commandContext);
-            }
-            else
-            {
-                throw new Exception(StringUtil.Loc("RMReleaseNameRequired"));
-            }
-        }
+                string data = command.Data;
+                ArgUtil.NotNull(context, nameof(context));
+                ArgUtil.NotNull(context.Endpoints, nameof(context.Endpoints));
 
-        private async Task UpdateReleaseNameAsync(
-            IAsyncCommandContext commandContext,
-            IExecutionContext context,
-            VssConnection connection,
-            Guid projectId,
-            string releaseId,
-            string releaseName,
-            CancellationToken cancellationToken)
-        {
-            ReleaseServer releaseServer = new ReleaseServer(connection, projectId);
-            var release = await releaseServer.UpdateReleaseName(releaseId, releaseName, cancellationToken);
-            commandContext.Output(StringUtil.Loc("RMUpdateReleaseNameForRelease", release.Name, release.Id));
-            context.Variables.Set("release.releaseName", release.Name);
+                Guid projectId = context.Variables.System_TeamProjectId ?? Guid.Empty;
+                ArgUtil.NotEmpty(projectId, nameof(projectId));
+                
+                string releaseId = context.Variables.Release_ReleaseId;
+                ArgUtil.NotNull(releaseId, nameof(releaseId));
+
+                if (!String.IsNullOrEmpty(data))
+                {
+                    // queue async command task to update release name.
+                    context.Debug($"Update release name for release: {releaseId} to: {data} at backend.");
+                    var commandContext = context.GetHostContext().CreateService<IAsyncCommandContext>();
+                    commandContext.InitializeCommandContext(context, StringUtil.Loc("RMUpdateReleaseName"));
+                    commandContext.Task = UpdateReleaseNameAsync(commandContext,
+                                                                context,
+                                                                WorkerUtilities.GetVssConnection(context),
+                                                                projectId,
+                                                                releaseId,
+                                                                data,
+                                                                context.CancellationToken);
+                    context.AsyncCommands.Add(commandContext);
+                }
+                else
+                {
+                    throw new Exception(StringUtil.Loc("RMReleaseNameRequired"));
+                }
+            }
+
+            private async Task UpdateReleaseNameAsync(
+                IAsyncCommandContext commandContext,
+                IExecutionContext context,
+                VssConnection connection,
+                Guid projectId,
+                string releaseId,
+                string releaseName,
+                CancellationToken cancellationToken)
+            {
+                ReleaseServer releaseServer = new ReleaseServer(connection, projectId);
+                var release = await releaseServer.UpdateReleaseName(releaseId, releaseName, cancellationToken);
+                commandContext.Output(StringUtil.Loc("RMUpdateReleaseNameForRelease", release.Name, release.Id));
+                context.Variables.Set("release.releaseName", release.Name);
+            }
         }
     }    
 
-    internal static class WellKnownReleaseCommand
-    {
-        public static readonly string UpdateReleaseName = "updatereleasename";
-    }
 }

--- a/src/Agent.Worker/Release/ReleaseCommandExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseCommandExtension.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker;
 using Microsoft.VisualStudio.Services.Agent;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/src/Agent.Worker/Release/ReleaseCommandExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseCommandExtension.cs
@@ -24,11 +24,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
         private class ReleaseUpdateReleaseNameCommand: IWorkerCommand
         {
             public string Name => "updatereleasename";
-            public string[] Aliases => new string [] {};
+            public List<string> Aliases => null;
 
             public void Execute(IExecutionContext context, Command command)
             {
-                string data = command.Data;
+                var data = command.Data;
                 ArgUtil.NotNull(context, nameof(context));
                 ArgUtil.NotNull(context.Endpoints, nameof(context.Endpoints));
 

--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     {
         string Name { get; }
 
-        string[] Aliases { get; }
+        List<string> Aliases { get; }
 
         void Execute(IExecutionContext context, Command command);
     }
@@ -157,9 +157,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         {
             // TODO: check for already defined
             _commands[commandExecutor.Name] = commandExecutor;
-            foreach (var alias in commandExecutor.Aliases)
+            var aliasList = commandExecutor.Aliases;
+            if (aliasList != null)
             {
-                _commands[alias] = commandExecutor;
+                foreach (var alias in commandExecutor.Aliases)
+                {
+                    _commands[alias] = commandExecutor;
+                }
             }
         }
 

--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -169,8 +169,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public void ProcessCommand(IExecutionContext context, Command command)
         {
-            IWorkerCommand commandExecutor = null;
-            _commands.TryGetValue(command.Event, out commandExecutor);
+            _commands.TryGetValue(command.Event, out var commandExecutor);
             if (commandExecutor == null)
             {
                 // TODO: make this generic

--- a/src/Misc/layoutbin/de-DE/strings.json
+++ b/src/Misc/layoutbin/de-DE/strings.json
@@ -423,7 +423,6 @@
     "RMCachingAllItems":  "Alle Elemente im Dateicontainer werden zwischengespeichert...",
     "RMCachingComplete":  "Die Zwischenspeicherung wurde abgeschlossen. ({0} ms)",
     "RMCachingContainerItems":  "Elemente werden unter \"{0}\" im Dateicontainer zwischengespeichert...",
-    "RMCommandNotFound":  "##vso[task.{0}] wird nicht als Befehl für die Erweiterung des Befehls \"Release\" erkannt. Schlagen Sie in der Dokumentation (http://go.microsoft.com/fwlink/?LinkId=817296) nach.",
     "RMContainerItemNotSupported":  "Der Containerelementtyp \"{0}\" wird nicht unterstützt.",
     "RMContainerItemPathDoesnotExist":  "Der Containerelementpfad beginnt nicht mit {0}: {1}",
     "RMContainerItemRequestTimedOut":  "Timeout der Anforderung nach {0} Sekunden. Ruhezustand {1} Sekunden und erneuter Versuch. Anforderung: {2}{3}",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -206,7 +206,8 @@
     "On-premises TFS with integrated authentication",
     ".{0}config.{1} remove --unattended --auth negotiate --username myDomain\\myUserName --password myPassword"
   ],
-  "CommandNotFound": "Can't find command extension for ##vso[{0}.command]. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
+  "CommandNotFound": "Cannot find command extension for ##vso[{0}.command]. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
+  "CommandNotFound2": "##vso[{0}.{1}] is not a recognized command for {2} command extension. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296).",
   "CommandNotSupported": "{0} commands are not supported for {1} flow. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
   "CommandProcessFailed": "Unable to process command '{0}' successfully. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
   "ConnectingToServer": "Connecting to server ...",
@@ -461,7 +462,6 @@
   "RMCachingAllItems": "Caching all items in the file container...",
   "RMCachingComplete": "Caching complete. ({0} ms)",
   "RMCachingContainerItems": "Caching items under '{0}' in the file container...",
-  "RMCommandNotFound": "##vso[release.{0}] is not a recognized command for Release command extension. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296).",
   "RMContainerItemNotSupported": "Container Item type '{0}' not supported.",
   "RMContainerItemPathDoesnotExist": "File container item path doesn't start with {0}: {1}",
   "RMContainerItemRequestTimedOut": "Request timed out after {0} seconds; sleeping for {1} seconds and attempting again. Request: {2} {3}",

--- a/src/Misc/layoutbin/es-ES/strings.json
+++ b/src/Misc/layoutbin/es-ES/strings.json
@@ -434,7 +434,6 @@
     "RMCachingAllItems":  "Almacenando en caché todos los elementos del contenedor de archivos...",
     "RMCachingComplete":  "Almacenamiento en caché completo. ({0} ms)",
     "RMCachingContainerItems":  "Almacenando en caché los elementos bajo \u0027{0}\u0027 del contenedor de archivos...",
-    "RMCommandNotFound":  "##vso[release.{0}] no es un comando reconocido para la extensión de comando Release. Consulte la documentación (http://go.microsoft.com/fwlink/?LinkId=817296).",
     "RMContainerItemNotSupported":  "El tipo de elemento de contenedor \u0027{0}\u0027 no se admite.",
     "RMContainerItemPathDoesnotExist":  "La ruta de acceso del elemento del contenedor de archivos no empieza por {0}: {1}",
     "RMContainerItemRequestTimedOut":  "Se agotó el tiempo de espera de la solicitud tras {0} segundos; se va a entrar en modo de suspensión durante {1} segundos y se intentará de nuevo. Solicitud: {2} {3}",

--- a/src/Misc/layoutbin/fr-FR/strings.json
+++ b/src/Misc/layoutbin/fr-FR/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "Mise en cache de tous les éléments du conteneur de fichiers...",
     "RMCachingComplete":  "Mise en cache effectuée. ({0} ms)",
     "RMCachingContainerItems":  "Mise en cache des éléments situés sous \u0027{0}\u0027 dans le conteneur de fichiers...",
-    "RMCommandNotFound":  "##vso[release.{0}] n\u0027est pas une commande reconnue pour l\u0027extension de commande de mise en production. Consultez la documentation de référence (http://go.microsoft.com/fwlink/?LinkId=817296).",
     "RMContainerItemNotSupported":  "Le type d\u0027élément de conteneur \u0027{0}\u0027 n\u0027est pas pris en charge.",
     "RMContainerItemPathDoesnotExist":  "Le chemin des éléments du conteneur de fichiers ne commence pas par {0} : {1}",
     "RMContainerItemRequestTimedOut":  "La requête a expiré après {0} secondes. Une nouvelle tentative aura lieu après un passage en veille de {1} secondes. Requête : {2} {3}",

--- a/src/Misc/layoutbin/it-IT/strings.json
+++ b/src/Misc/layoutbin/it-IT/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "Memorizzazione nella cache di tutti gli elementi presenti nel contenitore di file...",
     "RMCachingComplete":  "Memorizzazione nella cache completata. ({0} ms)",
     "RMCachingContainerItems":  "Memorizzazione nella cache degli elementi in \u0027{0}\u0027 presenti nel contenitore di file...",
-    "RMCommandNotFound":  "##vso[release.{0}] non è un comando riconosciuto per l\u0027estensione del comando release. Vedere la documentazione (http://go.microsoft.com/fwlink/?LinkId=817296).",
     "RMContainerItemNotSupported":  "Il tipo \u0027{0}\u0027 dell\u0027elemento contenitore non è supportato.",
     "RMContainerItemPathDoesnotExist":  "Il percorso dell\u0027elemento contenitore di file non inizia con {0}: {1}",
     "RMContainerItemRequestTimedOut":  "Si è verificato il timeout della richiesta dopo {0} secondi. Verrà effettuato un nuovo tentativo dopo una sospensione di {1} secondi. Richiesta: {2} {3}",

--- a/src/Misc/layoutbin/ja-JP/strings.json
+++ b/src/Misc/layoutbin/ja-JP/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "ファイル コンテナー内のすべてのアイテムをキャッシュしています...",
     "RMCachingComplete":  "キャッシュが完了しました。({0} ミリ秒)",
     "RMCachingContainerItems":  "ファイル コンテナー内の \u0027{0}\u0027 に属するアイテムをキャッシュしています...",
-    "RMCommandNotFound":  "##vso[release.{0}] は、Release コマンド拡張の認識されたコマンドではありません。ドキュメント (http://go.microsoft.com/fwlink/?LinkId=817296) を参照してください",
     "RMContainerItemNotSupported":  "コンテナー アイテムの種類 \u0027{0}\u0027 はサポートされていません。",
     "RMContainerItemPathDoesnotExist":  "ファイル コンテナー アイテムのパスの先頭が {0} ではありません: {1}",
     "RMContainerItemRequestTimedOut":  "要求は {0} 秒後にタイムアウトになりました。{1} 秒間休止してから再試行しています。要求: {2} {3}",

--- a/src/Misc/layoutbin/ko-KR/strings.json
+++ b/src/Misc/layoutbin/ko-KR/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "파일 컨테이너에 있는 모든 항목을 캐시하는 중...",
     "RMCachingComplete":  "캐싱이 완료되었습니다. ({0}ms)",
     "RMCachingContainerItems":  "파일 컨테이너의 \u0027{0}\u0027 아래에 있는 항목을 캐시하는 중...",
-    "RMCommandNotFound":  "##vso[release.{0}]는 릴리스 명령 확장에 대해 인식되는 명령이 아닙니다. 설명서(http://go.microsoft.com/fwlink/?LinkId=817296)를 참조하세요.",
     "RMContainerItemNotSupported":  "컨테이너 항목 종류 \u0027{0}\u0027은(는) 지원되지 않습니다.",
     "RMContainerItemPathDoesnotExist":  "파일 컨테이너 항목 경로가 {0}: {1}(으)로 시작하지 않습니다.",
     "RMContainerItemRequestTimedOut":  "{0}초 후에 요청 시간이 초과되었습니다. {1}초 동안 중지한 후 다시 시도합니다. 요청: {2} {3}",

--- a/src/Misc/layoutbin/ru-RU/strings.json
+++ b/src/Misc/layoutbin/ru-RU/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "Кэширование всех элементов в контейнере файлов...",
     "RMCachingComplete":  "Кэширование завершено ({0} мс).",
     "RMCachingContainerItems":  "Кэширование элементов в \"{0}\" в контейнере файлов...",
-    "RMCommandNotFound":  "##vso[release.{0}] не распознается в качестве команды для расширения команды Release. Ознакомьтесь с документацией (http://go.microsoft.com/fwlink/?LinkId=817296).",
     "RMContainerItemNotSupported":  "Тип элемента контейнера \"{0}\" не поддерживается.",
     "RMContainerItemPathDoesnotExist":  "Путь к элементу контейнера файлов не начинается с \"{0}\": {1}",
     "RMContainerItemRequestTimedOut":  "Время ожидания запроса истекло через {0} с. Ожидание перед повторной попыткой: {1} с. Запрос: {2} {3}",

--- a/src/Misc/layoutbin/zh-CN/strings.json
+++ b/src/Misc/layoutbin/zh-CN/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "正在缓存文件容器中的所有项目...",
     "RMCachingComplete":  "缓存完成。({0} 毫秒)",
     "RMCachingContainerItems":  "正在缓存文件容器中“{0}”下的项目...",
-    "RMCommandNotFound":  "##vso[release.{0}] 不是已识别的发布命令扩展的命令。请参阅参考文档(http://go.microsoft.com/fwlink/?LinkId=817296)。",
     "RMContainerItemNotSupported":  "不支持容器项目类型“{0}”。",
     "RMContainerItemPathDoesnotExist":  "文件容器项路径不以 {0} 开头: {1}",
     "RMContainerItemRequestTimedOut":  "{0} 秒后请求超时；睡眠 {1} 秒，然后再次尝试。请求: {2} {3}",

--- a/src/Misc/layoutbin/zh-TW/strings.json
+++ b/src/Misc/layoutbin/zh-TW/strings.json
@@ -424,7 +424,6 @@
     "RMCachingAllItems":  "正在快取檔案容器中的所有項目...",
     "RMCachingComplete":  "快取完成。({0} 毫秒)",
     "RMCachingContainerItems":  "正在快取檔案容器中 \u0027{0}\u0027 下的項目...",
-    "RMCommandNotFound":  "##vso[release.{0}] 對 Release 命令延伸模組而言是無法辨識的命令。請參閱文件 (http://go.microsoft.com/fwlink/?LinkId=817296)。",
     "RMContainerItemNotSupported":  "不支援容器項目類型 \u0027{0}\u0027。",
     "RMContainerItemPathDoesnotExist":  "檔案容器項目路徑的開頭不是 {0}: {1}",
     "RMContainerItemRequestTimedOut":  "要求在 {0} 秒後逾時; 將會睡眠 {1} 秒後再次嘗試。要求: {2} {3}",

--- a/src/Test/L0/ServiceInterfacesL0.cs
+++ b/src/Test/L0/ServiceInterfacesL0.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             var whitelist = new[]
             {
                 typeof(ICredentialProvider),
-                typeof(IConfigurationProvider),
+                typeof(IConfigurationProvider)
             };
             Validate(
                 assembly: typeof(IMessageListener).GetTypeInfo().Assembly,
@@ -90,7 +90,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 typeof(IDiagnosticLogManager),
                 typeof(IParser),
                 typeof(IResultReader),
-                typeof(INUnitResultsXmlReader)
+                typeof(INUnitResultsXmlReader),
+                typeof(IWorkerCommand)
             };
             Validate(
                 assembly: typeof(IStepsRunner).GetTypeInfo().Assembly,

--- a/src/Test/L0/Worker/WorkerCommandManagerL0.cs
+++ b/src/Test/L0/Worker/WorkerCommandManagerL0.cs
@@ -1,0 +1,77 @@
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.VisualStudio.Services.Agent.Worker;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.TeamFoundation.DistributedTask.Expressions;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
+{
+    public sealed class WorkerCommandManagerL0
+    {
+     
+        public sealed class TestWorkerCommandExtensionL0 : BaseWorkerCommandExtension
+        {
+            public TestWorkerCommandExtensionL0()
+            {
+                CommandArea = "TestL0";
+                SupportedHostTypes = HostTypes.All;
+                InstallWorkerCommand(new FooCommand());
+                InstallWorkerCommand(new Foo2Command());
+                InstallWorkerCommand(new BarCommand());
+            }
+        }
+
+        public class FooCommand: IWorkerCommand
+        {
+            public string Name => "foo";
+            public List<string> Aliases => null;
+
+            public void Execute(IExecutionContext context, Command command)
+            {
+            }
+        }
+
+        public class Foo2Command: IWorkerCommand
+        {
+            public string Name => "foo";
+            public List<string> Aliases => null;
+
+            public void Execute(IExecutionContext context, Command command)
+            {
+            }
+        }
+
+        public class BarCommand: IWorkerCommand
+        {
+            public string Name => "bar";
+            public List<string> Aliases => new List<string>() { "cat" };
+
+            public void Execute(IExecutionContext context, Command command)
+            {
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SimpleTests()
+        {
+            var commandExt = new TestWorkerCommandExtensionL0();  
+            IWorkerCommand command = commandExt.GetWorkerCommand("foo");
+            Assert.Equal("foo", command.Name);
+            Assert.IsType<FooCommand>(command);
+
+            IWorkerCommand command2 = commandExt.GetWorkerCommand("bar");
+            Assert.Equal("bar", command2.Name);
+            IWorkerCommand command3 = commandExt.GetWorkerCommand("cat");
+            Assert.Equal("bar", command3.Name);
+            Assert.Equal(command2, command3);
+        }
+    }
+}


### PR DESCRIPTION
Here is a first pass at how task commands are defined. The goal is to make each command it's own class so it can store meta data about the command and to remove all the string comparisons in order to simplify the dispatch logic.