### PR TITLE
Add static analysis

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />

--- a/src/Agent.PluginHost/Agent.PluginHost.csproj
+++ b/src/Agent.PluginHost/Agent.PluginHost.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Agent.Sdk\Agent.Sdk.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />
   </ItemGroup>

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />

--- a/src/Agent.Service/Windows/AgentService.csproj
+++ b/src/Agent.Service/Windows/AgentService.csproj
@@ -39,6 +39,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />

--- a/src/Common.props
+++ b/src/Common.props
@@ -50,6 +50,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <DefineConstants>$(OSPlatform);$(OSArchitecture);$(DebugConstant);TRACE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Common.props
+++ b/src/Common.props
@@ -49,10 +49,10 @@
     <OSArchitecture>ARM</OSArchitecture>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <!-- <PropertyGroup>
     <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>true</RunCodeAnalysis>
-  </PropertyGroup>
+  </PropertyGroup> -->
 
   <PropertyGroup>
     <DefineConstants>$(OSPlatform);$(OSArchitecture);$(DebugConstant);TRACE</DefineConstants>

--- a/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
+++ b/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />

--- a/src/rules.ruleset
+++ b/src/rules.ruleset
@@ -1,0 +1,210 @@
+<?xml version="1.0"?>
+<RuleSet Name="All Rules Enabled with default severity" Description="All Rules are enabled with default severity. Rules with IsEnabledByDefault = false are force enabled with default severity." ToolsVersion="15.0">
+   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Rule Id="CA1000" Action="Warning" />          <!-- Do not declare static members on generic types -->
+      <Rule Id="CA1001" Action="Warning" />          <!-- Types that own disposable fields should be disposable -->
+      <Rule Id="CA1003" Action="Warning" />          <!-- Use generic event handler instances -->
+      <Rule Id="CA1008" Action="Warning" />          <!-- Enums should have zero value -->
+      <Rule Id="CA1010" Action="Warning" />          <!-- Collections should implement generic interface -->
+      <Rule Id="CA1012" Action="Warning" />          <!-- Abstract types should not have constructors -->
+      <Rule Id="CA1014" Action="Warning" />          <!-- Mark assemblies with CLSCompliant -->
+      <Rule Id="CA1016" Action="Warning" />          <!-- Mark assemblies with assembly version -->
+      <Rule Id="CA1017" Action="Warning" />          <!-- Mark assemblies with ComVisible -->
+      <Rule Id="CA1018" Action="Warning" />          <!-- Mark attributes with AttributeUsageAttribute -->
+      <Rule Id="CA1019" Action="Warning" />          <!-- Define accessors for attribute arguments -->
+      <Rule Id="CA1024" Action="Warning" />          <!-- Use properties where appropriate -->
+      <Rule Id="CA1027" Action="Warning" />          <!-- Mark enums with FlagsAttribute -->
+      <Rule Id="CA1028" Action="Warning" />          <!-- Enum Storage should be Int32 -->
+      <Rule Id="CA1030" Action="Warning" />          <!-- Use events where appropriate -->
+      <Rule Id="CA1031" Action="Warning" />          <!-- Do not catch general exception types -->
+      <Rule Id="CA1032" Action="Warning" />          <!-- Implement standard exception constructors -->
+      <Rule Id="CA1033" Action="Warning" />          <!-- Interface methods should be callable by child types -->
+      <Rule Id="CA1034" Action="Warning" />          <!-- Nested types should not be visible -->
+      <Rule Id="CA1036" Action="Warning" />          <!-- Override methods on comparable types -->
+      <Rule Id="CA1040" Action="Warning" />          <!-- Avoid empty interfaces -->
+      <Rule Id="CA1041" Action="Warning" />          <!-- Provide ObsoleteAttribute message -->
+      <Rule Id="CA1043" Action="Warning" />          <!-- Use Integral Or String Argument For Indexers -->
+      <Rule Id="CA1044" Action="Warning" />          <!-- Properties should not be write only -->
+      <Rule Id="CA1050" Action="Warning" />          <!-- Declare types in namespaces -->
+      <Rule Id="CA1051" Action="Warning" />          <!-- Do not declare visible instance fields -->
+      <Rule Id="CA1052" Action="Warning" />          <!-- Static holder types should be Static or NotInheritable -->
+      <Rule Id="CA1054" Action="Warning" />          <!-- Uri parameters should not be strings -->
+      <Rule Id="CA1055" Action="Warning" />          <!-- Uri return values should not be strings -->
+      <Rule Id="CA1056" Action="Warning" />          <!-- Uri properties should not be strings -->
+      <Rule Id="CA1058" Action="Warning" />          <!-- Types should not extend certain base types -->
+      <Rule Id="CA1060" Action="Warning" />          <!-- Move pinvokes to native methods class -->
+      <Rule Id="CA1061" Action="Warning" />          <!-- Do not hide base class methods -->
+      <Rule Id="CA1062" Action="Warning" />          <!-- Validate arguments of public methods -->
+      <Rule Id="CA1063" Action="Warning" />          <!-- Implement IDisposable Correctly -->
+      <Rule Id="CA1064" Action="Warning" />          <!-- Exceptions should be public -->
+      <Rule Id="CA1065" Action="Warning" />          <!-- Do not raise exceptions in unexpected locations -->
+      <Rule Id="CA1066" Action="Warning" />          <!-- Type {0} should implement IEquatable<T> because it overrides Equals -->
+      <Rule Id="CA1067" Action="Warning" />          <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
+      <Rule Id="CA1068" Action="Warning" />          <!-- CancellationToken parameters must come last -->
+      <Rule Id="CA1200" Action="Warning" />          <!-- Avoid using cref tags with a prefix -->
+      <Rule Id="CA1303" Action="Warning" />          <!-- Do not pass literals as localized parameters -->
+      <Rule Id="CA1304" Action="Warning" />          <!-- Specify CultureInfo -->
+      <Rule Id="CA1305" Action="Warning" />          <!-- Specify IFormatProvider -->
+      <Rule Id="CA1307" Action="Warning" />          <!-- Specify StringComparison -->
+      <Rule Id="CA1308" Action="Warning" />          <!-- Normalize strings to uppercase -->
+      <Rule Id="CA1309" Action="Warning" />          <!-- Use ordinal stringcomparison -->
+      <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
+      <Rule Id="CA1501" Action="Warning" />          <!-- Avoid excessive inheritance -->
+      <Rule Id="CA1502" Action="Warning" />          <!-- Avoid excessive complexity -->
+      <Rule Id="CA1505" Action="Warning" />          <!-- Avoid unmaintainable code -->
+      <Rule Id="CA1506" Action="Warning" />          <!-- Avoid excessive class coupling -->
+      <Rule Id="CA1507" Action="Warning" />          <!-- Use nameof to express symbol names -->
+      <Rule Id="CA1508" Action="Warning" />          <!-- Avoid dead conditional code -->
+      <Rule Id="CA1509" Action="Warning" />          <!-- Invalid entry in code metrics rule specification file -->
+      <Rule Id="CA1707" Action="Warning" />          <!-- Identifiers should not contain underscores -->
+      <Rule Id="CA1708" Action="Warning" />          <!-- Identifiers should differ by more than case -->
+      <Rule Id="CA1710" Action="Warning" />          <!-- Identifiers should have correct suffix -->
+      <Rule Id="CA1711" Action="Warning" />          <!-- Identifiers should not have incorrect suffix -->
+      <Rule Id="CA1712" Action="Warning" />          <!-- Do not prefix enum values with type name -->
+      <Rule Id="CA1714" Action="Warning" />          <!-- Flags enums should have plural names -->
+      <Rule Id="CA1715" Action="Warning" />          <!-- Identifiers should have correct prefix -->
+      <Rule Id="CA1716" Action="Warning" />          <!-- Identifiers should not match keywords -->
+      <Rule Id="CA1717" Action="Warning" />          <!-- Only FlagsAttribute enums should have plural names -->
+      <Rule Id="CA1720" Action="Warning" />          <!-- Identifier contains type name -->
+      <Rule Id="CA1721" Action="Warning" />          <!-- Property names should not match get methods -->
+      <Rule Id="CA1724" Action="Warning" />          <!-- Type names should not match namespaces -->
+      <Rule Id="CA1725" Action="Warning" />          <!-- Parameter names should match base declaration -->
+      <Rule Id="CA1801" Action="Warning" />          <!-- Review unused parameters -->
+      <Rule Id="CA1802" Action="Warning" />          <!-- Use literals where appropriate -->
+      <Rule Id="CA1806" Action="Warning" />          <!-- Do not ignore method results -->
+      <Rule Id="CA1810" Action="Warning" />          <!-- Initialize reference type static fields inline -->
+      <Rule Id="CA1812" Action="Warning" />          <!-- Avoid uninstantiated internal classes -->
+      <Rule Id="CA1813" Action="Warning" />          <!-- Avoid unsealed attributes -->
+      <Rule Id="CA1814" Action="Warning" />          <!-- Prefer jagged arrays over multidimensional -->
+      <Rule Id="CA1815" Action="Warning" />          <!-- Override equals and operator equals on value types -->
+      <Rule Id="CA1816" Action="Warning" />          <!-- Dispose methods should call SuppressFinalize -->
+      <Rule Id="CA1819" Action="Warning" />          <!-- Properties should not return arrays -->
+      <Rule Id="CA1820" Action="Warning" />          <!-- Test for empty strings using string length -->
+      <Rule Id="CA1821" Action="Warning" />          <!-- Remove empty Finalizers -->
+      <Rule Id="CA1822" Action="Warning" />          <!-- Mark members as static -->
+      <Rule Id="CA1823" Action="Warning" />          <!-- Avoid unused private fields -->
+      <Rule Id="CA1824" Action="Warning" />          <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
+      <Rule Id="CA1825" Action="Warning" />          <!-- Avoid zero-length array allocations. -->
+      <Rule Id="CA1826" Action="Warning" />          <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+      <Rule Id="CA1827" Action="Warning" />          <!-- Do not use Count() or LongCount() when Any() can be used -->
+      <Rule Id="CA1828" Action="Warning" />          <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
+      <Rule Id="CA1829" Action="Warning" />          <!-- Use Length/Count property instead of Count() when available -->
+      <Rule Id="CA2000" Action="Warning" />          <!-- Dispose objects before losing scope -->
+      <Rule Id="CA2002" Action="Warning" />          <!-- Do not lock on objects with weak identity -->
+      <Rule Id="CA2007" Action="Warning" />          <!-- Consider calling ConfigureAwait on the awaited task -->
+      <Rule Id="CA2008" Action="Warning" />          <!-- Do not create tasks without passing a TaskScheduler -->
+      <Rule Id="CA2009" Action="Warning" />          <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
+      <Rule Id="CA2010" Action="Warning" />          <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
+      <Rule Id="CA2100" Action="Warning" />          <!-- Review SQL queries for security vulnerabilities -->
+      <Rule Id="CA2101" Action="Warning" />          <!-- Specify marshaling for P/Invoke string arguments -->
+      <Rule Id="CA2119" Action="Warning" />          <!-- Seal methods that satisfy private interfaces -->
+      <Rule Id="CA2153" Action="Warning" />          <!-- Do Not Catch Corrupted State Exceptions -->
+      <Rule Id="CA2200" Action="Warning" />          <!-- Rethrow to preserve stack details. -->
+      <Rule Id="CA2201" Action="Warning" />          <!-- Do not raise reserved exception types -->
+      <Rule Id="CA2207" Action="Warning" />          <!-- Initialize value type static fields inline -->
+      <Rule Id="CA2208" Action="Warning" />          <!-- Instantiate argument exceptions correctly -->
+      <Rule Id="CA2211" Action="Warning" />          <!-- Non-constant fields should not be visible -->
+      <Rule Id="CA2213" Action="Warning" />          <!-- Disposable fields should be disposed -->
+      <Rule Id="CA2214" Action="Warning" />          <!-- Do not call overridable methods in constructors -->
+      <Rule Id="CA2216" Action="Warning" />          <!-- Disposable types should declare finalizer -->
+      <Rule Id="CA2217" Action="Warning" />          <!-- Do not mark enums with FlagsAttribute -->
+      <Rule Id="CA2218" Action="Warning" />          <!-- Override GetHashCode on overriding Equals -->
+      <Rule Id="CA2219" Action="Warning" />          <!-- Do not raise exceptions in finally clauses -->
+      <Rule Id="CA2224" Action="Warning" />          <!-- Override Equals on overloading operator equals -->
+      <Rule Id="CA2225" Action="Warning" />          <!-- Operator overloads have named alternates -->
+      <Rule Id="CA2226" Action="Warning" />          <!-- Operators should have symmetrical overloads -->
+      <Rule Id="CA2227" Action="Warning" />          <!-- Collection properties should be read only -->
+      <Rule Id="CA2229" Action="Warning" />          <!-- Implement serialization constructors -->
+      <Rule Id="CA2231" Action="Warning" />          <!-- Overload operator equals on overriding value type Equals -->
+      <Rule Id="CA2234" Action="Warning" />          <!-- Pass system uri objects instead of strings -->
+      <Rule Id="CA2235" Action="Warning" />          <!-- Mark all non-serializable fields -->
+      <Rule Id="CA2237" Action="Warning" />          <!-- Mark ISerializable types with serializable -->
+      <Rule Id="CA2241" Action="Warning" />          <!-- Provide correct arguments to formatting methods -->
+      <Rule Id="CA2242" Action="Warning" />          <!-- Test for NaN correctly -->
+      <Rule Id="CA2243" Action="Warning" />          <!-- Attribute string literals should parse correctly -->
+      <Rule Id="CA2244" Action="Warning" />          <!-- Do not duplicate indexed element initializations -->
+      <Rule Id="CA2245" Action="Warning" />          <!-- Do not assign a property to itself. -->
+      <Rule Id="CA2246" Action="Warning" />          <!-- Assigning symbol and its member in the same statement. -->
+      <Rule Id="CA2300" Action="Warning" />          <!-- Do not use insecure deserializer BinaryFormatter -->
+      <Rule Id="CA2301" Action="Warning" />          <!-- Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder -->
+      <Rule Id="CA2302" Action="Warning" />          <!-- Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize -->
+      <Rule Id="CA2305" Action="Warning" />          <!-- Do not use insecure deserializer LosFormatter -->
+      <Rule Id="CA2310" Action="Warning" />          <!-- Do not use insecure deserializer NetDataContractSerializer -->
+      <Rule Id="CA2311" Action="Warning" />          <!-- Do not deserialize without first setting NetDataContractSerializer.Binder -->
+      <Rule Id="CA2312" Action="Warning" />          <!-- Ensure NetDataContractSerializer.Binder is set before deserializing -->
+      <Rule Id="CA2315" Action="Warning" />          <!-- Do not use insecure deserializer ObjectStateFormatter -->
+      <Rule Id="CA2321" Action="Warning" />          <!-- Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver -->
+      <Rule Id="CA2322" Action="Warning" />          <!-- Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing -->
+      <Rule Id="CA2326" Action="Warning" />          <!-- Do not use TypeNameHandling values other than None -->
+      <Rule Id="CA2327" Action="Warning" />          <!-- Do not use insecure JsonSerializerSettings -->
+      <Rule Id="CA2328" Action="Warning" />          <!-- Ensure that JsonSerializerSettings are secure -->
+      <Rule Id="CA2329" Action="Warning" />          <!-- Do not deserialize with JsonSerializer using an insecure configuration -->
+      <Rule Id="CA2330" Action="Warning" />          <!-- Ensure that JsonSerializer has a secure configuration when deserializing -->
+      <Rule Id="CA3001" Action="Warning" />          <!-- Review code for SQL injection vulnerabilities -->
+      <Rule Id="CA3002" Action="Warning" />          <!-- Review code for XSS vulnerabilities -->
+      <Rule Id="CA3003" Action="Warning" />          <!-- Review code for file path injection vulnerabilities -->
+      <Rule Id="CA3004" Action="Warning" />          <!-- Review code for information disclosure vulnerabilities -->
+      <Rule Id="CA3005" Action="Warning" />          <!-- Review code for LDAP injection vulnerabilities -->
+      <Rule Id="CA3006" Action="Warning" />          <!-- Review code for process command injection vulnerabilities -->
+      <Rule Id="CA3007" Action="Warning" />          <!-- Review code for open redirect vulnerabilities -->
+      <Rule Id="CA3008" Action="Warning" />          <!-- Review code for XPath injection vulnerabilities -->
+      <Rule Id="CA3009" Action="Warning" />          <!-- Review code for XML injection vulnerabilities -->
+      <Rule Id="CA3010" Action="Warning" />          <!-- Review code for XAML injection vulnerabilities -->
+      <Rule Id="CA3011" Action="Warning" />          <!-- Review code for DLL injection vulnerabilities -->
+      <Rule Id="CA3012" Action="Warning" />          <!-- Review code for regex injection vulnerabilities -->
+      <Rule Id="CA3061" Action="Warning" />          <!-- Do Not Add Schema By URL -->
+      <Rule Id="CA3075" Action="Warning" />          <!-- Insecure DTD processing in XML -->
+      <Rule Id="CA3076" Action="Warning" />          <!-- Insecure XSLT script processing. -->
+      <Rule Id="CA3077" Action="Warning" />          <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
+      <Rule Id="CA3147" Action="Warning" />          <!-- Mark Verb Handlers With Validate Antiforgery Token -->
+      <Rule Id="CA5350" Action="Warning" />          <!-- Do Not Use Weak Cryptographic Algorithms -->
+      <Rule Id="CA5351" Action="Warning" />          <!-- Do Not Use Broken Cryptographic Algorithms -->
+      <Rule Id="CA5358" Action="Warning" />          <!-- Do Not Use Unsafe Cipher Modes -->
+      <Rule Id="CA5359" Action="Warning" />          <!-- Do Not Disable Certificate Validation -->
+      <Rule Id="CA5360" Action="Warning" />          <!-- Do Not Call Dangerous Methods In Deserialization -->
+      <Rule Id="CA5361" Action="Warning" />          <!-- Do Not Disable SChannel Use of Strong Crypto -->
+      <Rule Id="CA5362" Action="Warning" />          <!-- Do Not Refer Self In Serializable Class -->
+      <Rule Id="CA5363" Action="Warning" />          <!-- Do Not Disable Request Validation -->
+      <Rule Id="CA5364" Action="Warning" />          <!-- Do Not Use Deprecated Security Protocols -->
+      <Rule Id="CA5365" Action="Warning" />          <!-- Do Not Disable HTTP Header Checking -->
+      <Rule Id="CA5366" Action="Warning" />          <!-- Use XmlReader For DataSet Read Xml -->
+      <Rule Id="CA5367" Action="Warning" />          <!-- Do Not Serialize Types With Pointer Fields -->
+      <Rule Id="CA5368" Action="Warning" />          <!-- Set ViewStateUserKey For Classes Derived From Page -->
+      <Rule Id="CA5369" Action="Warning" />          <!-- Use XmlReader For Deserialize -->
+      <Rule Id="CA5370" Action="Warning" />          <!-- Use XmlReader For Validating Reader -->
+      <Rule Id="CA5371" Action="Warning" />          <!-- Use XmlReader For Schema Read -->
+      <Rule Id="CA5372" Action="Warning" />          <!-- Use XmlReader For XPathDocument -->
+      <Rule Id="CA5373" Action="Warning" />          <!-- Do not use obsolete key derivation function -->
+      <Rule Id="CA5374" Action="Warning" />          <!-- Do Not Use XslTransform -->
+      <Rule Id="CA5375" Action="Warning" />          <!-- Do Not Use Account Shared Access Signature -->
+      <Rule Id="CA5376" Action="Warning" />          <!-- Use SharedAccessProtocol HttpsOnly -->
+      <Rule Id="CA5377" Action="Warning" />          <!-- Use Container Level Access Policy -->
+      <Rule Id="CA5378" Action="Warning" />          <!-- Do not disable ServicePointManagerSecurityProtocols -->
+      <Rule Id="CA5379" Action="Warning" />          <!-- Do Not Use Weak Key Derivation Function Algorithm -->
+      <Rule Id="CA5380" Action="Warning" />          <!-- Do Not Add Certificates To Root Store -->
+      <Rule Id="CA5381" Action="Warning" />          <!-- Ensure Certificates Are Not Added To Root Store -->
+      <Rule Id="CA5382" Action="Warning" />          <!-- Use Secure Cookies In ASP.Net Core -->
+      <Rule Id="CA5383" Action="Warning" />          <!-- Ensure Use Secure Cookies In ASP.Net Core -->
+      <Rule Id="CA5384" Action="Warning" />          <!-- Do Not Use Digital Signature Algorithm (DSA) -->
+      <Rule Id="CA5385" Action="Warning" />          <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size -->
+      <Rule Id="CA5386" Action="Warning" />          <!-- Avoid hardcoding SecurityProtocolType value -->
+      <Rule Id="CA5387" Action="Warning" />          <!-- Do Not Use Weak Key Derivation Function With Insufficient Iteration Count -->
+      <Rule Id="CA5388" Action="Warning" />          <!-- Ensure Sufficient Iteration Count When Using Weak Key Derivation Function -->
+      <Rule Id="CA5389" Action="Warning" />          <!-- Do Not Add Archive Item's Path To The Target File System Path -->
+      <Rule Id="CA5390" Action="Warning" />          <!-- Do not hard-code encryption key -->
+      <Rule Id="CA5391" Action="Warning" />          <!-- Use antiforgery tokens in ASP.NET Core MVC controllers -->
+      <Rule Id="CA5392" Action="Warning" />          <!-- Use DefaultDllImportSearchPaths attribute for P/Invokes -->
+      <Rule Id="CA5393" Action="Warning" />          <!-- Do not use unsafe DllImportSearchPath value -->
+      <Rule Id="CA5394" Action="Warning" />          <!-- Do not use insecure randomness -->
+      <Rule Id="CA5395" Action="Warning" />          <!-- Miss HttpVerb attribute for action methods -->
+      <Rule Id="CA5396" Action="Warning" />          <!-- Set HttpOnly to true for HttpCookie -->
+      <Rule Id="CA5397" Action="Warning" />          <!-- Do not use deprecated SslProtocols values -->
+      <Rule Id="CA5398" Action="Warning" />          <!-- Avoid hardcoded SslProtocols values -->
+      <Rule Id="CA5399" Action="Warning" />          <!-- HttpClients should enable certificate revocation list checks -->
+      <Rule Id="CA5400" Action="Warning" />          <!-- Ensure HttpClient certificate revocation list check is not disabled -->
+      <Rule Id="CA5401" Action="Warning" />          <!-- Do not use CreateEncryptor with non-default IV -->
+      <Rule Id="CA5402" Action="Warning" />          <!-- Use CreateEncryptor with the default IV  -->
+      <Rule Id="CA5403" Action="Warning" />          <!-- Do not hard-code certificate -->
+      <Rule Id="CA9999" Action="Warning" />          <!-- Analyzer version mismatch -->
+   </Rules>
+</RuleSet>


### PR DESCRIPTION
This adds static analysis to all projects in the Agent.

The ruleset I picked is "All" from Microsoft. We can decide on a case by case basis what we want to remove.

For now, we will keep warnings as warnings but we should try to resolve everything and then enable `Treat Warnings as Errors`.

There is also this warning:

`MSBUILD : warning : Post-build Code Analysis (FxCopCmd.exe) has been deprecated in favor of FxCop analyzers, which run during build. Refer to https://aka.ms/fxcopanalyzers to migrate to FxCop analyzers. [E:\github\vsts-agent\src\Agent.Service\Windows\AgentService.csproj] [E:\github\vsts-agent\src\dir.proj]`

Which needs to be investigated.