### PR TITLE
Add a warning in the post job cache task when the fingerprint is different

### DIFF
--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -1,16 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="..\Common.props" />
+
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Agent.Sdk\Agent.Sdk.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.2" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -1,15 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\Common.props" />
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Agent.Sdk\Agent.Sdk.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.2" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -29,7 +29,7 @@ namespace Agent.Plugins.PipelineCache
         protected const string ContentFormatVariableName = "AZP_CACHING_CONTENT_FORMAT";
         public Guid Id => PipelineCachePluginConstants.CacheTaskId;
         public abstract String Stage { get; }
-        public const string CalculatedFingerPrintVariableName = "CALCULATED_FINGER_PRINT";
+        public const string ResolvedFingerPrintVariableName = "RESTORE_STEP_RESOLVED_FINGERPRINT";
 
         internal static (bool isOldFormat, string[] keySegments,IEnumerable<string[]> restoreKeys) ParseIntoSegments(string salt, string key, string restoreKeysBlock)
         {

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -29,6 +29,7 @@ namespace Agent.Plugins.PipelineCache
         protected const string ContentFormatVariableName = "AZP_CACHING_CONTENT_FORMAT";
         public Guid Id => PipelineCachePluginConstants.CacheTaskId;
         public abstract String Stage { get; }
+        public const string CalculatedFingerPrintVariableName = "CALCULATED_FINGER_PRINT";
 
         internal static (bool isOldFormat, string[] keySegments,IEnumerable<string[]> restoreKeys) ParseIntoSegments(string salt, string key, string restoreKeysBlock)
         {
@@ -141,7 +142,6 @@ namespace Agent.Plugins.PipelineCache
             public static readonly string PipelineId = "pipelineId";
             public static readonly string CacheHitVariable = "cacheHitVar";
             public static readonly string Salt = "salt";
-
         }
     }
 }

--- a/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
@@ -22,7 +22,7 @@ namespace Agent.Plugins.PipelineCache
             CancellationToken token)
         {
             context.SetTaskVariable(RestoreStepRanVariableName, RestoreStepRanVariableValue);
-            context.SetTaskVariable(CalculatedFingerPrintVariableName, fingerprint.ToString());
+            context.SetTaskVariable(ResolvedFingerPrintVariableName, fingerprint.ToString());
 
             var server = new PipelineCacheServer();
             Fingerprint[] restoreFingerprints = restoreKeysGenerator();

--- a/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
@@ -22,6 +22,7 @@ namespace Agent.Plugins.PipelineCache
             CancellationToken token)
         {
             context.SetTaskVariable(RestoreStepRanVariableName, RestoreStepRanVariableValue);
+            context.SetTaskVariable(CalculatedFingerPrintVariableName, fingerprint.ToString());
 
             var server = new PipelineCacheServer();
             Fingerprint[] restoreFingerprints = restoreKeysGenerator();

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -62,7 +62,13 @@ namespace Agent.Plugins.PipelineCache
             string path,
             CancellationToken token)
         {
-            string contentFormatValue  = context.Variables.GetValueOrDefault(ContentFormatVariableName)?.Value ?? string.Empty;
+            string contentFormatValue  = context.TaskVariables.GetValueOrDefault(ContentFormatVariableName)?.Value ?? string.Empty;
+            string calculatedFingerPrint = context.TaskVariables.GetValueOrDefault(CalculatedFingerPrintVariableName)?.Value ?? string.Empty;
+
+            if(!string.IsNullOrWhiteSpace(calculatedFingerPrint) && !fingerprint.ToString().Equals(calculatedFingerPrint, StringComparison.Ordinal))
+            {
+                context.Warning($"Fingerprint has been modified; original fp: {calculatedFingerPrint}, modified fingerprint {fingerprint}");
+            } 
 
             ContentFormat contentFormat;
             if (string.IsNullOrWhiteSpace(contentFormatValue))

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -62,12 +62,14 @@ namespace Agent.Plugins.PipelineCache
             string path,
             CancellationToken token)
         {
-            string contentFormatValue  = context.TaskVariables.GetValueOrDefault(ContentFormatVariableName)?.Value ?? string.Empty;
-            string calculatedFingerPrint = context.TaskVariables.GetValueOrDefault(CalculatedFingerPrintVariableName)?.Value ?? string.Empty;
+            string contentFormatValue  = context.Variables.GetValueOrDefault(ContentFormatVariableName)?.Value ?? string.Empty;
+            string calculatedFingerPrint = context.TaskVariables.GetValueOrDefault(ResolvedFingerPrintVariableName)?.Value ?? string.Empty;
 
             if(!string.IsNullOrWhiteSpace(calculatedFingerPrint) && !fingerprint.ToString().Equals(calculatedFingerPrint, StringComparison.Ordinal))
             {
-                context.Warning($"Fingerprint has been modified; original fp: {calculatedFingerPrint}, modified fingerprint {fingerprint}");
+                context.Warning($"The given cache key has changed in it's resolved value between restore and save steps;\n"+
+                                $"original key: {calculatedFingerPrint}\n"+
+                                $"modified key: {fingerprint}\n");
             } 
 
             ContentFormat contentFormat;


### PR DESCRIPTION
Description: A lot of times, the fingerprint changes between the Cache task and the Post Cache task which results in a cache stored using a different fingerprint and the user might be oblivious to this.

Solution: This PR prints out a warning when the fingerprint changes between the steps.