### PR TITLE
Remove references to the commit message

### DIFF
--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -65,8 +65,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         Pipelines.RepositoryPropertyNames.VersionInfo,
                         new Pipelines.VersionInfo()
                         {
-                            Author = "[PII]",
-                            Message = versionInfo.Message
+                            Author = "[PII]"
                         });
                 }
 

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -199,8 +199,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 Pipelines.RepositoryPropertyNames.VersionInfo,
                 new Pipelines.VersionInfo()
                 {
-                    Author = "MyAuthor",
-                    Message = "MyMessage"
+                    Author = "MyAuthor"
                 });
 
             message.Resources.Repositories.Add(repository);
@@ -223,7 +222,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 Assert.Equal("[PII]", value.Value);
             }
 
-            Pipelines.RepositoryResource scrubbedRepo = scrubbedMessage.Resources.Repositories[0];     
+            Pipelines.RepositoryResource scrubbedRepo = scrubbedMessage.Resources.Repositories[0];
             Pipelines.VersionInfo scrubbedInfo = scrubbedRepo.Properties.Get<Pipelines.VersionInfo>(Pipelines.RepositoryPropertyNames.VersionInfo);
 
             Assert.Equal("[PII]", scrubbedInfo.Author);


### PR DESCRIPTION
The commit message will soon stop being sent down to the agent. This PR removes the only place it is referenced (when outputting diagnostic logs).