### PR TITLE
Add an option to reduce checkout verbosity

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -170,21 +170,25 @@ namespace Agent.Plugins.Repository
                 forceTag = "--force";
             }
 
+            bool reducedOutput = StringUtil.ConvertToBoolean(
+                context.Variables.GetValueOrDefault("agent.source.checkout.quiet")?.Value);
+            string progress = reducedOutput ? string.Empty : "--progress";
+
             // default options for git fetch.
-            string options = StringUtil.Format($"{forceTag} --tags --prune --progress --no-recurse-submodules {remoteName} {string.Join(" ", refSpec)}");
+            string options = StringUtil.Format($"{forceTag} --tags --prune {progress} --no-recurse-submodules {remoteName} {string.Join(" ", refSpec)}");
 
             // If shallow fetch add --depth arg
             // If the local repository is shallowed but there is no fetch depth provide for this build,
             // add --unshallow to convert the shallow repository to a complete repository
             if (fetchDepth > 0)
             {
-                options = StringUtil.Format($"{forceTag} --tags --prune --progress --no-recurse-submodules --depth={fetchDepth} {remoteName} {string.Join(" ", refSpec)}");
+                options = StringUtil.Format($"{forceTag} --tags --prune {progress} --no-recurse-submodules --depth={fetchDepth} {remoteName} {string.Join(" ", refSpec)}");
             }
             else
             {
                 if (File.Exists(Path.Combine(repositoryPath, ".git", "shallow")))
                 {
-                    options = StringUtil.Format($"{forceTag} --tags --prune --progress --no-recurse-submodules --unshallow {remoteName} {string.Join(" ", refSpec)}");
+                    options = StringUtil.Format($"{forceTag} --tags --prune {progress} --no-recurse-submodules --unshallow {remoteName} {string.Join(" ", refSpec)}");
                 }
             }
 

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -231,6 +231,16 @@ namespace Agent.Plugins.Repository
             string clientCertPrivateKeyAskPassFile = null;
             bool acceptUntrustedCerts = false;
 
+            bool reducedOutput = StringUtil.ConvertToBoolean(
+                executionContext.Variables.GetValueOrDefault("agent.source.checkout.quiet")?.Value ??
+                System.Environment.GetEnvironmentVariable("AGENT_SOURCE_CHECKOUT_QUIET"), false);
+            if (reducedOutput)
+            {
+                // TODO: LOCSTRING
+                executionContext.Output("Quiet checkout mode: less will be printed to the console.");
+                executionContext.SetTaskVariable("agent.source.checkout.quiet", "false");
+            }
+
             executionContext.Output($"Syncing repository: {repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Name)} ({repository.Type})");
             Uri repositoryUrl = repository.Url;
             if (!repositoryUrl.IsAbsoluteUri)

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -236,8 +236,7 @@ namespace Agent.Plugins.Repository
                 System.Environment.GetEnvironmentVariable("AGENT_SOURCE_CHECKOUT_QUIET"), false);
             if (reducedOutput)
             {
-                // TODO: LOCSTRING
-                executionContext.Output("Quiet checkout mode: less will be printed to the console.");
+                executionContext.Output(StringUtil.Loc("QuietCheckoutModeRequested"));
                 executionContext.SetTaskVariable("agent.source.checkout.quiet", "false");
             }
 
@@ -357,7 +356,6 @@ namespace Agent.Plugins.Repository
             if (selfManageGitCreds)
             {
                 // Customer choose to own git creds by themselves.
-                executionContext.Output(StringUtil.Loc("SelfManageGitCreds"));
             }
 
             // Initialize git command manager with additional environment variables.

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -356,6 +356,7 @@ namespace Agent.Plugins.Repository
             if (selfManageGitCreds)
             {
                 // Customer choose to own git creds by themselves.
+                executionContext.Output(StringUtil.Loc("SelfManageGitCreds"));
             }
 
             // Initialize git command manager with additional environment variables.

--- a/src/Agent.Plugins/ITfsVCCliManager.cs
+++ b/src/Agent.Plugins/ITfsVCCliManager.cs
@@ -32,7 +32,7 @@ namespace Agent.Plugins.Repository
         Task WorkfoldUnmapAsync(string serverPath);
         Task WorkfoldMapAsync(string serverPath, string localPath);
         Task WorkfoldCloakAsync(string serverPath);
-        Task GetAsync(string localPath);
+        Task GetAsync(string localPath, bool quiet = false);
         Task AddAsync(string localPath);
         Task ShelveAsync(string shelveset, string commentFile, bool move);
         Task<ITfsVCShelveset> ShelvesetsAsync(string shelveset);

--- a/src/Agent.Plugins/TFCliManager.cs
+++ b/src/Agent.Plugins/TFCliManager.cs
@@ -61,10 +61,10 @@ namespace Agent.Plugins.Repository
             throw new NotSupportedException();
         }
 
-        public async Task GetAsync(string localPath)
+        public async Task GetAsync(string localPath, bool quiet = false)
         {
             ArgUtil.NotNullOrEmpty(localPath, nameof(localPath));
-            await RunCommandAsync(FormatFlags.OmitCollectionUrl, "vc", "get", $"/version:{SourceVersion}", "/recursive", "/overwrite", localPath);
+            await RunCommandAsync(FormatFlags.OmitCollectionUrl, quiet, "vc", "get", $"/version:{SourceVersion}", "/recursive", "/overwrite", localPath);
         }
 
         public string ResolvePath(string serverPath)

--- a/src/Agent.Plugins/TeeCliManager.cs
+++ b/src/Agent.Plugins/TeeCliManager.cs
@@ -39,10 +39,10 @@ namespace Agent.Plugins.Repository
             await RunCommandAsync(FormatFlags.All, "eula", "-accept");
         }
 
-        public async Task GetAsync(string localPath)
+        public async Task GetAsync(string localPath, bool quiet = false)
         {
             ArgUtil.NotNullOrEmpty(localPath, nameof(localPath));
-            await RunCommandAsync(FormatFlags.OmitCollectionUrl, "get", $"-version:{SourceVersion}", "-recursive", "-overwrite", localPath);
+            await RunCommandAsync(FormatFlags.OmitCollectionUrl, quiet, "get", $"-version:{SourceVersion}", "-recursive", "-overwrite", localPath);
         }
 
         public string ResolvePath(string serverPath)

--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -69,7 +69,12 @@ namespace Agent.Plugins.Repository
             return RunCommandAsync(FormatFlags.None, args);
         }
 
-        protected async Task RunCommandAsync(FormatFlags formatFlags, params string[] args)
+        protected Task RunCommandAsync(FormatFlags formatFlags, params string[] args)
+        {
+            return RunCommandAsync(formatFlags, false, args);
+        }
+
+        protected async Task RunCommandAsync(FormatFlags formatFlags, bool quiet, params string[] args)
         {
             // Validation.
             ArgUtil.NotNull(args, nameof(args));
@@ -82,7 +87,14 @@ namespace Agent.Plugins.Repository
             {
                 lock (outputLock)
                 {
-                    ExecutionContext.Output(e.Data);
+                    if (quiet)
+                    {
+                        ExecutionContext.Debug(e.Data);
+                    }
+                    else
+                    {
+                        ExecutionContext.Output(e.Data);
+                    }
                 }
             };
             processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>

--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -38,8 +38,7 @@ namespace Agent.Plugins.Repository
                 System.Environment.GetEnvironmentVariable("AGENT_SOURCE_CHECKOUT_QUIET"), false);
             if (reducedOutput)
             {
-                // TODO: LOCSTRING
-                executionContext.Output("Quiet checkout mode: less will be printed to the console.");
+                executionContext.Output(StringUtil.Loc("QuietCheckoutModeRequested"));
                 executionContext.SetTaskVariable("agent.source.checkout.quiet", "false");
             }
 

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -433,6 +433,7 @@
   "QueryingWorkspaceInfo": "Querying workspace information.",
   "QueueConError": "{0:u}: Agent connect error: {1}. Retrying until reconnected.",
   "QueueConnected": "{0:u}: Agent reconnected.",
+  "QuietCheckoutModeRequested": "Quiet checkout mode: less will be printed to the console.",
   "ReadingCodeCoverageSummary": "Reading code coverage summary from '{0}'",
   "RegisterAgentSectionHeader": "Register Agent",
   "ReleaseDirLastUseTIme": "The last time release directory '{0}' been used is: {1}",


### PR DESCRIPTION
Fixes #2542 by offering a job variable "agent.source.checkout.quiet" (can also be set as an environment variable, "AGENT_SOURCE_CHECKOUT_QUIET"). For Git, this will remove the `--progress` flag from `fetch` and `checkout`. For TFVC, it will remap `get` output to the debug stream instead of the standard console stream.