### PR TITLE
Make running containers on Windows 1909 work

### DIFF
--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -293,7 +293,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 executionContext.Debug($"Default Working Directory {defaultWorkingDirectory}");
                 executionContext.Debug($"Working Directory {workingDirectory}");
                 executionContext.Debug($"Mount Working Directory {mountWorkingDirectory}");
-                container.MountVolumes.Add(new MountVolume(mountWorkingDirectory, workingDirectory));
+                if (!string.IsNullOrEmpty(workingDirectory))
+                {
+                    container.MountVolumes.Add(new MountVolume(mountWorkingDirectory, workingDirectory));
+                }
+
                 container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
                 container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tasks), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tasks))));
 


### PR DESCRIPTION
- Fix NRE when create docker network
- Properly decide which command to use. Docker desktop may not have `nat` plugin, and as such running should be done without specifying that plugin.
- In my case working directory was empty, and as such passing it as the volume is incorrect and lead to volume mapping failure.

Closes: #2613