### PR TITLE
Fix some flaky environment tests

### DIFF
--- a/src/Agent.Listener/Program.cs
+++ b/src/Agent.Listener/Program.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 }
 
                 // Parse the command line args.
-                var command = new CommandSettings(context, args);
+                var command = new CommandSettings(context, args, new SystemEnvironment());
                 trace.Info("Arguments parsed");
 
                 // Up front validation, warn for unrecognized commandline args.

--- a/src/Agent.Sdk/ScopedEnvironment.cs
+++ b/src/Agent.Sdk/ScopedEnvironment.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Agent.Sdk
+{
+    public interface IScopedEnvironment
+    {
+        IDictionary GetEnvironmentVariables();
+        void SetEnvironmentVariable(string key, string value);
+        string GetEnvironmentVariable(string key);
+    }
+
+    public class SystemEnvironment : IScopedEnvironment
+    {
+        public IDictionary GetEnvironmentVariables()
+        {
+            return Environment.GetEnvironmentVariables();
+        }
+
+        public void SetEnvironmentVariable(string key, string value)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+
+        public string GetEnvironmentVariable(string key)
+        {
+            return Environment.GetEnvironmentVariable(key);
+        }
+    }
+
+    public class LocalEnvironment : IScopedEnvironment
+    {
+        private Dictionary<string,string> _delegate = null;
+
+        public LocalEnvironment() : this(null)
+        {
+
+        }
+        
+        public LocalEnvironment(Dictionary<string,string> data)
+        {
+            _delegate = data;
+            if (_delegate == null)
+            {
+                _delegate = new Dictionary<string, string>();
+            }
+        }
+
+        public IDictionary GetEnvironmentVariables()
+        {
+            // we have to return a new collection here because this method
+            // is used in foreach statements that modify the environment. This 
+            // is allowed from Environment class since the methods are not typed to a
+            // a single object.
+            return new Dictionary<string,string>(_delegate);
+        }
+
+        public void SetEnvironmentVariable(string key, string value)
+        {
+            _delegate[key] = value;
+        }
+
+        public string GetEnvironmentVariable(string key)
+        {
+            return _delegate.GetValueOrDefault(key);
+        }
+    }
+}

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 var environment = new LocalEnvironment();
                 // Arrange.
                 environment.SetEnvironmentVariable(envVarName, expected);
-                var command = new CommandSettings(hc, args: new string[0], environment);
+                var command = new CommandSettings(hc, args: new string[0], environmentScope: environment);
 
                 // Act.
                 MethodInfo mi = command.GetType().GetMethod(accessor);
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                  var environment = new LocalEnvironment();
                 // Arrange.
                 environment.SetEnvironmentVariable(envVarName, expected);
-                var command = new CommandSettings(hc, args: new string[0], environment);
+                var command = new CommandSettings(hc, args: new string[0], environmentScope: environment);
 
                 // Act.
                 MethodInfo mi = command.GetType().GetMethod(accessor);
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 var environment = new LocalEnvironment();
                 // Arrange.
                 environment.SetEnvironmentVariable(envVarName, "true");
-                var command = new CommandSettings(hc, args: new string[0], environment);
+                var command = new CommandSettings(hc, args: new string[0], environmentScope: environment);
 
                 // Act.
                 PropertyInfo pi = command.GetType().GetProperty(flag);

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -38,23 +38,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
         }
 
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", nameof(CommandSettings))]
-        [InlineData("agent", "GetAgentName", "some agent")]
-        public void GetsArgFromEnvVar(String arg, String accessor, String expected)
+        public void GetsArgFromEnvVar()
         {
             using (TestHostContext hc = CreateTestContext())
             {
-                var envVarName = "VSTS_AGENT_INPUT_" + arg.ToUpperInvariant();
+                var envVarName = "VSTS_AGENT_INPUT_AGENT";
+                var expected = "some agent";
                 var environment = new LocalEnvironment();
                 // Arrange.
                 environment.SetEnvironmentVariable(envVarName, expected);
                 var command = new CommandSettings(hc, args: new string[0], environmentScope: environment);
 
                 // Act.
-                MethodInfo mi = command.GetType().GetMethod(accessor);
-                var actual = (string)mi.Invoke(command, null);
+                var actual = command.GetAgentName();
 
                 // Assert.
                 Assert.Equal(expected, actual);
@@ -63,23 +62,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
         }
 
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", nameof(CommandSettings))]
-        [InlineData("token", "GetToken", "some secret token value")]
-        public void GetsArgSecretFromEnvVar(String arg, String accessor, String expected)
+        public void GetsArgSecretFromEnvVar()
         {
             using (TestHostContext hc = CreateTestContext())
             {
-                var envVarName = "VSTS_AGENT_INPUT_" + arg.ToUpperInvariant();
-                 var environment = new LocalEnvironment();
+                var envVarName = "VSTS_AGENT_INPUT_TOKEN";
+                var expected = "some secret token value";
+                var environment = new LocalEnvironment();
                 // Arrange.
                 environment.SetEnvironmentVariable(envVarName, expected);
                 var command = new CommandSettings(hc, args: new string[0], environmentScope: environment);
 
                 // Act.
-                MethodInfo mi = command.GetType().GetMethod(accessor);
-                var actual = (string)mi.Invoke(command, null);
+                var actual = command.GetToken();
 
                 // Assert.
                 Assert.Equal(expected, actual);
@@ -250,23 +248,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
         }
 
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", nameof(CommandSettings))]
-        [InlineData("Unattended")]
-        public void GetsFlagFromEnvVar(string flag)
+        public void GetsFlagUnattendedFromEnvVar()
         {
             using (TestHostContext hc = CreateTestContext())
             {
-                var envVarName = "VSTS_AGENT_INPUT_" + flag.ToUpperInvariant();
+                var envVarName = "VSTS_AGENT_INPUT_UNATTENDED";
                 var environment = new LocalEnvironment();
                 // Arrange.
                 environment.SetEnvironmentVariable(envVarName, "true");
                 var command = new CommandSettings(hc, args: new string[0], environmentScope: environment);
 
                 // Act.
-                PropertyInfo pi = command.GetType().GetProperty(flag);
-                bool actual = (bool)pi.GetValue(command);
+                bool actual = command.Unattended;
 
                 // Assert.
                 Assert.Equal(true, actual);


### PR DESCRIPTION
This PR attempts to address two flaky environment tests

One is how we attempt to read environment variables from a child process
on windows. For this, I updated the code original referenced to an
updated version from the author.

The second is a refactor that to fix flaky tests that rely on
Environment since they run in parallel and appear to collide
occasionally