### PR TITLE
Support compiling for arm64

### DIFF
--- a/src/Agent.Listener/Program.cs
+++ b/src/Agent.Listener/Program.cs
@@ -15,10 +15,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
     {
         public static int Main(string[] args)
         {
-            // We can't use the new SocketsHttpHandler for now for both Windows and Linux
-            // On linux, Negotiate auth is not working if the TFS url is behind Https
-            // On windows, Proxy is not working
-            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
             using (HostContext context = new HostContext("Agent"))
             {
                 return MainAsync(context, args).GetAwaiter().GetResult();

--- a/src/Agent.PluginHost/Program.cs
+++ b/src/Agent.PluginHost/Program.cs
@@ -24,10 +24,6 @@ namespace Agent.PluginHost
 
         public static int Main(string[] args)
         {
-            // We can't use the new SocketsHttpHandler for now for both Windows and Linux
-            // On linux, Negotiate auth is not working if the TFS url is behind Https
-            // On windows, Proxy is not working
-            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
             Console.CancelKeyPress += Console_CancelKeyPress;
 
             // Set encoding to UTF8, process invoker will use UTF8 write to STDIN

--- a/src/Agent.Worker/Program.cs
+++ b/src/Agent.Worker/Program.cs
@@ -12,10 +12,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     {
         public static int Main(string[] args)
         {
-            // We can't use the new SocketsHttpHandler for now for both Windows and Linux
-            // On linux, Negotiate auth is not working if the TFS url is behind Https
-            // On windows, Proxy is not working
-            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
             using (HostContext context = new HostContext("Worker"))
             {
                 return MainAsync(context, args).GetAwaiter().GetResult();

--- a/src/Common.props
+++ b/src/Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeFrameworkVersion>3.1.0</RuntimeFrameworkVersion>
-    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm;rhel.6-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-arm;linux-arm64;rhel.6-x64;osx-x64</RuntimeIdentifiers>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <AssetTargetFallback>portable-net45+win8</AssetTargetFallback>
     <NoWarn>NU1701;NU1603;</NoWarn>

--- a/src/Common.props
+++ b/src/Common.props
@@ -48,6 +48,9 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-arm'">
     <OSArchitecture>ARM</OSArchitecture>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-arm64'">
+    <OSArchitecture>ARM64</OSArchitecture>
+  </PropertyGroup>
 
   <PropertyGroup>
     <DefineConstants>$(OSPlatform);$(OSArchitecture);$(DebugConstant);TRACE</DefineConstants>

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -180,3 +180,8 @@ if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-armv7l.tar.gz" node fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-armv7l.tar.gz" node10 fix_nested_dir
 fi
+
+if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
+    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.gz" node fix_nested_dir
+    acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-arm64.tar.gz" node10 fix_nested_dir
+fi

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -48,7 +48,7 @@ function detect_platform_and_runtime_id ()
             local CPU_NAME=$(uname -m)
             case $CPU_NAME in
                 armv7l) DETECTED_RUNTIME_ID="linux-arm";;
-                aarch64) DETECTED_RUNTIME_ID="linux-arm";;
+                aarch64) DETECTED_RUNTIME_ID="linux-arm64";;
             esac
         fi
 
@@ -199,7 +199,7 @@ else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
 fi
 
-_VALID_RIDS='linux-x64:linux-arm:rhel.6-x64:osx-x64:win-x64:win-x86'
+_VALID_RIDS='linux-x64:linux-arm:linux-arm64:rhel.6-x64:osx-x64:win-x64:win-x86'
 if [[ ":$_VALID_RIDS:" != *:$RUNTIME_ID:* ]]; then
     failed "must specify a valid target runtime ID (one of: $_VALID_RIDS)"
 fi


### PR DESCRIPTION
This updates the build scripts and allow you to compile on arm64 hardware (such as the Raspberry Pi 4).
Essentially #1921 / #2256 redone for the current state of master.