### PR TITLE
A customer reported an issue of a NPE when initializing secret masker

### DIFF
--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             // Add mask hints for secret variables
             foreach (var variable in (message.Variables ?? new Dictionary<string, VariableValue>()))
             {
-                if (variable.Value.IsSecret)
+                if (variable.Value.IsSecret && !string.IsNullOrEmpty(variable.Value.Value))
                 {
                     HostContext.SecretMasker.AddValue(variable.Value.Value);
                     // for variables, it is possible that they are used inside a shell which would strip off surrounding quotes


### PR DESCRIPTION
Stack trace of NPE was:
[2019-11-27 01:47:59Z ERR  Program] System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.VisualStudio.Services.Agent.Worker.Worker.InitializeSecretMasker(AgentJobRequestMessage message)
   at Microsoft.VisualStudio.Services.Agent.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at Microsoft.VisualStudio.Services.Agent.Worker.Program.MainAsync(IHostContext context, String[] args)