### PR TITLE
Optional task signature verification

### DIFF
--- a/src/Agent.Worker/SignatureService.cs
+++ b/src/Agent.Worker/SignatureService.cs
@@ -29,7 +29,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var configurationStore = HostContext.GetService<IConfigurationStore>();
             AgentSettings settings = configurationStore.GetSettings();
             String fingerprint = settings.Fingerprint;
-
             String taskZipPath = definition.ZipPath;
             String taskNugetPath = definition.ZipPath.Replace(".zip", ".nupkg");
 

--- a/src/Agent.Worker/SignatureService.cs
+++ b/src/Agent.Worker/SignatureService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.VisualStudio.Services.Agent.Util;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker
+{
+    [ServiceLocator(Default = typeof(SignatureService))]
+    public interface ISignatureService : IAgentService
+    {
+        Task<Boolean> VerifyAsync(Definition definition, CancellationToken token);
+    }
+
+    public class SignatureService : AgentService, ISignatureService
+    {
+        public async Task<Boolean> VerifyAsync(Definition definition, CancellationToken token)
+        {
+            // This is used for the Checkout task.
+            // We can consider it verified since it's embedded in the Agent code.
+            if (String.IsNullOrEmpty(definition.ZipPath))
+            {
+                return true;
+            }
+
+            // Find NuGet
+            String nugetPath = WhichUtil.Which("nuget", require: true);
+
+            var configurationStore = HostContext.GetService<IConfigurationStore>();
+            AgentSettings settings = configurationStore.GetSettings();
+            String fingerprint = settings.Fingerprint;
+
+            String taskZipPath = definition.ZipPath;
+            String taskNugetPath = definition.ZipPath.Replace(".zip", ".nupkg");
+
+            // Rename .zip to .nupkg
+            File.Move(taskZipPath, taskNugetPath);
+
+            String arguments = $"verify -Signatures \"{taskNugetPath}\" -CertificateFingerprint {fingerprint} -Verbosity Detailed";
+
+            // Run nuget verify
+            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
+            {
+                int exitCode = await processInvoker.ExecuteAsync(workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Root),
+                                                                 fileName: nugetPath,
+                                                                 arguments: arguments,
+                                                                 environment: null,
+                                                                 requireExitCodeZero: false,
+                                                                 outputEncoding: null,
+                                                                 killProcessOnCancel: false,
+                                                                 cancellationToken: token);
+
+                // Rename back to zip
+                File.Move(taskNugetPath, taskZipPath);
+
+                if (exitCode != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}
+    

--- a/src/Agent.Worker/SignatureService.cs
+++ b/src/Agent.Worker/SignatureService.cs
@@ -62,4 +62,3 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         }
     }
 }
-    

--- a/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
@@ -28,6 +28,9 @@ namespace Microsoft.VisualStudio.Services.Agent
         public bool IsHosted => !string.IsNullOrEmpty(NotificationPipeName) || !string.IsNullOrEmpty(NotificationSocketAddress);
 
         [DataMember(EmitDefaultValue = false)]
+        public string Fingerprint { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public string NotificationPipeName { get; set; }
 
         [DataMember(EmitDefaultValue = false)]

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         Root,
         ServerOM,
         Tasks,
+        TaskZips,
         Tee,
         Temp,
         Tf,
@@ -238,6 +239,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             public static readonly string ToolDirectory = "_tool";
             public static readonly string TaskJsonFile = "task.json";
             public static readonly string TasksDirectory = "_tasks";
+            public static readonly string TaskZipsDirectory = "_taskzips";
             public static readonly string UpdateDirectory = "_update";
             public static readonly string WorkDirectory = "_work";
         }

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -225,6 +225,12 @@ namespace Microsoft.VisualStudio.Services.Agent
                         Constants.Path.TasksDirectory);
                     break;
 
+                case WellKnownDirectory.TaskZips:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Work),
+                        Constants.Path.TaskZipsDirectory);
+                    break;
+
                 case WellKnownDirectory.Tools:
                     path = Environment.GetEnvironmentVariable("AGENT_TOOLSDIRECTORY") ?? Environment.GetEnvironmentVariable(Constants.Variables.Agent.ToolsDirectory);
                     if (string.IsNullOrEmpty(path))

--- a/src/Misc/dotnet-install.sh
+++ b/src/Misc/dotnet-install.sh
@@ -855,8 +855,6 @@ install_dotnet() {
     extract_dotnet_package "$zip_path" "$install_root"
 
     #  Check if the SDK version is installed; if not, fail the installation.
-    is_asset_installed=false
-
     # if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.
     if [[ $specific_version == *"rtm"* || $specific_version == *"servicing"* ]]; then
         IFS='-'
@@ -864,21 +862,19 @@ install_dotnet() {
         release_version="${verArr[0]}"
         unset IFS;
         say_verbose "Checking installation: version = $release_version"
-        is_asset_installed="$(is_dotnet_package_installed "$install_root" "$asset_relative_path" "$release_version")"
+        if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$release_version"; then
+            return 0
+        fi
     fi
 
-    #  Check if the SDK version is installed.
-    if [ "$is_asset_installed" = false ]; then
-        say_verbose "Checking installation: version = $specific_version"
-        is_asset_installed="$(is_dotnet_package_installed "$install_root" "$asset_relative_path" "$specific_version")"
+    #  Check if the standard SDK version is installed.
+    say_verbose "Checking installation: version = $specific_version"
+    if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$specific_version"; then
+        return 0
     fi
 
-    if [ "$is_asset_installed" = false ]; then
-        say_err "\`$asset_name\` with version = $specific_version failed to install with an unknown error."
-        return 1
-    fi
-
-    return 0
+    say_err "\`$asset_name\` with version = $specific_version failed to install with an unknown error."
+    return 1
 }
 
 args=("$@")

--- a/src/Test/L0/ProcessExtensionL0.cs
+++ b/src/Test/L0/ProcessExtensionL0.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     var timeout = Process.GetProcessById(sleep.Id);
                     while (timeout == null)
                     {
-                        await Task.Delay(500);
+                        await Task.Delay(1500);
                         timeout = Process.GetProcessById(sleep.Id);
                     }
 

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -232,6 +232,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                         Constants.Path.TasksDirectory);
                     break;
 
+                case WellKnownDirectory.TaskZips:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Work),
+                        Constants.Path.TaskZipsDirectory);
+                    break;
+
                 case WellKnownDirectory.Tools:
                     path = Environment.GetEnvironmentVariable("AGENT_TOOLSDIRECTORY") ?? Environment.GetEnvironmentVariable(Constants.Variables.Agent.ToolsDirectory);
                     if (string.IsNullOrEmpty(path))


### PR DESCRIPTION
This change adds optional task signature verification to the Agent. This feature can be enabled by adding a `Fingerprint` property to the Agent configuration file. If this property exists, task signatures will be verified at run time. If the verification fails, the task fails. If the verification is successful we extract the task and overwrite whatever may exist on disk.

In order to support this a new folder inside the Agent is added, `_taskzips`. This contains the original task zips that are downloaded from the server. This allows us to verify the signature and extract at task run time.

**Manual Tests**

1. From a clean Agent with signing disabled, run multiple builds with the same tasks to make sure they are downloaded and reused.
1. From an agent that already has tasks downloaded, run builds with task signing then turned on and make sure they are verified and replaced at runtime.
1. From a clean Agent with signing enabled, run multiple builds with the same tasks to make sure they are downloaded and reused.
1. Go back to an Agent with signing disabled and make sure it works.

