### PR TITLE
Adding ContainerResource.MapDockerSocket

### DIFF
--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -50,6 +50,8 @@ namespace Agent.Sdk
             _environmentVariables = container.Environment != null ? new Dictionary<string, string>(container.Environment) : new Dictionary<string, string>();
             this.ContainerCommand = container.Properties.Get<string>("command", defaultValue: "");
             this.IsJobContainer = isJobContainer;
+            // Windows has never automatically enabled Docker.Sock, but Linux does. So we need to set the default here based on OS.
+            this.MapDockerSocket = container.Properties.Get<bool>("mapDockerSocket", !PlatformUtil.RunningOnWindows);
             this._imageOS = PlatformUtil.HostOS;
            _pathMappings = new Dictionary<string, string>( PlatformUtil.RunningOnWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 
@@ -83,6 +85,7 @@ namespace Agent.Sdk
         public string CurrentUserName { get; set; }
         public string CurrentUserId { get; set; }
         public bool IsJobContainer { get; set; }
+        public bool MapDockerSocket { get; set; }
         public PlatformUtil.OS ImageOS {
             get
             {

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -474,10 +474,11 @@ namespace Microsoft.VisualStudio.Services.Agent
                 pathMappings[this.GetDirectory(WellKnownDirectory.Tools)] = "/__t"; // Tool cache folder may come from ENV, so we need a unique folder to avoid collision
                 pathMappings[this.GetDirectory(WellKnownDirectory.Work)] = "/__w";
                 pathMappings[this.GetDirectory(WellKnownDirectory.Root)] = "/__a";
-                if (containerInfo.IsJobContainer)
-                {
-                    containerInfo.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
-                }
+            }
+
+            if (containerInfo.IsJobContainer && containerInfo.MapDockerSocket)
+            {
+                containerInfo.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
             }
 
             containerInfo.AddPathMappings(pathMappings);


### PR DESCRIPTION
Adding ContainerResource.MapDockerSocket to allow turning off docker-n-docker

These are the agent side changes to pay attention to the flag.
There are matching changes to the Server side to allow the yaml to set the flag.

Testing
I manually tested this new setting on Windows. I hope to setup Linux as well for testing.