### PR TITLE
Updated ARM build timeout

### DIFF
--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -125,6 +125,7 @@ jobs:
     name: buildDevs
     demands: 'Agent.OSArchitecture -equals ARM'
   container: dotnetcore_arm
+  timeoutInMinutes: 75
   steps:
 
   # Steps template for non-windows platform


### PR DESCRIPTION
ARM builds have started taking longer, and needed to bump the timeout to unblock