### PR TITLE
Support building on 32-bit personality profile on ARM64 processors

### DIFF
--- a/src/Misc/dotnet-install.sh
+++ b/src/Misc/dotnet-install.sh
@@ -332,7 +332,7 @@ get_machine_architecture() {
     if command -v uname > /dev/null; then
         CPUName=$(uname -m)
         case $CPUName in
-        armv7l)
+        armv*l)
             echo "arm"
             return 0
             ;;

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -47,7 +47,7 @@ function detect_platform_and_runtime_id ()
         if command -v uname > /dev/null; then
             local CPU_NAME=$(uname -m)
             case $CPU_NAME in
-                armv7l) DETECTED_RUNTIME_ID="linux-arm";;
+                armv*l) DETECTED_RUNTIME_ID="linux-arm";;
                 aarch64) DETECTED_RUNTIME_ID="linux-arm";;
             esac
         fi


### PR DESCRIPTION
`uname -m` on ARM64 processors using 32-bit personality shows as `armv8l`, not `armv7l`. See https://github.com/torvalds/linux/blob/cef7298262e9af841fb70d8673af45caf55300a1/arch/arm64/include/asm/compat.h#L22

This allows building on 64-bit ARM machines in a 32-bit environment. Without this patch, the build system thinks 32-bit personality on ARM64 is linux-x64, and the build explodes accordingly.

32-bit personality allows building ARM32 code on modern ARM64 systems, which in this day and age are easier to obtain with decent performance characteristics.

```
builder@xam-softiron-1:~$ uname -a
Linux xam-softiron-1 4.17.0ilp32-31333-gb2d7ec3 #1 SMP Tue Oct 16 16:37:20 EDT 2018 aarch64 aarch64 aarch64 GNU/Linux
builder@xam-softiron-1:~$ linux32 uname -a
Linux xam-softiron-1 4.17.0ilp32-31333-gb2d7ec3 #1 SMP Tue Oct 16 16:37:20 EDT 2018 armv8l armv8l armv8l GNU/Linux
```