### PR TITLE
Always checkout git repo by commit for a PR if SHA is present

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -804,6 +804,10 @@ namespace Agent.Plugins.Repository
             List<string> additionalFetchSpecs = new List<string>();
             string refFetchedByCommit = null;
 
+            executionContext.Debug($"fetchDepth : {fetchDepth}");
+            executionContext.Debug($"fetchByCommit : {fetchByCommit}");
+            executionContext.Debug($"sourceVersion : {sourceVersion}");
+
             if (IsPullRequest(sourceBranch))
             {
                 // Build a 'fetch-by-commit' refspec iff the server allows us to do so in the shallow fetch scenario
@@ -844,12 +848,13 @@ namespace Agent.Plugins.Repository
             cancellationToken.ThrowIfCancellationRequested();
             executionContext.Progress(80, "Starting checkout...");
             string sourcesToBuild;
-
+            executionContext.Debug($"refFetchedByCommit : {refFetchedByCommit}");
+            
             if (refFetchedByCommit != null)
             {
                 sourcesToBuild = refFetchedByCommit;
             }
-            else if (IsPullRequest(sourceBranch) || string.IsNullOrEmpty(sourceVersion))
+            else if (IsPullRequest(sourceBranch) && string.IsNullOrEmpty(sourceVersion))
             {
                 sourcesToBuild = GetRemoteRefName(sourceBranch);
             }


### PR DESCRIPTION
#2283 introduced a regression where a GitHub repo was using branch ref instead of the commit id for checkout on a build triggered by a pull request. This PR fixes the bug by updating the condition to allow for the checkout by branch ref only if the SHA is not present for the PR. Also added few debug log statements. 