### PR TITLE
Do not sign debug builds

### DIFF
--- a/src/Agent.Service/Windows/AgentService.csproj
+++ b/src/Agent.Service/Windows/AgentService.csproj
@@ -26,6 +26,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <SignAssembly>false</SignAssembly>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
This make life of living on the bleeding edge slightly easier. For now I have to manually tweak configuration to build the service executable from master. It was quite annoying trying troubleshoot while something not loaded.