### PR TITLE
Fixed to not error out on null source volume path

### DIFF
--- a/src/Agent.Sdk/LogPlugin.cs
+++ b/src/Agent.Sdk/LogPlugin.cs
@@ -404,6 +404,12 @@ namespace Agent.Sdk
                 foreach (var queue in _outputQueue)
                 {
                     string pluginName = queue.Key;
+
+                    if (token.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
                     if (queue.Value.Count > _shortCircuitThreshold)
                     {
                         _trace.Trace($"Plugin '{pluginName}' has too many buffered outputs.");

--- a/src/Agent.Sdk/LogPlugin.cs
+++ b/src/Agent.Sdk/LogPlugin.cs
@@ -404,11 +404,6 @@ namespace Agent.Sdk
                 foreach (var queue in _outputQueue)
                 {
                     string pluginName = queue.Key;
-                    if (token.IsCancellationRequested)
-                    {
-                        break;
-                    }
-
                     if (queue.Value.Count > _shortCircuitThreshold)
                     {
                         _trace.Trace($"Plugin '{pluginName}' has too many buffered outputs.");
@@ -428,7 +423,7 @@ namespace Agent.Sdk
 
                 await Task.WhenAny(Task.Delay(_shortCircuitMonitorFrequency), Task.Delay(-1, token));
             }
-            
+
             _trace.Trace($"Output buffer monitor stopped.");
         }
 

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TeamFoundation.Framework.Common;
 using Microsoft.VisualStudio.Services.Agent.Util;
-using Agent.Sdk;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 {
@@ -196,7 +195,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             {
                 return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} --driver nat", context.CancellationToken);
             }
-            
+
             return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network}", context.CancellationToken);
         }
 

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -13,7 +13,6 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker.Container;
 using Microsoft.VisualStudio.Services.WebApi;
 using Newtonsoft.Json;
-using Agent.Sdk;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 {

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -106,7 +106,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             StringComparison sc = (PlatformUtil.RunningOnWindows)
                                 ? StringComparison.OrdinalIgnoreCase
                                 : StringComparison.Ordinal;
-            if (Container.MountVolumes.Exists(x => path.StartsWith(x.SourceVolumePath, sc)))
+            if (Container.MountVolumes.Exists(x => {
+                if (!string.IsNullOrEmpty(x.SourceVolumePath))
+                {
+                    return path.StartsWith(x.SourceVolumePath, sc);
+                }
+                if (!string.IsNullOrEmpty(x.TargetVolumePath))
+                {
+                    return path.StartsWith(x.TargetVolumePath, sc);
+                }
+                return false; // this should not happen, but just in case bad data got into MountVolumes, we do not want to throw an exception here
+            }))
             {
                 return Container.TranslateToContainerPath(path);
             }

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -16,7 +16,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Newtonsoft.Json.Linq;
-using Agent.Sdk;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -447,8 +446,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         // the scheme://hostname:port (how the agent knows the server) is external to our server
         // in other words, an agent may have it's own way (DNS, hostname) of refering
         // to the server.  it owns that.  That's the scheme://hostname:port we will use.
-        // Example: Server's notification url is http://tfsserver:8080/tfs 
-        //          Agent config url is https://tfsserver.mycompany.com:9090/tfs 
+        // Example: Server's notification url is http://tfsserver:8080/tfs
+        //          Agent config url is https://tfsserver.mycompany.com:9090/tfs
         private Uri ReplaceWithConfigUriBase(Uri messageUri)
         {
             AgentSettings settings = HostContext.GetService<IConfigurationStore>().GetSettings();

--- a/src/Misc/dotnet-install.ps1
+++ b/src/Misc/dotnet-install.ps1
@@ -37,10 +37,7 @@
 .PARAMETER SharedRuntime
     This parameter is obsolete and may be removed in a future version of this script.
     The recommended alternative is '-Runtime dotnet'.
-
-    Default: false
     Installs just the shared runtime bits, not the entire SDK.
-    This is equivalent to specifying `-Runtime dotnet`.
 .PARAMETER Runtime
     Installs just a shared runtime, not the entire SDK.
     Possible values:
@@ -77,11 +74,15 @@
     Skips installing non-versioned files if they already exist, such as dotnet.exe.
 .PARAMETER NoCdn
     Disable downloading from the Azure CDN, and use the uncached feed directly.
+.PARAMETER JSonFile
+    Determines the SDK version from a user specified global.json file
+    Note: global.json must have a value for 'SDK:Version'
 #>
 [cmdletbinding()]
 param(
    [string]$Channel="LTS",
    [string]$Version="Latest",
+   [string]$JSonFile,
    [string]$InstallDir="<auto>",
    [string]$Architecture="<auto>",
    [ValidateSet("dotnet", "aspnetcore", "windowsdesktop", IgnoreCase = $false)]
@@ -258,7 +259,6 @@ function GetHTTPResponse([Uri] $Uri)
     })
 }
 
-
 function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Coherent) {
     Say-Invocation $MyInvocation
 
@@ -304,20 +304,64 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Co
     return $VersionInfo
 }
 
-
-function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel, [string]$Version) {
+function Parse-Jsonfile-For-Version([string]$JSonFile) {
     Say-Invocation $MyInvocation
 
-    switch ($Version.ToLower()) {
-        { $_ -eq "latest" } {
-            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel -Coherent $False
-            return $LatestVersionInfo.Version
+    If (-Not (Test-Path $JSonFile)) {
+        throw "Unable to find '$JSonFile'"
+        exit 0
+    }
+    try {
+        $JSonContent = Get-Content($JSonFile) -Raw | ConvertFrom-Json | Select-Object -expand "sdk" -ErrorAction SilentlyContinue
+    }
+    catch {
+        throw "Json file unreadable: '$JSonFile'"
+        exit 0
+    }
+    if ($JSonContent) {
+        try {
+            $JSonContent.PSObject.Properties | ForEach-Object {
+                $PropertyName = $_.Name
+                if ($PropertyName -eq "version") {
+                    $Version = $_.Value
+                    Say-Verbose "Version = $Version"
+                }
+            }
         }
-        { $_ -eq "coherent" } {
-            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel -Coherent $True
-            return $LatestVersionInfo.Version
+        catch {
+            throw "Unable to parse the SDK node in '$JSonFile'"
+            exit 0
         }
-        default { return $Version }
+    }
+    else {
+        throw "Unable to find the SDK node in '$JSonFile'"
+        exit 0
+    }
+    If ($Version -eq $null) {
+        throw "Unable to find the SDK:version node in '$JSonFile'"
+        exit 0
+    }
+    return $Version
+}
+
+function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel, [string]$Version, [string]$JSonFile) {
+    Say-Invocation $MyInvocation
+
+    if (-not $JSonFile) {
+        switch ($Version.ToLower()) {
+            { $_ -eq "latest" } {
+                $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel -Coherent $False
+                return $LatestVersionInfo.Version
+            }
+            { $_ -eq "coherent" } {
+                $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel -Coherent $True
+                return $LatestVersionInfo.Version
+            }
+            default { return $Version }
+        }
+    }
+    else {
+        return Parse-Jsonfile-For-Version $JSonFile
     }
 }
 
@@ -380,23 +424,6 @@ function Resolve-Installation-Path([string]$InstallDir) {
         return Get-User-Share-Path
     }
     return $InstallDir
-}
-
-function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$RelativePathToVersionFile) {
-    Say-Invocation $MyInvocation
-
-    $VersionFile = Join-Path -Path $InstallRoot -ChildPath $RelativePathToVersionFile
-    Say-Verbose "Local version file: $VersionFile"
-
-    if (Test-Path $VersionFile) {
-        $VersionText = cat $VersionFile
-        Say-Verbose "Local version file text: $VersionText"
-        return Get-Version-Info-From-Version-Text $VersionText
-    }
-
-    Say-Verbose "Local version file not found."
-
-    return $null
 }
 
 function Is-Dotnet-Package-Installed([string]$InstallRoot, [string]$RelativePathToPackage, [string]$SpecificVersion) {
@@ -534,7 +561,7 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
 }
 
 $CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
-$SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -Channel $Channel -Version $Version
+$SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -Channel $Channel -Version $Version -JSonFile $JSonFile
 $DownloadLink = Get-Download-Link -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
 $LegacyDownloadLink = Get-LegacyDownload-Link -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
 

--- a/src/Misc/dotnet-install.sh
+++ b/src/Misc/dotnet-install.sh
@@ -436,10 +436,51 @@ get_latest_version_info() {
 }
 
 # args:
+# json_file - $1
+parse_jsonfile_for_version() {
+    eval $invocation
+
+    local json_file="$1"
+    if [ ! -f "$json_file" ]; then
+        say_err "Unable to find \`$json_file\`"
+        return 1
+    fi
+
+    sdk_section=$(cat $json_file | awk '/"sdk"/,/}/')
+    if [ -z "$sdk_section" ]; then
+        say_err "Unable to parse the SDK node in \`$json_file\`"
+        return 1
+    fi
+
+    sdk_list=$(echo $sdk_section | awk -F"[{}]" '{print $2}')
+    sdk_list=${sdk_list//[\" ]/}
+    sdk_list=${sdk_list//,/$'\n'}
+    sdk_list="$(echo -e "${sdk_list}" | tr -d '[[:space:]]')"
+
+    local version_info=""
+    while read -r line; do
+      IFS=:
+      while read -r key value; do
+        if [[ "$key" == "version" ]]; then
+          version_info=$value
+        fi
+      done <<< "$line"
+    done <<< "$sdk_list"
+    if [ -z "$version_info" ]; then
+        say_err "Unable to find the SDK:version node in \`$json_file\`"
+        return 1
+    fi
+
+    echo "$version_info"
+    return 0
+}
+
+# args:
 # azure_feed - $1
 # channel - $2
 # normalized_architecture - $3
 # version - $4
+# json_file - $5
 get_specific_version_from_version() {
     eval $invocation
 
@@ -447,27 +488,35 @@ get_specific_version_from_version() {
     local channel="$2"
     local normalized_architecture="$3"
     local version="$(to_lowercase "$4")"
+    local json_file="$5"
 
-    case "$version" in
-        latest)
-            local version_info
-            version_info="$(get_latest_version_info "$azure_feed" "$channel" "$normalized_architecture" false)" || return 1
-            say_verbose "get_specific_version_from_version: version_info=$version_info"
-            echo "$version_info" | get_version_from_version_info
-            return 0
-            ;;
-        coherent)
-            local version_info
-            version_info="$(get_latest_version_info "$azure_feed" "$channel" "$normalized_architecture" true)" || return 1
-            say_verbose "get_specific_version_from_version: version_info=$version_info"
-            echo "$version_info" | get_version_from_version_info
-            return 0
-            ;;
-        *)
-            echo "$version"
-            return 0
-            ;;
-    esac
+    if [ -z "$json_file" ]; then
+        case "$version" in
+            latest)
+                local version_info
+                version_info="$(get_latest_version_info "$azure_feed" "$channel" "$normalized_architecture" false)" || return 1
+                say_verbose "get_specific_version_from_version: version_info=$version_info"
+                echo "$version_info" | get_version_from_version_info
+                return 0
+                ;;
+            coherent)
+                local version_info
+                version_info="$(get_latest_version_info "$azure_feed" "$channel" "$normalized_architecture" true)" || return 1
+                say_verbose "get_specific_version_from_version: version_info=$version_info"
+                echo "$version_info" | get_version_from_version_info
+                return 0
+                ;;
+            *)
+                echo "$version"
+                return 0
+                ;;
+        esac
+    else
+        local version_info
+        version_info="$(parse_jsonfile_for_version "$json_file")" || return 1
+        echo "$version_info"
+        return 0
+    fi
 }
 
 # args:
@@ -555,24 +604,6 @@ resolve_installation_path() {
     fi
 
     echo "$install_dir"
-    return 0
-}
-
-# args:
-# install_root - $1
-get_installed_version_info() {
-    eval $invocation
-
-    local install_root="$1"
-    local version_file="$(combine_paths "$install_root" "$local_version_file_relative_path")"
-    say_verbose "Local version file: $version_file"
-    if [ ! -z "$version_file" ] | [ -r "$version_file" ]; then
-        local version_info="$(cat "$version_file")"
-        echo "$version_info"
-        return 0
-    fi
-
-    say_verbose "Local version file not found."
     return 0
 }
 
@@ -724,7 +755,7 @@ calculate_vars() {
     normalized_architecture="$(get_normalized_architecture_from_architecture "$architecture")"
     say_verbose "normalized_architecture=$normalized_architecture"
 
-    specific_version="$(get_specific_version_from_version "$azure_feed" "$channel" "$normalized_architecture" "$version")"
+    specific_version="$(get_specific_version_from_version "$azure_feed" "$channel" "$normalized_architecture" "$version" "$json_file")"
     say_verbose "specific_version=$specific_version"
     if [ -z "$specific_version" ]; then
         say_err "Could not resolve version information."
@@ -826,6 +857,7 @@ temporary_file_template="${TMPDIR:-/tmp}/dotnet.XXXXXXXXX"
 
 channel="LTS"
 version="Latest"
+json_file=""
 install_dir="<auto>"
 architecture="<auto>"
 dry_run=false
@@ -912,6 +944,10 @@ do
             runtime_id="$1"
             non_dynamic_parameters+=" $name "\""$1"\"""
             ;;
+        --jsonfile|-[Jj][Ss]on[Ff]ile)
+            shift
+            json_file="$1"
+            ;;
         --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
             override_non_versioned_files=false
             non_dynamic_parameters+=" $name"
@@ -953,22 +989,25 @@ do
             echo "          Possible values:"
             echo "          - dotnet     - the Microsoft.NETCore.App shared runtime"
             echo "          - aspnetcore - the Microsoft.AspNetCore.App shared runtime"
-            echo "  --skip-non-versioned-files         Skips non-versioned files if they already exist, such as the dotnet executable."
-            echo "      -SkipNonVersionedFiles"
             echo "  --dry-run,-DryRun                  Do not perform installation. Display download link."
             echo "  --no-path, -NoPath                 Do not set PATH for the current process."
             echo "  --verbose,-Verbose                 Display diagnostics information."
             echo "  --azure-feed,-AzureFeed            Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
             echo "  --uncached-feed,-UncachedFeed      Uncached feed location. This parameter typically is not changed by the user."
-            echo "  --no-cdn,-NoCdn                    Disable downloading from the Azure CDN, and use the uncached feed directly."
             echo "  --feed-credential,-FeedCredential  Azure feed shared access token. This parameter typically is not specified."
+            echo "  --skip-non-versioned-files         Skips non-versioned files if they already exist, such as the dotnet executable."
+            echo "      -SkipNonVersionedFiles"
+            echo "  --no-cdn,-NoCdn                    Disable downloading from the Azure CDN, and use the uncached feed directly."
+            echo "  --jsonfile <JSONFILE>              Determines the SDK version from a user specified global.json file."
+            echo "                                     Note: global.json must have a value for 'SDK:Version'"
             echo "  --runtime-id                       Installs the .NET Tools for the given platform (use linux-x64 for portable linux)."
             echo "      -RuntimeId"
             echo "  -?,--?,-h,--help,-Help             Shows this help message"
             echo ""
             echo "Obsolete parameters:"
             echo "  --shared-runtime                   The recommended alternative is '--runtime dotnet'."
-            echo "      -SharedRuntime                 Installs just the shared runtime bits, not the entire SDK."
+            echo "                                     This parameter is obsolete and may be removed in a future version of this script."
+            echo "                                     Installs just the shared runtime bits, not the entire SDK."
             echo ""
             echo "Install Location:"
             echo "  Location is chosen in following order:"

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -63,7 +63,7 @@ function acquireExternalTool() {
             #      -S Show error. With -s, make curl show errors when they occur
             #      -L Follow redirects (H)
             #      -o FILE    Write to FILE instead of stdout
-            curl -fkSL -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
+            curl --retry 10 -fkSL -o "$partial_target" "$download_source" 2>"${download_target}_download.log" || checkRC 'curl'
 
             # Move the partial file to the download target.
             mv "$partial_target" "$download_target" || checkRC 'mv'
@@ -177,5 +177,5 @@ fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-armv7l.tar.gz" node fix_nested_dir
-    acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-armv7l.tar.gz" node10 fix_nested_dir	
+    acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-armv7l.tar.gz" node10 fix_nested_dir
 fi

--- a/src/Test/L0/Plugin/LogPluginHostL0.cs
+++ b/src/Test/L0/Plugin/LogPluginHostL0.cs
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.LogPluginHost
                     logPluginHost.EnqueueOutput($"{Guid.Empty.ToString("D")}:{i}");
                 }
 
-                await Task.Delay(1000);
+                await Task.Delay(2000);
                 logPluginHost.Finish();
                 await task;
 
@@ -473,7 +473,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.LogPluginHost
                 Assert.True(trace.Outputs.Contains("TestException: Done"));
             }
         }
-        
+
         // potential bug in XUnit cause the test failure.
         // [Fact]
         // [Trait("Level", "L0")]


### PR DESCRIPTION
This does not necessarily fix the underlying issue reported, but it does prevent the exception.
Other code in DockerCommandManager does guard against MountVolumes.SourceVolumePath from being null so we
should here too.

DTS Feedback Ticket: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1621619