### PR TITLE
Cleans up #ifs in Agent.Plugins

### DIFF
--- a/src/Agent.Plugins/ITfsVCCliManager.cs
+++ b/src/Agent.Plugins/ITfsVCCliManager.cs
@@ -1,0 +1,39 @@
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using System.Threading;
+using System.Threading.Tasks;
+using Agent.Sdk;
+using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+
+namespace Agent.Plugins.Repository
+{
+    public interface ITfsVCCliManager
+    {
+        CancellationToken CancellationToken { set; }
+        Pipelines.RepositoryResource Repository { set; }
+        AgentTaskPluginExecutionContext ExecutionContext { set; }
+        ServiceEndpoint Endpoint { set; }
+        TfsVCFeatures Features { get; }
+        string FilePath { get; }
+        void SetupProxy(string proxyUrl, string proxyUsername, string proxyPassword);
+        void SetupClientCertificate(string clientCert, string clientCertKey, string clientCertArchive, string clientCertPassword);
+        bool TestEulaAccepted();
+        Task EulaAsync();
+        Task<ITfsVCWorkspace[]> WorkspacesAsync(bool matchWorkspaceNameOnAnyComputer = false);
+        Task<ITfsVCStatus> StatusAsync(string localPath);
+        Task UndoAsync(string localPath);
+        Task ScorchAsync();
+        Task<bool> TryWorkspaceDeleteAsync(ITfsVCWorkspace workspace);
+        Task WorkspaceDeleteAsync(ITfsVCWorkspace workspace);
+        Task WorkspacesRemoveAsync(ITfsVCWorkspace workspace);
+        Task WorkspaceNewAsync();
+        Task WorkfoldUnmapAsync(string serverPath);
+        Task WorkfoldMapAsync(string serverPath, string localPath);
+        Task WorkfoldCloakAsync(string serverPath);
+        Task GetAsync(string localPath);
+        Task AddAsync(string localPath);
+        Task ShelveAsync(string shelveset, string commentFile, bool move);
+        Task<ITfsVCShelveset> ShelvesetsAsync(string shelveset);
+        Task UnshelveAsync(string shelveset);
+        void CleanupProxySetting();
+    }
+}

--- a/src/Agent.Plugins/TFCliManager.cs
+++ b/src/Agent.Plugins/TFCliManager.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 
 namespace Agent.Plugins.Repository
 {
-    public sealed class TFCliManager : TfsVCCliManager
+    public sealed class TFCliManager : TfsVCCliManager, ITfsVCCliManager
     {
         public override TfsVCFeatures Features
         {

--- a/src/Agent.Plugins/TeeCliManager.cs
+++ b/src/Agent.Plugins/TeeCliManager.cs
@@ -1,3 +1,4 @@
+using Agent.Sdk;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,7 +11,7 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 
 namespace Agent.Plugins.Repository
 {
-    public sealed class TeeCliManager : TfsVCCliManager
+    public sealed class TeeCliManager : TfsVCCliManager, ITfsVCCliManager
     {
         public override TfsVCFeatures Features => TfsVCFeatures.Eula;
 
@@ -173,27 +174,19 @@ namespace Agent.Plugins.Repository
             string homeDirectory = Environment.GetEnvironmentVariable("HOME");
             if (!string.IsNullOrEmpty(homeDirectory) && Directory.Exists(homeDirectory))
             {
-#if OS_OSX
+                string tfDataDirectory = (PlatformUtil.RunningOnMacOS)
+                    ? Path.Combine("Library", "Application Support", "Microsoft")
+                    : ".microsoft";
+
                 string xmlFile = Path.Combine(
                     homeDirectory,
-                    "Library",
-                    "Application Support",
-                    "Microsoft",
+                    tfDataDirectory,
                     "Team Foundation",
                     "4.0",
                     "Configuration",
                     "TEE-Mementos",
                     "com.microsoft.tfs.client.productid.xml");
-#else
-                string xmlFile = Path.Combine(
-                    homeDirectory,
-                    ".microsoft",
-                    "Team Foundation",
-                    "4.0",
-                    "Configuration",
-                    "TEE-Mementos",
-                    "com.microsoft.tfs.client.productid.xml");
-#endif
+
                 if (File.Exists(xmlFile))
                 {
                     // Load and deserialize the XML.

--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -257,6 +257,29 @@ namespace Agent.Plugins.Repository
             OmitNoPrompt = 4,
             All = OmitCollectionUrl | OmitLogin | OmitNoPrompt,
         }
+
+        /*
+        public abstract string FilePath { get; }
+        public abstract void SetupProxy(string proxyUrl, string proxyUsername, string proxyPassword);
+        public abstract void SetupClientCertificate(string clientCert, string clientCertKey, string clientCertArchive, string clientCertPassword);
+        public abstract bool TestEulaAccepted();
+        public abstract Task EulaAsync();
+        public abstract Task<ITfsVCWorkspace[]> WorkspacesAsync(bool matchWorkspaceNameOnAnyComputer = false);
+        public abstract Task<ITfsVCStatus> StatusAsync(string localPath);
+        public abstract Task UndoAsync(string localPath);
+        public abstract Task ScorchAsync();
+        public abstract Task WorkspaceDeleteAsync(ITfsVCWorkspace workspace);
+        public abstract Task WorkspaceNewAsync();
+        public abstract Task WorkfoldUnmapAsync(string serverPath);
+        public abstract Task WorkfoldMapAsync(string serverPath, string localPath);
+        public abstract Task WorkfoldCloakAsync(string serverPath);
+        public abstract Task GetAsync(string localPath);
+        public abstract Task AddAsync(string localPath);
+        public abstract Task ShelveAsync(string shelveset, string commentFile, bool move);
+        public abstract Task<ITfsVCShelveset> ShelvesetsAsync(string shelveset);
+        public abstract Task UnshelveAsync(string shelveset);
+        public abstract void CleanupProxySetting();
+        */
     }
 
     [Flags]

--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -257,29 +257,6 @@ namespace Agent.Plugins.Repository
             OmitNoPrompt = 4,
             All = OmitCollectionUrl | OmitLogin | OmitNoPrompt,
         }
-
-        /*
-        public abstract string FilePath { get; }
-        public abstract void SetupProxy(string proxyUrl, string proxyUsername, string proxyPassword);
-        public abstract void SetupClientCertificate(string clientCert, string clientCertKey, string clientCertArchive, string clientCertPassword);
-        public abstract bool TestEulaAccepted();
-        public abstract Task EulaAsync();
-        public abstract Task<ITfsVCWorkspace[]> WorkspacesAsync(bool matchWorkspaceNameOnAnyComputer = false);
-        public abstract Task<ITfsVCStatus> StatusAsync(string localPath);
-        public abstract Task UndoAsync(string localPath);
-        public abstract Task ScorchAsync();
-        public abstract Task WorkspaceDeleteAsync(ITfsVCWorkspace workspace);
-        public abstract Task WorkspaceNewAsync();
-        public abstract Task WorkfoldUnmapAsync(string serverPath);
-        public abstract Task WorkfoldMapAsync(string serverPath, string localPath);
-        public abstract Task WorkfoldCloakAsync(string serverPath);
-        public abstract Task GetAsync(string localPath);
-        public abstract Task AddAsync(string localPath);
-        public abstract Task ShelveAsync(string shelveset, string commentFile, bool move);
-        public abstract Task<ITfsVCShelveset> ShelvesetsAsync(string shelveset);
-        public abstract Task UnshelveAsync(string shelveset);
-        public abstract void CleanupProxySetting();
-        */
     }
 
     [Flags]

--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -23,20 +23,23 @@ namespace Agent.Plugins.Repository
             ArgUtil.NotNull(executionContext, nameof(executionContext));
             ArgUtil.NotNull(repository, nameof(repository));
 
-#if OS_WINDOWS
             // Validate .NET Framework 4.6 or higher is installed.
-            if (!NetFrameworkUtil.Test(new Version(4, 6), executionContext))
+            if (PlatformUtil.RunningOnWindows && !NetFrameworkUtil.Test(new Version(4, 6), executionContext))
             {
                 throw new Exception(StringUtil.Loc("MinimumNetFramework46"));
             }
-#endif
 
             // Create the tf command manager.
-#if OS_WINDOWS
-            var tf = new TFCliManager();
-#else
-            var tf = new TeeCliManager();
-#endif            
+            ITfsVCCliManager tf;
+            if (PlatformUtil.RunningOnWindows)
+            {
+                tf = new TFCliManager();
+            }
+            else
+            {
+                tf = new TeeCliManager();
+            }
+
             tf.CancellationToken = cancellationToken;
             tf.Repository = repository;
             tf.ExecutionContext = executionContext;
@@ -63,11 +66,7 @@ namespace Agent.Plugins.Repository
             var agentCertManager = executionContext.GetCertConfiguration();
             if (agentCertManager != null && agentCertManager.SkipServerCertificateValidation)
             {
-#if OS_WINDOWS
-                executionContext.Debug("TF.exe does not support ignore SSL certificate validation error.");
-#else
-                executionContext.Debug("TF does not support ignore SSL certificate validation error.");
-#endif
+                executionContext.Debug("TF does not support ignoring SSL certificate validation error.");
             }
 
             // prepare client cert, if the repository's endpoint url match the TFS/VSTS url
@@ -86,14 +85,15 @@ namespace Agent.Plugins.Repository
             executionContext.PrependPath(Path.GetDirectoryName(tfPath));
             executionContext.Debug($"PATH: '{Environment.GetEnvironmentVariable("PATH")}'");
 
-#if OS_WINDOWS
-            // Set TFVC_BUILDAGENT_POLICYPATH
-            string policyDllPath = Path.Combine(executionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf", "Microsoft.TeamFoundation.VersionControl.Controls.dll");
-            ArgUtil.File(policyDllPath, nameof(policyDllPath));
-            const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";
-            executionContext.Output(StringUtil.Loc("SetEnvVar", policyPathEnvKey));
-            executionContext.SetVariable(policyPathEnvKey, policyDllPath);
-#endif
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // Set TFVC_BUILDAGENT_POLICYPATH
+                string policyDllPath = Path.Combine(executionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf", "Microsoft.TeamFoundation.VersionControl.Controls.dll");
+                ArgUtil.File(policyDllPath, nameof(policyDllPath));
+                const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";
+                executionContext.Output(StringUtil.Loc("SetEnvVar", policyPathEnvKey));
+                executionContext.SetVariable(policyPathEnvKey, policyDllPath);
+            }
 
             // Check if the administrator accepted the license terms of the TEE EULA when configuring the agent.
             if (tf.Features.HasFlag(TfsVCFeatures.Eula) && StringUtil.ConvertToBoolean(executionContext.Variables.GetValueOrDefault("Agent.AcceptTeeEula")?.Value))
@@ -432,11 +432,16 @@ namespace Agent.Plugins.Repository
                 executionContext.Debug($"Undo pending changes left by shelveset '{shelvesetName}'.");
 
                 // Create the tf command manager.
-#if OS_WINDOWS
-                var tf = new TFCliManager();
-#else
-                var tf = new TeeCliManager();
-#endif
+                ITfsVCCliManager tf;
+                if (PlatformUtil.RunningOnWindows)
+                {
+                    tf = new TFCliManager();
+                }
+                else
+                {
+                    tf = new TeeCliManager();
+                }
+                
                 tf.CancellationToken = CancellationToken.None;
                 tf.Repository = repository;
                 tf.ExecutionContext = executionContext;
@@ -518,7 +523,7 @@ namespace Agent.Plugins.Repository
             }
         }
 
-        private async Task RemoveConflictingWorkspacesAsync(TfsVCCliManager tf, ITfsVCWorkspace[] tfWorkspaces, string name, string directory)
+        private async Task RemoveConflictingWorkspacesAsync(ITfsVCCliManager tf, ITfsVCWorkspace[] tfWorkspaces, string name, string directory)
         {
             // Validate the args.
             ArgUtil.NotNullOrEmpty(name, nameof(name));


### PR DESCRIPTION
Clears up all the OS-based #ifs in Agent.Plugins.

Does not attempt to reconcile why there's a shadow copy of all the source providers present.