### PR TITLE
Fixed variable expansion for container targets #2646

### DIFF
--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 {
                     if (handlerData is AgentPluginHandlerData)
                     {
-                        // plugin handler always runs on the Host, the rumtime variables needs to the variable works on the Host, ex: file path variable System.DefaultWorkingDirectory
+                        // plugin handler always runs on the Host, the runtime variables needs to the variable works on the Host, ex: file path variable System.DefaultWorkingDirectory
                         Dictionary<string, VariableValue> variableCopy = new Dictionary<string, VariableValue>(StringComparer.OrdinalIgnoreCase);
                         foreach (var publicVar in ExecutionContext.Variables.Public)
                         {

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -256,7 +256,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (Variable variable in _expanded.Values)
             {
-                source[variable.Name] = variable.Value;
+                var value = StringTranslator(variable.Value);
+                source[variable.Name] = value;
             }
 
             VarUtil.ExpandValues(_hostContext, source, target);
@@ -268,7 +269,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (Variable variable in _expanded.Values)
             {
-                source[variable.Name] = variable.Value;
+                source[variable.Name] = StringTranslator(variable.Value);
             }
             var target = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -284,7 +285,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var source = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (Variable variable in _expanded.Values)
             {
-                source[variable.Name] = variable.Value;
+                source[variable.Name] = StringTranslator(variable.Value);
             }
 
             return VarUtil.ExpandValues(_hostContext, source, target);
@@ -406,30 +407,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 _expanded[name] = variable;
                 _nonexpanded[name] = variable;
                 _trace.Verbose($"Set '{name}' = '{val}'");
-            }
-        }
-
-        public void Transform(Func<string, string> function)
-        {
-            lock (_setLock)
-            {
-                Dictionary<string, Variable> modified = new Dictionary<string, Variable>();
-                foreach (var entry in _expanded)
-                {
-                    var variable = entry.Value;
-                    var newVal = function.Invoke(variable.Value);
-                    if (string.CompareOrdinal(newVal, variable.Value) != 0)
-                    {
-                        modified.Add(entry.Key, new Variable(entry.Key, newVal, variable.Secret));
-                    }
-                }
-                foreach (var entry in modified)
-                {
-                    var name = entry.Key;
-                    var variable = entry.Value;
-                    _expanded[name] = variable;
-                    _nonexpanded[name] = variable;
-                }
             }
         }
 

--- a/src/Misc/dotnet-install.sh
+++ b/src/Misc/dotnet-install.sh
@@ -144,7 +144,7 @@ get_linux_platform_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            echo "$ID.$VERSION_ID"
+            echo "$ID${VERSION_ID:+.${VERSION_ID}}"
             return 0
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
@@ -157,6 +157,10 @@ get_linux_platform_name() {
 
     say_verbose "Linux specific platform name and version could not be detected: UName = $uname"
     return 1
+}
+
+is_musl_based_distro() {
+    (ldd --version 2>&1 || true) | grep -q musl
 }
 
 get_current_os_name() {
@@ -173,10 +177,10 @@ get_current_os_name() {
         local linux_platform_name
         linux_platform_name="$(get_linux_platform_name)" || { echo "linux" && return 0 ; }
 
-        if [[ $linux_platform_name == "rhel.6" ]]; then
+        if [ "$linux_platform_name" = "rhel.6" ]; then
             echo $linux_platform_name
             return 0
-        elif [[ $linux_platform_name == alpine* ]]; then
+        elif is_musl_based_distro; then
             echo "linux-musl"
             return 0
         else
@@ -202,7 +206,7 @@ get_legacy_os_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            os=$(get_legacy_os_name_from_platform "$ID.$VERSION_ID" || echo "")
+            os=$(get_legacy_os_name_from_platform "$ID${VERSION_ID:+.${VERSION_ID}}" || echo "")
             if [ -n "$os" ]; then
                 echo "$os"
                 return 0
@@ -245,20 +249,29 @@ check_pre_reqs() {
     fi
 
     if [ "$(uname)" = "Linux" ]; then
-        if [ ! -x "$(command -v ldconfig)" ]; then
-            echo "ldconfig is not in PATH, trying /sbin/ldconfig."
-            LDCONFIG_COMMAND="/sbin/ldconfig"
+        if is_musl_based_distro; then
+            if ! command -v scanelf > /dev/null; then
+                say_warning "scanelf not found, please install pax-utils package."
+                return 0
+            fi
+            LDCONFIG_COMMAND="scanelf --ldpath -BF '%f'"
+            [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libintl)" ] && say_warning "Unable to locate libintl. Probable prerequisite missing; install libintl (or gettext)."
         else
-            LDCONFIG_COMMAND="ldconfig"
+            if [ ! -x "$(command -v ldconfig)" ]; then
+                say_verbose "ldconfig is not in PATH, trying /sbin/ldconfig."
+                LDCONFIG_COMMAND="/sbin/ldconfig"
+            else
+                LDCONFIG_COMMAND="ldconfig"
+            fi
+            local librarypath=${LD_LIBRARY_PATH:-}
+            LDCONFIG_COMMAND="$LDCONFIG_COMMAND -NXv ${librarypath//:/ }"
         fi
 
-        local librarypath=${LD_LIBRARY_PATH:-}
-        LDCONFIG_COMMAND="$LDCONFIG_COMMAND -NXv ${librarypath//:/ }"
-
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libunwind)" ] && say_warning "Unable to locate libunwind. Probable prerequisite missing; install libunwind."
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libssl)" ] && say_warning "Unable to locate libssl. Probable prerequisite missing; install libssl."
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep zlib)" ] && say_warning "Unable to locate zlib. Probable prerequisite missing; install zlib."
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep ssl)" ] && say_warning "Unable to locate libssl. Probable prerequisite missing; install libssl."
         [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libicu)" ] && say_warning "Unable to locate libicu. Probable prerequisite missing; install libicu."
-        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep -F libcurl.so)" ] && say_warning "Unable to locate libcurl. Probable prerequisite missing; install libcurl."
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep lttng)" ] && say_warning "Unable to locate liblttng. Probable prerequisite missing; install libcurl."
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libcurl)" ] && say_warning "Unable to locate libcurl. Probable prerequisite missing; install libcurl."
     fi
 
     return 0
@@ -360,7 +373,7 @@ get_normalized_architecture_from_architecture() {
             ;;
     esac
 
-    say_err "Architecture \`$architecture\` not supported. If you think this is a bug, report it at https://github.com/dotnet/cli/issues"
+    say_err "Architecture \`$architecture\` not supported. If you think this is a bug, report it at https://github.com/dotnet/sdk/issues"
     return 1
 }
 
@@ -471,6 +484,7 @@ parse_jsonfile_for_version() {
         return 1
     fi
 
+    unset IFS;
     echo "$version_info"
     return 0
 }
@@ -631,7 +645,7 @@ copy_files_or_dirs_from_list() {
     local osname="$(get_current_os_name)"
     local override_switch=$(
         if [ "$override" = false ]; then
-            if [[ "$osname" == "linux-musl" ]]; then
+            if [ "$osname" = "linux-musl" ]; then
                 printf -- "-u";
             else
                 printf -- "-n";
@@ -840,13 +854,27 @@ install_dotnet() {
     say "Extracting zip from $download_link"
     extract_dotnet_package "$zip_path" "$install_root"
 
-    #  Check if the SDK version is now installed; if not, fail the installation.
-    if ! is_dotnet_package_installed "$install_root" "$asset_relative_path" "$specific_version"; then
-        say_err "\`$asset_name\` with version = $specific_version failed to install with an unknown error."
-        return 1
+    #  Check if the SDK version is installed; if not, fail the installation.
+    # if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.
+    if [[ $specific_version == *"rtm"* || $specific_version == *"servicing"* ]]; then
+        IFS='-'
+        read -ra verArr <<< "$specific_version"
+        release_version="${verArr[0]}"
+        unset IFS;
+        say_verbose "Checking installation: version = $release_version"
+        if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$release_version"; then
+            return 0
+        fi
     fi
 
-    return 0
+    #  Check if the standard SDK version is installed.
+    say_verbose "Checking installation: version = $specific_version"
+    if is_dotnet_package_installed "$install_root" "$asset_relative_path" "$specific_version"; then
+        return 0
+    fi
+
+    say_err "\`$asset_name\` with version = $specific_version failed to install with an unknown error."
+    return 1
 }
 
 args=("$@")


### PR DESCRIPTION
The call to translate variable values based on the step target was missing for the variable expansion methods. Previously, the value of the variable was reset once it was determined to be inside a container at the beginning of the job. With the introduction of step targets, we needed this to be dynamic per step. 