### PR TITLE
Small fixes to multi-repo checkout scenario

### DIFF
--- a/src/Agent.Sdk/Util/RepositoryUtil.cs
+++ b/src/Agent.Sdk/Util/RepositoryUtil.cs
@@ -122,11 +122,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         /// </summary>
         public static string GuessRepositoryType(string repositoryUrl)
         {
-            if (repositoryUrl?.IndexOf("github.com", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (string.IsNullOrEmpty(repositoryUrl))
+            {
+                return string.Empty;
+            }
+
+            if (repositoryUrl.IndexOf("github.com", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return RepositoryTypes.GitHub;
             }
-            else if (repositoryUrl?.IndexOf(".visualstudio.com", StringComparison.OrdinalIgnoreCase) >= 0 || repositoryUrl?.IndexOf("dev.azure.com", StringComparison.OrdinalIgnoreCase) >= 0)
+            else if (repositoryUrl.IndexOf(".visualstudio.com", StringComparison.OrdinalIgnoreCase) >= 0 
+                  || repositoryUrl.IndexOf("dev.azure.com", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 if (repositoryUrl.IndexOf("/_git/", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
@@ -135,7 +141,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
                 return RepositoryTypes.Tfvc;
             }
-            else if (repositoryUrl?.IndexOf("bitbucket.org", StringComparison.OrdinalIgnoreCase) >= 0)
+            else if (repositoryUrl.IndexOf("bitbucket.org", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return RepositoryTypes.Bitbucket;
             }

--- a/src/Agent.Sdk/Util/RepositoryUtil.cs
+++ b/src/Agent.Sdk/Util/RepositoryUtil.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
+using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using Agent.Sdk;
 using Microsoft.TeamFoundation.DistributedTask.Pipelines;
 
@@ -15,6 +13,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
     public static class RepositoryUtil
     {
         public static readonly string PrimaryRepositoryName = "self";
+        public static readonly string GitStandardBranchPrefix = "refs/heads/";
+
+        public static string TrimStandardBranchPrefix(string branchName)
+        {
+            if (!string.IsNullOrEmpty(branchName) && branchName.StartsWith(GitStandardBranchPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return branchName.Substring(GitStandardBranchPrefix.Length);
+            }
+
+            return branchName;
+        }
 
         /// <summary>
         /// Returns true if the dictionary contains the 'HasMultipleCheckouts' key and the value is set to 'true'.
@@ -61,6 +70,39 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         }
 
         /// <summary>
+        /// This method returns the repository from the list that has a 'Path' that the localPath is parented to.
+        /// If the localPath is not part of any of the repo paths, null is returned.
+        /// </summary>
+        public static RepositoryResource GetRepositoryForLocalPath(IList<RepositoryResource> repositories, string localPath)
+        {
+            if (repositories == null || !repositories.Any() || String.IsNullOrEmpty(localPath))
+            {
+                return null;
+            }
+
+            if (repositories.Count == 1)
+            {
+                return repositories.First();
+            }
+            else
+            {
+                foreach (var repo in repositories)
+                {
+                    var repoPath = repo.Properties.Get<string>(RepositoryPropertyNames.Path)?.TrimEnd(Path.DirectorySeparatorChar);
+
+                    if (!string.IsNullOrEmpty(repoPath) && 
+                        (localPath.Equals(repoPath, IOUtil.FilePathStringComparison)) ||
+                         localPath.StartsWith(repoPath + Path.DirectorySeparatorChar, IOUtil.FilePathStringComparison))
+                    {
+                        return repo;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// This method returns the repo matching the repo alias passed.
         /// It returns null if that repo can't be found.
         /// </summary>
@@ -93,7 +135,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
                 return RepositoryTypes.Tfvc;
             }
-            else if (repositoryUrl.IndexOf("bitbucket.org", StringComparison.OrdinalIgnoreCase) >= 0)
+            else if (repositoryUrl?.IndexOf("bitbucket.org", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return RepositoryTypes.Bitbucket;
             }

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         public override void ConvertLocalPath(IExecutionContext context, string localPath, out string repoName, out string sourcePath)
         {
             repoName = "";
-            TryGetRepositoryInfo(context, out RepositoryInfo repoInfo);
+            TryGetRepositoryInfoFromLocalPath(context, localPath, out RepositoryInfo repoInfo);
 
             // If no repo was found, send back an empty repo with original path.
             sourcePath = localPath;
@@ -152,39 +152,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             executionContext.Variables.Set(Constants.Variables.Build.RepoProvider, ConvertToLegacyRepositoryType(repoInfo.Repository.Type));
             executionContext.Variables.Set(Constants.Variables.Build.RepoUri, repoInfo.Repository.Url?.AbsoluteUri);
 
-            // There may be more than one Checkout task, but for back compat we will simply pay attention to the first checkout task here
-            var checkoutTask = steps.FirstOrDefault(x => x.IsCheckoutTask()) as Pipelines.TaskStep;
-            if (checkoutTask != null)
-            {
-                if (checkoutTask.Inputs.ContainsKey(Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules))
-                {
-                    executionContext.Variables.Set(Constants.Variables.Build.RepoGitSubmoduleCheckout, Boolean.TrueString);
-                }
-                else
-                {
-                    executionContext.Variables.Set(Constants.Variables.Build.RepoGitSubmoduleCheckout, Boolean.FalseString);
-                }
-
-                // overwrite primary repository's clean value if build.repository.clean is sent from server. this is used by tfvc gated check-in
-                bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);
-                if (repoClean != null)
-                {
-                    checkoutTask.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Clean] = repoClean.Value.ToString();
-                }
-                else
-                {
-                    if (checkoutTask.Inputs.ContainsKey(Pipelines.PipelineConstants.CheckoutTaskInputs.Clean))
-                    {
-                        executionContext.Variables.Set(Constants.Variables.Build.RepoClean, checkoutTask.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Clean]);
-                    }
-                    else
-                    {
-                        executionContext.Variables.Set(Constants.Variables.Build.RepoClean, Boolean.FalseString);
-                    }
-                }
-            }
-
-
             // Prepare the build directory.
             executionContext.Output(StringUtil.Loc("PrepareBuildDir"));
             var directoryManager = HostContext.GetService<IBuildDirectoryManager>();
@@ -193,10 +160,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 executionContext.Repositories,
                 workspace);
 
+            string _workDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
+            string pipelineWorkspaceDirectory = Path.Combine(_workDirectory, trackingConfig.BuildDirectory);
+
+            UpdateCheckoutTasksAndVariables(executionContext, steps, repoInfo, pipelineWorkspaceDirectory);
+
             // Set the directory variables.
             executionContext.Output(StringUtil.Loc("SetBuildVars"));
-            string _workDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
-            executionContext.SetVariable(Constants.Variables.Agent.BuildDirectory, Path.Combine(_workDirectory, trackingConfig.BuildDirectory), isFilePath: true);
+            executionContext.SetVariable(Constants.Variables.Agent.BuildDirectory, pipelineWorkspaceDirectory, isFilePath: true);
             executionContext.SetVariable(Constants.Variables.System.ArtifactsDirectory, Path.Combine(_workDirectory, trackingConfig.ArtifactsDirectory), isFilePath: true);
             executionContext.SetVariable(Constants.Variables.System.DefaultWorkingDirectory, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
             executionContext.SetVariable(Constants.Variables.Common.TestResultsDirectory, Path.Combine(_workDirectory, trackingConfig.TestResultsDirectory), isFilePath: true);
@@ -205,32 +176,114 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             executionContext.SetVariable(Constants.Variables.Build.StagingDirectory, Path.Combine(_workDirectory, trackingConfig.ArtifactsDirectory), isFilePath: true);
             executionContext.SetVariable(Constants.Variables.Build.ArtifactStagingDirectory, Path.Combine(_workDirectory, trackingConfig.ArtifactsDirectory), isFilePath: true);
             executionContext.SetVariable(Constants.Variables.Build.RepoLocalPath, Path.Combine(_workDirectory, trackingConfig.SourcesDirectory), isFilePath: true);
-            executionContext.SetVariable(Constants.Variables.Pipeline.Workspace, Path.Combine(_workDirectory, trackingConfig.BuildDirectory), isFilePath: true);
+            executionContext.SetVariable(Constants.Variables.Pipeline.Workspace, pipelineWorkspaceDirectory, isFilePath: true);
+        }
+
+        private void UpdateCheckoutTasksAndVariables(IExecutionContext executionContext, IList<JobStep> steps, RepositoryInfo repoInfo, string pipelineWorkspaceDirectory)
+        {
+            bool? submoduleCheckout = null;
+            // RepoClean may be set from the server, so start with the server value
+            bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);
+
+            foreach (var checkoutTask in steps.Where(x => x.IsCheckoutTask()).Select(x => x as TaskStep))
+            {
+                if (!checkoutTask.Inputs.TryGetValue(PipelineConstants.CheckoutTaskInputs.Repository, out string repositoryAlias))
+                {
+                    // If the checkout task isn't associated with a repo, just skip it
+                    Trace.Info($"Checkout task {checkoutTask.Name} does not have a repository property.");
+                    continue;
+                }
+
+                // Update the checkout "Clean" property for all repos, if the variable was set by the server.
+                if (repoClean != null)
+                {
+                    checkoutTask.Inputs[PipelineConstants.CheckoutTaskInputs.Clean] = repoClean.Value.ToString();
+                }
+
+                // If this is the primary repository, use it to get the variable values
+                if (RepositoryUtil.IsPrimaryRepositoryName(repositoryAlias))
+                {
+                    submoduleCheckout = checkoutTask.Inputs.ContainsKey(PipelineConstants.CheckoutTaskInputs.Submodules);
+                    repoClean = repoClean ?? checkoutTask.Inputs.ContainsKey(PipelineConstants.CheckoutTaskInputs.Clean);
+                }
+
+                // Update the checkout task display name if not already set
+                if (string.IsNullOrEmpty(checkoutTask.DisplayName) || string.Equals(checkoutTask.DisplayName, "Checkout", StringComparison.OrdinalIgnoreCase))
+                {
+                    var repository = RepositoryUtil.GetRepository(executionContext.Repositories, repositoryAlias);
+                    if (repository != null)
+                    {
+                        string repoName = repository.Properties.Get<string>(RepositoryPropertyNames.Name);
+                        string version = RepositoryUtil.TrimStandardBranchPrefix(repository.Properties.Get<string>(RepositoryPropertyNames.Ref));
+                        string path = null;
+                        if (checkoutTask.Inputs.ContainsKey(PipelineConstants.CheckoutTaskInputs.Path))
+                        {
+                            path = checkoutTask.Inputs[PipelineConstants.CheckoutTaskInputs.Path];
+                        }
+                        else
+                        {
+                            path = IOUtil.MakeRelative(repository.Properties.Get<string>(RepositoryPropertyNames.Path), pipelineWorkspaceDirectory);
+                        }
+                        checkoutTask.DisplayName = StringUtil.Loc("CheckoutTaskDisplayNameFormat", repoName, version, path);
+                    }
+                    else
+                    {
+                        Trace.Info($"Checkout task {checkoutTask.Name} has a repository property {repositoryAlias} that does not match any repository resource.");
+                    }
+                }
+            }
+
+            // Set variables
+            if (submoduleCheckout.HasValue)
+            {
+                executionContext.Variables.Set(Constants.Variables.Build.RepoGitSubmoduleCheckout, submoduleCheckout.Value.ToString());
+            }
+
+            if (repoClean.HasValue)
+            {
+                executionContext.Variables.Set(Constants.Variables.Build.RepoClean, repoClean.Value.ToString());
+            }
+        }
+
+        private bool TryGetRepositoryInfoFromLocalPath(IExecutionContext executionContext, string localPath, out RepositoryInfo repoInfo)
+        {
+            // Return the matching repository resource and its source provider.
+            Trace.Entering();
+            var repo = RepositoryUtil.GetRepositoryForLocalPath(executionContext.Repositories, localPath);
+            repoInfo = new RepositoryInfo
+            {
+                Repository = repo,
+                SourceProvider = GetSourceProvider(executionContext, repo),
+            };
+
+            return repoInfo.SourceProvider != null;
         }
 
         private bool TryGetRepositoryInfo(IExecutionContext executionContext, out RepositoryInfo repoInfo)
         {
             // Return the matching repository resource and its source provider.
             Trace.Entering();
-            repoInfo = new RepositoryInfo();
-            var extensionManager = HostContext.GetService<IExtensionManager>();
-            List<ISourceProvider> sourceProviders = extensionManager.GetExtensions<ISourceProvider>();
-
-            var primaryRepository = RepositoryUtil.GetPrimaryRepository(executionContext.Repositories);
-
-            if (primaryRepository != null)
+            var repo = RepositoryUtil.GetPrimaryRepository(executionContext.Repositories);
+            repoInfo = new RepositoryInfo
             {
-                var sourceProvider = sourceProviders.FirstOrDefault(x => string.Equals(x.RepositoryType, primaryRepository.Type, StringComparison.OrdinalIgnoreCase));
+                Repository = repo,
+                SourceProvider = GetSourceProvider(executionContext, repo),
+            };
 
-                if (sourceProvider != null)
-                {
-                    repoInfo.Repository = primaryRepository;
-                    repoInfo.SourceProvider = sourceProvider;
-                    return true;
-                }
+            return repoInfo.SourceProvider != null;
+        }
+
+        private ISourceProvider GetSourceProvider(IExecutionContext executionContext, RepositoryResource repository)
+        {
+            if (repository != null)
+            {
+                var extensionManager = HostContext.GetService<IExtensionManager>();
+                List<ISourceProvider> sourceProviders = extensionManager.GetExtensions<ISourceProvider>();
+                var sourceProvider = sourceProviders.FirstOrDefault(x => string.Equals(x.RepositoryType, repository.Type, StringComparison.OrdinalIgnoreCase));
+                return sourceProvider;
             }
 
-            return false;
+            return null;
         }
 
         private string ConvertToLegacyRepositoryType(string pipelineRepositoryType)

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -236,12 +236,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             // Set variables
             if (submoduleCheckout.HasValue)
             {
-                executionContext.Variables.Set(Constants.Variables.Build.RepoGitSubmoduleCheckout, submoduleCheckout.Value.ToString());
+                executionContext.SetVariable(Constants.Variables.Build.RepoGitSubmoduleCheckout, submoduleCheckout.Value.ToString());
             }
 
             if (repoClean.HasValue)
             {
-                executionContext.Variables.Set(Constants.Variables.Build.RepoClean, repoClean.Value.ToString());
+                executionContext.SetVariable(Constants.Variables.Build.RepoClean, repoClean.Value.ToString());
             }
         }
 

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -60,6 +60,7 @@
   "CannotUploadFile": "Cannot upload file because file location is not specified.",
   "CannotUploadFromCurrentEnvironment": "Cannot upload to a pipeline artifact from {0} environment.",
   "CannotUploadSummary": "Cannot upload summary file, summary file location is not specified.",
+  "CheckoutTaskDisplayNameFormat": "Checkout {0}@{1} to {2}",
   "ClockSkewStopRetry": "Stopped retrying OAuth token request exception after {0} seconds.",
   "CodeCoverageCommandNotFound": "##vso[codecoverage.{0}] is not a recognized command for Task command extension. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
   "CodeCoverageDataIsNull": "No coverage data found. Check the build errors/warnings for more details.",


### PR DESCRIPTION
 - Handle ConvertToLocalPath in agent code (this is used to make local paths relative to build dir)
 - Update checkout description to include name of repo and disk location - [user story 1629387](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1629387)