### PR TITLE
Refactored to remove stringly-typed bindings from AgentPluginManager

### DIFF
--- a/src/Agent.Worker/AgentPluginManager.cs
+++ b/src/Agent.Worker/AgentPluginManager.cs
@@ -8,8 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Loader;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
 using Microsoft.TeamFoundation.Framework.Common;
@@ -27,54 +25,39 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     {
         private readonly Dictionary<Guid, List<string>> _supportedTasks = new Dictionary<Guid, List<string>>();
 
-        private readonly HashSet<string> _taskPlugins = new HashSet<string>()
-        {
-            "Agent.Plugins.Repository.CheckoutTask, Agent.Plugins",
-            "Agent.Plugins.Repository.CleanupTask, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTask, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTask, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV1, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_0, Agent.Plugins",
-            "Agent.Plugins.PipelineCache.SavePipelineCacheV0, Agent.Plugins",
-            "Agent.Plugins.PipelineCache.RestorePipelineCacheV0, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_1, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_2, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_3, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV2_0_0, Agent.Plugins",
-            "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV0_140_0, Agent.Plugins"
-        };
+        private HashSet<string> _taskPlugins = new HashSet<string>();
 
         public override void Initialize(IHostContext hostContext)
         {
             base.Initialize(hostContext);
-
-            // Load task plugins
-            foreach (var pluginTypeName in _taskPlugins)
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                IAgentTaskPlugin taskPlugin = null;
-                AssemblyLoadContext.Default.Resolving += ResolveAssembly;
                 try
                 {
-                    Trace.Info($"Load task plugin from '{pluginTypeName}'.");
-                    Type type = Type.GetType(pluginTypeName, throwOnError: true);
-                    taskPlugin = Activator.CreateInstance(type) as IAgentTaskPlugin;
-                }
-                finally
-                {
-                    AssemblyLoadContext.Default.Resolving -= ResolveAssembly;
-                }
+                    foreach (var type in assembly.GetTypes())
+                    {
+                        if (typeof(IAgentTaskPlugin).IsAssignableFrom(type) && !type.IsInterface && !type.IsAbstract)
+                        {
+                            IAgentTaskPlugin taskPlugin = Activator.CreateInstance(type) as IAgentTaskPlugin;
+                            ArgUtil.NotNull(taskPlugin, nameof(taskPlugin));
+                            ArgUtil.NotNull(taskPlugin.Id, nameof(taskPlugin.Id));
+                            ArgUtil.NotNullOrEmpty(taskPlugin.Stage, nameof(taskPlugin.Stage));
+                            if (!_supportedTasks.ContainsKey(taskPlugin.Id))
+                            {
+                                _supportedTasks[taskPlugin.Id] = new List<string>();
+                            }
 
-                ArgUtil.NotNull(taskPlugin, nameof(taskPlugin));
-                ArgUtil.NotNull(taskPlugin.Id, nameof(taskPlugin.Id));
-                ArgUtil.NotNullOrEmpty(taskPlugin.Stage, nameof(taskPlugin.Stage));
-                if (!_supportedTasks.ContainsKey(taskPlugin.Id))
-                {
-                    _supportedTasks[taskPlugin.Id] = new List<string>();
+                            Trace.Info($"Loaded task plugin id '{taskPlugin.Id}' ({taskPlugin.Stage}).");
+                            var pluginTypeName = $"{type.FullName}, {assembly.FullName.Split(',')[0]}";
+                            _taskPlugins.Add(pluginTypeName);
+                            _supportedTasks[taskPlugin.Id].Add(pluginTypeName);
+                        }
+                    }
                 }
-
-                Trace.Info($"Loaded task plugin id '{taskPlugin.Id}' ({taskPlugin.Stage}).");
-                _supportedTasks[taskPlugin.Id].Add(pluginTypeName);
+                catch (ReflectionTypeLoadException)
+                {
+                    // ignore exceptions for assemblies we cannnot load
+                }
             }
         }
 
@@ -163,12 +146,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                                   redirectStandardIn: redirectStandardIn,
                                                   cancellationToken: context.CancellationToken);
             }
-        }
-
-        private Assembly ResolveAssembly(AssemblyLoadContext context, AssemblyName assembly)
-        {
-            string assemblyFilename = assembly.Name + ".dll";
-            return context.LoadFromAssemblyPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), assemblyFilename));
         }
     }
 }

--- a/src/Agent.Worker/AgentPluginManager.cs
+++ b/src/Agent.Worker/AgentPluginManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             base.Initialize(hostContext);
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                try
+                if (assembly.FullName.StartsWith("Agent.", StringComparison.OrdinalIgnoreCase))
                 {
                     foreach (var type in assembly.GetTypes())
                     {
@@ -53,10 +53,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             _supportedTasks[taskPlugin.Id].Add(pluginTypeName);
                         }
                     }
-                }
-                catch (ReflectionTypeLoadException)
-                {
-                    // ignore exceptions for assemblies we cannnot load
                 }
             }
         }

--- a/src/Agent.Worker/AgentPluginManager.cs
+++ b/src/Agent.Worker/AgentPluginManager.cs
@@ -20,14 +20,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     public interface IAgentPluginManager : IAgentService
     {
         List<string> GetTaskPlugins(Guid taskId);
-        AgentCommandPluginInfo GetPluginCommad(string commandArea, string commandEvent);
         Task RunPluginTaskAsync(IExecutionContext context, string plugin, Dictionary<string, string> inputs, Dictionary<string, string> environment, Variables runtimeVariables, EventHandler<ProcessDataReceivedEventArgs> outputHandler);
-        void ProcessCommand(IExecutionContext context, Command command);
     }
 
     public sealed class AgentPluginManager : AgentService, IAgentPluginManager
     {
-        private readonly Dictionary<string, Dictionary<string, AgentCommandPluginInfo>> _supportedLoggingCommands = new Dictionary<string, Dictionary<string, AgentCommandPluginInfo>>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<Guid, List<string>> _supportedTasks = new Dictionary<Guid, List<string>>();
 
         private readonly HashSet<string> _taskPlugins = new HashSet<string>()
@@ -47,8 +44,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV2_0_0, Agent.Plugins",
             "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV0_140_0, Agent.Plugins"
         };
-
-        private readonly HashSet<string> _commandPlugins = new HashSet<string>();
 
         public override void Initialize(IHostContext hostContext)
         {
@@ -81,36 +76,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Trace.Info($"Loaded task plugin id '{taskPlugin.Id}' ({taskPlugin.Stage}).");
                 _supportedTasks[taskPlugin.Id].Add(pluginTypeName);
             }
-
-            // Load command plugin
-            foreach (var pluginTypeName in _commandPlugins)
-            {
-                IAgentCommandPlugin commandPlugin = null;
-                AssemblyLoadContext.Default.Resolving += ResolveAssembly;
-                try
-                {
-                    Trace.Info($"Load command plugin from '{pluginTypeName}'.");
-                    Type type = Type.GetType(pluginTypeName, throwOnError: true);
-                    commandPlugin = Activator.CreateInstance(type) as IAgentCommandPlugin;
-                }
-                finally
-                {
-                    AssemblyLoadContext.Default.Resolving -= ResolveAssembly;
-                }
-
-                ArgUtil.NotNull(commandPlugin, nameof(commandPlugin));
-                ArgUtil.NotNullOrEmpty(commandPlugin.Area, nameof(commandPlugin.Area));
-                ArgUtil.NotNullOrEmpty(commandPlugin.Event, nameof(commandPlugin.Event));
-                ArgUtil.NotNullOrEmpty(commandPlugin.DisplayName, nameof(commandPlugin.DisplayName));
-
-                if (!_supportedLoggingCommands.ContainsKey(commandPlugin.Area))
-                {
-                    _supportedLoggingCommands[commandPlugin.Area] = new Dictionary<string, AgentCommandPluginInfo>(StringComparer.OrdinalIgnoreCase);
-                }
-
-                Trace.Info($"Loaded command plugin to handle '##vso[{commandPlugin.Area}.{commandPlugin.Event}]'.");
-                _supportedLoggingCommands[commandPlugin.Area][commandPlugin.Event] = new AgentCommandPluginInfo() { CommandPluginTypeName = pluginTypeName, DisplayName = commandPlugin.DisplayName };
-            }
         }
 
         public List<string> GetTaskPlugins(Guid taskId)
@@ -118,18 +83,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             if (_supportedTasks.ContainsKey(taskId))
             {
                 return _supportedTasks[taskId];
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        public AgentCommandPluginInfo GetPluginCommad(string commandArea, string commandEvent)
-        {
-            if (_supportedLoggingCommands.ContainsKey(commandArea) && _supportedLoggingCommands[commandArea].ContainsKey(commandEvent))
-            {
-                return _supportedLoggingCommands[commandArea][commandEvent];
             }
             else
             {
@@ -212,121 +165,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        public void ProcessCommand(IExecutionContext context, Command command)
-        {
-            // queue async command task to run agent plugin.
-            context.Debug($"Process {command.Area}.{command.Event} command through agent plugin in backend.");
-            if (!_supportedLoggingCommands.ContainsKey(command.Area) ||
-                !_supportedLoggingCommands[command.Area].ContainsKey(command.Event))
-            {
-                throw new NotSupportedException(command.ToString());
-            }
-
-            var plugin = _supportedLoggingCommands[command.Area][command.Event];
-            ArgUtil.NotNull(plugin, nameof(plugin));
-            ArgUtil.NotNullOrEmpty(plugin.DisplayName, nameof(plugin.DisplayName));
-
-            // construct plugin context
-            AgentCommandPluginExecutionContext pluginContext = new AgentCommandPluginExecutionContext
-            {
-                Data = command.Data,
-                Properties = command.Properties,
-                Endpoints = context.Endpoints,
-            };
-
-            var target = context.StepTarget();
-            Variables.TranslationMethod translateToHostPath = Variables.DefaultStringTranslator;
-
-            ContainerInfo containerInfo = target as ContainerInfo;
-            // Since plugins run on the host, but the inputs and variables have already been translated
-            // to the container path, we need to convert them back to the host path
-            // TODO: look to see if there is a better way to not have translate these back
-            if (containerInfo != null)
-            {
-                translateToHostPath = (string val) => { return containerInfo.TranslateToHostPath(val); };
-            }
-            // variables
-            context.Variables.CopyInto(pluginContext.Variables, translateToHostPath);
-
-            var commandContext = HostContext.CreateService<IAsyncCommandContext>();
-            commandContext.InitializeCommandContext(context, plugin.DisplayName);
-            commandContext.Task = ProcessPluginCommandAsync(commandContext, pluginContext, plugin.CommandPluginTypeName, command, context.CancellationToken);
-            context.AsyncCommands.Add(commandContext);
-        }
-
-        private async Task ProcessPluginCommandAsync(IAsyncCommandContext context, AgentCommandPluginExecutionContext pluginContext, string plugin, Command command, CancellationToken token)
-        {
-            // Resolve the working directory.
-            string workingDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
-            ArgUtil.Directory(workingDirectory, nameof(workingDirectory));
-
-            // Agent.PluginHost
-            string file = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), $"Agent.PluginHost{Util.IOUtil.ExeExtension}");
-
-            // Agent.PluginHost's arguments
-            string arguments = $"command \"{plugin}\"";
-
-            // Execute the process. Exit code 0 should always be returned.
-            // A non-zero exit code indicates infrastructural failure.
-            // Any content coming from STDERR will indicate the command process failed.
-            // We can't use ## command for plugin to communicate, since we are already processing ## command
-            using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
-            {
-                object stderrLock = new object();
-                List<string> stderr = new List<string>();
-                processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
-                {
-                    context.Output(e.Data);
-                };
-                processInvoker.ErrorDataReceived += (object sender, ProcessDataReceivedEventArgs e) =>
-                {
-                    lock (stderrLock)
-                    {
-                        stderr.Add(e.Data);
-                    };
-                };
-
-                var redirectStandardIn = new InputQueue<string>();
-                redirectStandardIn.Enqueue(JsonUtility.ToString(pluginContext));
-
-                int returnCode = await processInvoker.ExecuteAsync(workingDirectory: workingDirectory,
-                                                                   fileName: file,
-                                                                   arguments: arguments,
-                                                                   environment: null,
-                                                                   requireExitCodeZero: false,
-                                                                   outputEncoding: null,
-                                                                   killProcessOnCancel: false,
-                                                                   redirectStandardIn: redirectStandardIn,
-                                                                   cancellationToken: token);
-
-                if (returnCode != 0)
-                {
-                    context.Output(string.Join(Environment.NewLine, stderr));
-                    throw new ProcessExitCodeException(returnCode, file, arguments);
-                }
-                else if (stderr.Count > 0)
-                {
-                    throw new InvalidOperationException(string.Join(Environment.NewLine, stderr));
-                }
-                else
-                {
-                    // Everything works fine.
-                    // Return code is 0.
-                    // No STDERR comes out.
-                }
-            }
-        }
-
         private Assembly ResolveAssembly(AssemblyLoadContext context, AssemblyName assembly)
         {
             string assemblyFilename = assembly.Name + ".dll";
             return context.LoadFromAssemblyPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), assemblyFilename));
         }
-    }
-
-    public class AgentCommandPluginInfo
-    {
-        public string CommandPluginTypeName { get; set; }
-        public string DisplayName { get; set; }
     }
 }

--- a/src/Agent.Worker/AgentPluginManager.cs
+++ b/src/Agent.Worker/AgentPluginManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             base.Initialize(hostContext);
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                if (assembly.FullName.StartsWith("Agent.", StringComparison.OrdinalIgnoreCase))
+                if (assembly.FullName.StartsWith("Agent.Plugins", StringComparison.OrdinalIgnoreCase))
                 {
                     foreach (var type in assembly.GetTypes())
                     {

--- a/src/Test/L0/Worker/AgentPluginManagerL0.cs
+++ b/src/Test/L0/Worker/AgentPluginManagerL0.cs
@@ -5,11 +5,30 @@ using Xunit;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Agent.Plugins.PipelineArtifact;
 using Agent.Plugins.PipelineCache;
+using System.Collections.Generic;
+
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 {
     public sealed class AgentPluginManagerL0
     {
+
+        private class AgentPluginTaskTest
+        {
+            public string Name;
+            public Guid TaskGuid;
+            public List<string> ExpectedTaskPlugins;
+
+            public void RunTest(AgentPluginManager manager)
+            {
+                var taskPlugins = manager.GetTaskPlugins(TaskGuid);
+                Assert.True(taskPlugins.Count == ExpectedTaskPlugins.Count, $"{Name} has {ExpectedTaskPlugins.Count} Task Plugin(s)");
+                foreach (var s in ExpectedTaskPlugins)
+                {
+                    Assert.True(taskPlugins.Contains(s), $"{Name} contains '{s}'");
+                }
+            }
+        }
 
         [Fact]
         [Trait("Level", "L0")]
@@ -22,10 +41,62 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var agentPluginManager = new AgentPluginManager();
                 agentPluginManager.Initialize(tc);
 
-                Assert.True(agentPluginManager.GetTaskPlugins(Pipelines.PipelineConstants.CheckoutTask.Id).Count == 2, "Checkout Task has 2 Task Plugins");
-                Assert.True(agentPluginManager.GetTaskPlugins(PipelineArtifactPluginConstants.DownloadPipelineArtifactTaskId).Count == 7, "Download Pipline Artifact Task has 2 Task Plugins");
-                Assert.True(agentPluginManager.GetTaskPlugins(PipelineArtifactPluginConstants.PublishPipelineArtifactTaskId).Count == 3, "Publish Pipeline Artifact Task has 2 Task Plugins");
-                Assert.True(agentPluginManager.GetTaskPlugins(PipelineCachePluginConstants.CacheTaskId).Count == 2, "Pipeline Cache Task has 2 Task Plugins");
+                List<AgentPluginTaskTest> tests = new List<AgentPluginTaskTest>
+                {
+                    new AgentPluginTaskTest()
+                    {
+                        Name = "Checkout Task",
+                        TaskGuid = Pipelines.PipelineConstants.CheckoutTask.Id,
+                        ExpectedTaskPlugins = new List<string>
+                        {
+                            "Agent.Plugins.Repository.CheckoutTask, Agent.Plugins",
+                            "Agent.Plugins.Repository.CleanupTask, Agent.Plugins",
+                        }
+                    },
+                    new AgentPluginTaskTest()
+                    {
+                        Name = "Download Pipline Artifact Task",
+                        TaskGuid = PipelineArtifactPluginConstants.DownloadPipelineArtifactTaskId,
+                        ExpectedTaskPlugins = new List<string>
+                        {
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTask, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_0, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_1, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_2, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_3, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV2_0_0, Agent.Plugins",
+                        }
+                    },
+                    new AgentPluginTaskTest()
+                    {
+                        Name = "Publish Pipeline Artifact Task",
+                        TaskGuid = PipelineArtifactPluginConstants.PublishPipelineArtifactTaskId,
+                        ExpectedTaskPlugins = new List<string>
+                        {
+                            "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTask, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV1, Agent.Plugins",
+                            "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV0_140_0, Agent.Plugins"
+                        }
+                    },
+                    new AgentPluginTaskTest()
+                    {
+                        Name = "Pipeline Cache Task",
+                        TaskGuid = PipelineCachePluginConstants.CacheTaskId,
+                        ExpectedTaskPlugins = new List<string>
+                        {
+                            "Agent.Plugins.PipelineCache.SavePipelineCacheV0, Agent.Plugins",
+                            "Agent.Plugins.PipelineCache.RestorePipelineCacheV0, Agent.Plugins",
+                        }
+                    },
+                };
+
+                foreach (var test in tests)
+                {
+                    test.RunTest(agentPluginManager);
+                }
+
+
             }
         }
 

--- a/src/Test/L0/Worker/AgentPluginManagerL0.cs
+++ b/src/Test/L0/Worker/AgentPluginManagerL0.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.VisualStudio.Services.Agent.Worker;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using Agent.Plugins.PipelineArtifact;
+using Agent.Plugins.PipelineCache;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
+{
+    public sealed class AgentPluginManagerL0
+    {
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void SimpleTests()
+        {
+            using (TestHostContext tc = CreateTestContext())
+            {
+                Tracing trace = tc.GetTrace();
+                var agentPluginManager = new AgentPluginManager();
+                agentPluginManager.Initialize(tc);
+
+                Assert.True(agentPluginManager.GetTaskPlugins(Pipelines.PipelineConstants.CheckoutTask.Id).Count == 2, "Checkout Task has 2 Task Plugins");
+                Assert.True(agentPluginManager.GetTaskPlugins(PipelineArtifactPluginConstants.DownloadPipelineArtifactTaskId).Count == 7, "Download Pipline Artifact Task has 2 Task Plugins");
+                Assert.True(agentPluginManager.GetTaskPlugins(PipelineArtifactPluginConstants.PublishPipelineArtifactTaskId).Count == 3, "Publish Pipeline Artifact Task has 2 Task Plugins");
+                Assert.True(agentPluginManager.GetTaskPlugins(PipelineCachePluginConstants.CacheTaskId).Count == 2, "Pipeline Cache Task has 2 Task Plugins");
+            }
+        }
+
+        private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
+        {
+            TestHostContext tc = new TestHostContext(this, testName);
+            return tc;
+        }
+    }
+}

--- a/src/Test/L0/Worker/AgentPluginManagerL0.cs
+++ b/src/Test/L0/Worker/AgentPluginManagerL0.cs
@@ -12,7 +12,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 {
     public sealed class AgentPluginManagerL0
     {
-
         private class AgentPluginTaskTest
         {
             public string Name;
@@ -95,8 +94,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 {
                     test.RunTest(agentPluginManager);
                 }
-
-
             }
         }
 


### PR DESCRIPTION
I am not entirely happy with how this turned out  since I just moved all the stringy-ness to the tests, but wanted to get some feedback