### PR TITLE
React to nested artifacts

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -244,7 +244,7 @@ stages:
         Select-AzureRmSubscription -SubscriptionId $(SubscriptionId)
         $storage = Get-AzureRmStorageAccount -ResourceGroupName vstsagentpackage -AccountName vstsagentpackage
         Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
-          $versionDir = $_.Name.Trim('.zip').Trim('.tar.gz')
+          $versionDir = (Get-ChildItem $_)[0].Name.Trim('.zip').Trim('.tar.gz')
           $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
           Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"
           Write-Host "Uploading $_ to BlobStorage vstsagentpackage/agent/$versionDir"

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -244,7 +244,7 @@ stages:
         Select-AzureRmSubscription -SubscriptionId $(SubscriptionId)
         $storage = Get-AzureRmStorageAccount -ResourceGroupName vstsagentpackage -AccountName vstsagentpackage
         Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
-          $executable = (Get-ChildItem $_)[0]
+          $executable = (Get-ChildItem "$(System.ArtifactsDirectory)/agent/$_")[0]
           $versionDir = $executable.Name.Trim('.zip').Trim('.tar.gz')
           $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
           Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -244,12 +244,13 @@ stages:
         Select-AzureRmSubscription -SubscriptionId $(SubscriptionId)
         $storage = Get-AzureRmStorageAccount -ResourceGroupName vstsagentpackage -AccountName vstsagentpackage
         Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
-          $versionDir = (Get-ChildItem $_)[0].Name.Trim('.zip').Trim('.tar.gz')
+          $executable = (Get-ChildItem $_)[0]
+          $versionDir = $executable.Name.Trim('.zip').Trim('.tar.gz')
           $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
           Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"
-          Write-Host "Uploading $_ to BlobStorage vstsagentpackage/agent/$versionDir"
-          Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$_" -Blob "$versionDir/$_" -Force
-          $uploadFiles.Add("/agent/$versionDir/$_")
+          Write-Host "Uploading $executable to BlobStorage vstsagentpackage/agent/$versionDir"
+          Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$executable" -Blob "$versionDir/$executable" -Force
+          $uploadFiles.Add("/agent/$versionDir/$executable")
         }
         Write-Host "Purge Azure CDN Cache"
         Unpublish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -PurgeContent $uploadFiles

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -249,7 +249,7 @@ stages:
           $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
           Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"
           Write-Host "Uploading $executable to BlobStorage vstsagentpackage/agent/$versionDir"
-          Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$executable" -Blob "$versionDir/$executable" -Force
+          Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$_/$executable" -Blob "$versionDir/$executable" -Force
           $uploadFiles.Add("/agent/$versionDir/$executable")
         }
         Write-Host "Purge Azure CDN Cache"


### PR DESCRIPTION
Right now, our publish process produces artifacts of the form:

```
- agent
--- linux-x64
------ vsts-agent-linux-arm-2.160.1.tar.gz
--- win-x64
------ vsts-agent-win-2.160.1.tar.gz
...etc
```

see https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=10942550&view=artifacts&type=publishedArtifacts as an example

Previously, they were just of the form:

```
- agent
--- vsts-agent-linux-arm-2.160.1.tar.gz
--- vsts-agent-win-2.160.1.tar.gz
...etc
```

see https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=10894910&view=artifacts&type=publishedArtifacts as an example

I think this was probably introduced by https://github.com/microsoft/azure-pipelines-agent/pull/2581/files, though I'm not 100% sure.

This was causing an issue where when we were looking to extract the version name from the artifact, we looked at the folder name (e.g. `linux-x64`) instead of the filename (`vsts-agent-linux-arm-2.160.1.tar.gz`) - which led to us writing x64 or x86 as the version.

This fixes that problem