### PR TITLE
run as serviceaccount fix for environment vm scenario 

### DIFF
--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             // TODO: Fix bug that exists in the legacy Windows agent where configuration using mirrored credentials causes an error, but the agent is still functional (after restarting). Mirrored credentials is a supported scenario and shouldn't manifest any errors.
 
             // We use NetworkService as default account for build and release agent
-            // We use Local System as default account for deployment agent, deployment pool agent
+            // We use Local System as default account for deployment agent, deployment pool agent, environment vm agent 
             bool isDeploymentGroupScenario = command.DeploymentGroup || command.DeploymentPool || command.EnvironmentVMResource;
             NTAccount defaultServiceAccount = isDeploymentGroupScenario ? _windowsServiceHelper.GetDefaultAdminServiceAccount() : _windowsServiceHelper.GetDefaultServiceAccount();
             string logonAccount = command.GetWindowsLogonAccount(defaultValue: defaultServiceAccount.ToString(), descriptionMsg: StringUtil.Loc("WindowsLogonAccountNameDescription"));

--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
             // We use NetworkService as default account for build and release agent
             // We use Local System as default account for deployment agent, deployment pool agent
-            bool isDeploymentGroupScenario = command.DeploymentGroup || command.DeploymentPool;
+            bool isDeploymentGroupScenario = command.DeploymentGroup || command.DeploymentPool || command.EnvironmentVMResource;
             NTAccount defaultServiceAccount = isDeploymentGroupScenario ? _windowsServiceHelper.GetDefaultAdminServiceAccount() : _windowsServiceHelper.GetDefaultServiceAccount();
             string logonAccount = command.GetWindowsLogonAccount(defaultValue: defaultServiceAccount.ToString(), descriptionMsg: StringUtil.Loc("WindowsLogonAccountNameDescription"));
 


### PR DESCRIPTION
For environment vm scenario, runAsService user should have default option as ‘system’ user (‘NT AUTHORITY\SYSTEM’) 