### PR TITLE
fix retrieval of ImageVersion environment variable

### DIFF
--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -67,10 +67,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                     // Set agent version variable.
                     context.Variables.Set(Constants.Variables.Agent.Version, BuildConstants.AgentPackage.Version);
+
+                    // Log agent properties
                     context.Output(StringUtil.Loc("AgentNameLog", context.Variables.Get(Constants.Variables.Agent.Name)));
                     context.Output(StringUtil.Loc("AgentMachineNameLog", context.Variables.Get(Constants.Variables.Agent.MachineName)));
                     context.Output(StringUtil.Loc("AgentVersion", BuildConstants.AgentPackage.Version));
-                    if (context.Variables.TryGetValue(Constants.ImageVersionVariable, out string imageVersion))
+                    string imageVersion = System.Environment.GetEnvironmentVariable(Constants.ImageVersionVariable);
+                    if (imageVersion != null)
                     {
                         context.Output(StringUtil.Loc("ImageVersionLog", imageVersion));
                     }


### PR DESCRIPTION
In the first version of this change, I was using context.Variables to retrieve the image version variable, but that only works for variables set in the agent context. This switches to instead use System.Environment.GetEnvironmentVariable so that the value for the environment variable is retrieved successfully.