### PR TITLE
Refactor to make collapsing duplicate Git CLI classes easier

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -76,7 +76,7 @@ namespace Agent.Plugins.Repository
             return gitLfsVersion >= requiredVersion;
         }
 
-        public async Task LoadGitExecutionInfo(AgentTaskPluginExecutionContext context, bool useBuiltInGit)
+        public async Task LoadGitExecutionInfo(IBaseContext context, bool useBuiltInGit)
         {
             // There is no built-in git for OSX/Linux
             gitPath = null;
@@ -84,7 +84,7 @@ namespace Agent.Plugins.Repository
             // Resolve the location of git.
             if (useBuiltInGit && PlatformUtil.RunningOnWindows)
             {
-                string agentHomeDir = context.Variables.GetValueOrDefault("agent.homedirectory")?.Value;
+                string agentHomeDir = context.GetVariableValueOrDefault("agent.homedirectory");
                 ArgUtil.NotNullOrEmpty(agentHomeDir, nameof(agentHomeDir));
                 gitPath = Path.Combine(agentHomeDir, "externals", "git", "cmd", $"git.exe");
 
@@ -139,13 +139,13 @@ namespace Agent.Plugins.Repository
             }
 
             // Set the user agent.
-            string gitHttpUserAgentEnv = $"git/{gitVersion.ToString()} (vsts-agent-git/{context.Variables.GetValueOrDefault("agent.version")?.Value ?? "unknown"})";
+            string gitHttpUserAgentEnv = $"git/{gitVersion.ToString()} (vsts-agent-git/{context.GetVariableValueOrDefault("agent.version") ?? "unknown"})";
             context.Debug($"Set git useragent to: {gitHttpUserAgentEnv}.");
             gitEnv["GIT_HTTP_USER_AGENT"] = gitHttpUserAgentEnv;
         }
 
         // git init <LocalDir>
-        public async Task<int> GitInit(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitInit(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Init git repository at: {repositoryPath}.");
             string repoRootEscapeSpace = StringUtil.Format(@"""{0}""", repositoryPath.Replace(@"""", @"\"""));
@@ -153,7 +153,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        public async Task<int> GitFetch(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitFetch(IBaseContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch git repository at: {repositoryPath} remote: {remoteName}.");
             if (refSpec != null && refSpec.Count > 0)
@@ -171,7 +171,7 @@ namespace Agent.Plugins.Repository
             }
 
             bool reducedOutput = StringUtil.ConvertToBoolean(
-                context.Variables.GetValueOrDefault("agent.source.checkout.quiet")?.Value);
+                context.GetVariableValueOrDefault("agent.source.checkout.quiet"));
             string progress = reducedOutput ? string.Empty : "--progress";
 
             // default options for git fetch.
@@ -234,7 +234,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git lfs fetch origin [ref]
-        public async Task<int> GitLFSFetch(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitLFSFetch(IBaseContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch LFS objects for git repository at: {repositoryPath} remote: {remoteName}.");
 
@@ -265,7 +265,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git checkout -f --progress <commitId/branch>
-        public async Task<int> GitCheckout(AgentTaskPluginExecutionContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
+        public async Task<int> GitCheckout(IBaseContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
         {
             context.Debug($"Checkout {committishOrBranchSpec}.");
 
@@ -284,7 +284,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git clean -ffdx
-        public async Task<int> GitClean(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitClean(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for repository at {repositoryPath}.");
 
@@ -303,35 +303,35 @@ namespace Agent.Plugins.Repository
         }
 
         // git reset --hard HEAD
-        public async Task<int> GitReset(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitReset(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for repository at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "reset", "--hard HEAD");
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteAdd(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteAdd(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Add git remote: {remoteName} to url: {remoteUrl} for repository under: {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"add {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteSetUrl(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git fetch url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url --push <origin> <url>
-        public async Task<int> GitRemoteSetPushUrl(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetPushUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git push url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url --push {remoteName} {remoteUrl}"));
         }
 
         // git submodule foreach --recursive "git clean -ffdx"
-        public async Task<int> GitSubmoduleClean(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleClean(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for submodules at {repositoryPath}.");
 
@@ -350,14 +350,14 @@ namespace Agent.Plugins.Repository
         }
 
         // git submodule foreach --recursive "git reset --hard HEAD"
-        public async Task<int> GitSubmoduleReset(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleReset(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for submodules at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach --recursive \"git reset --hard HEAD\"");
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        public async Task<int> GitSubmoduleUpdate(AgentTaskPluginExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleUpdate(IBaseContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Update the registered git submodules.");
             string options = "update --init --force";
@@ -374,7 +374,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git submodule sync [--recursive]
-        public async Task<int> GitSubmoduleSync(AgentTaskPluginExecutionContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleSync(IBaseContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Synchronizes submodules' remote URL configuration setting.");
             string options = "sync";
@@ -387,7 +387,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git config --get remote.origin.url
-        public async Task<Uri> GitGetFetchUrl(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<Uri> GitGetFetchUrl(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Inspect remote.origin.url for repository under {repositoryPath}");
             Uri fetchUrl = null;
@@ -426,14 +426,14 @@ namespace Agent.Plugins.Repository
         }
 
         // git config <key> <value>
-        public async Task<int> GitConfig(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey, string configValue)
+        public async Task<int> GitConfig(IBaseContext context, string repositoryPath, string configKey, string configValue)
         {
             context.Debug($"Set git config {configKey} {configValue}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"{configKey} {configValue}"));
         }
 
         // git config --get-all <key>
-        public async Task<bool> GitConfigExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey)
+        public async Task<bool> GitConfigExist(IBaseContext context, string repositoryPath, string configKey)
         {
             // git config --get-all {configKey} will return 0 and print the value if the config exist.
             context.Debug($"Checking git config {configKey} exist or not");
@@ -446,59 +446,59 @@ namespace Agent.Plugins.Repository
         }
 
         // git config --unset-all <key>
-        public async Task<int> GitConfigUnset(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey)
+        public async Task<int> GitConfigUnset(IBaseContext context, string repositoryPath, string configKey)
         {
             context.Debug($"Unset git config --unset-all {configKey}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--unset-all {configKey}"));
         }
 
         // git config gc.auto 0
-        public async Task<int> GitDisableAutoGC(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitDisableAutoGC(IBaseContext context, string repositoryPath)
         {
             context.Debug("Disable git auto garbage collection.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", "gc.auto 0");
         }
 
         // git repack -adfl
-        public async Task<int> GitRepack(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitRepack(IBaseContext context, string repositoryPath)
         {
             context.Debug("Compress .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "repack", "-adfl");
         }
 
         // git prune
-        public async Task<int> GitPrune(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitPrune(IBaseContext context, string repositoryPath)
         {
             context.Debug("Delete unreachable objects under .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "prune", "-v");
         }
 
         // git count-objects -v -H
-        public async Task<int> GitCountObjects(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitCountObjects(IBaseContext context, string repositoryPath)
         {
             context.Debug("Inspect .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "count-objects", "-v -H");
         }
 
         // git lfs install --local
-        public async Task<int> GitLFSInstall(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitLFSInstall(IBaseContext context, string repositoryPath)
         {
             context.Debug("Ensure git-lfs installed.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "install --local");
         }
 
         // git lfs logs last
-        public async Task<int> GitLFSLogs(AgentTaskPluginExecutionContext context, string repositoryPath)
+        public async Task<int> GitLFSLogs(IBaseContext context, string repositoryPath)
         {
             context.Debug("Get git-lfs logs.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "logs last");
         }
 
         // git version
-        public async Task<Version> GitVersion(AgentTaskPluginExecutionContext context)
+        public async Task<Version> GitVersion(IBaseContext context)
         {
             context.Debug("Get git version.");
-            string workingDir = context.Variables.GetValueOrDefault("agent.workfolder")?.Value;
+            string workingDir = context.GetVariableValueOrDefault("agent.workfolder");
             ArgUtil.Directory(workingDir, "agent.workfolder");
             Version version = null;
             List<string> outputStrings = new List<string>();
@@ -528,10 +528,10 @@ namespace Agent.Plugins.Repository
         }
 
         // git lfs version
-        public async Task<Version> GitLfsVersion(AgentTaskPluginExecutionContext context)
+        public async Task<Version> GitLfsVersion(IBaseContext context)
         {
             context.Debug("Get git-lfs version.");
-            string workingDir = context.Variables.GetValueOrDefault("agent.workfolder")?.Value;
+            string workingDir = context.GetVariableValueOrDefault("agent.workfolder");
             ArgUtil.Directory(workingDir, "agent.workfolder");
             Version version = null;
             List<string> outputStrings = new List<string>();
@@ -560,7 +560,7 @@ namespace Agent.Plugins.Repository
             return version;
         }
 
-        private async Task<int> ExecuteGitCommandAsync(AgentTaskPluginExecutionContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -586,7 +586,7 @@ namespace Agent.Plugins.Repository
                 cancellationToken: cancellationToken);
         }
 
-        private async Task<int> ExecuteGitCommandAsync(AgentTaskPluginExecutionContext context, string repoRoot, string command, string options, IList<string> output)
+        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, IList<string> output)
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -617,7 +617,7 @@ namespace Agent.Plugins.Repository
                 cancellationToken: default(CancellationToken));
         }
 
-        private async Task<int> ExecuteGitCommandAsync(AgentTaskPluginExecutionContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
+        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
         {
             string arg = StringUtil.Format($"{additionalCommandLine} {command} {options}").Trim();
             context.Command($"git {arg}");

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -76,7 +76,7 @@ namespace Agent.Plugins.Repository
             return gitLfsVersion >= requiredVersion;
         }
 
-        public async Task LoadGitExecutionInfo(IBaseContext context, bool useBuiltInGit)
+        public async Task LoadGitExecutionInfo(IBaseExecutionContext context, bool useBuiltInGit)
         {
             // There is no built-in git for OSX/Linux
             gitPath = null;
@@ -145,7 +145,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git init <LocalDir>
-        public async Task<int> GitInit(IBaseContext context, string repositoryPath)
+        public async Task<int> GitInit(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Init git repository at: {repositoryPath}.");
             string repoRootEscapeSpace = StringUtil.Format(@"""{0}""", repositoryPath.Replace(@"""", @"\"""));
@@ -153,7 +153,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        public async Task<int> GitFetch(IBaseContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitFetch(IBaseExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch git repository at: {repositoryPath} remote: {remoteName}.");
             if (refSpec != null && refSpec.Count > 0)
@@ -234,7 +234,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git lfs fetch origin [ref]
-        public async Task<int> GitLFSFetch(IBaseContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitLFSFetch(IBaseExecutionContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch LFS objects for git repository at: {repositoryPath} remote: {remoteName}.");
 
@@ -265,7 +265,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git checkout -f --progress <commitId/branch>
-        public async Task<int> GitCheckout(IBaseContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
+        public async Task<int> GitCheckout(IBaseExecutionContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
         {
             context.Debug($"Checkout {committishOrBranchSpec}.");
 
@@ -284,7 +284,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git clean -ffdx
-        public async Task<int> GitClean(IBaseContext context, string repositoryPath)
+        public async Task<int> GitClean(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for repository at {repositoryPath}.");
 
@@ -303,35 +303,35 @@ namespace Agent.Plugins.Repository
         }
 
         // git reset --hard HEAD
-        public async Task<int> GitReset(IBaseContext context, string repositoryPath)
+        public async Task<int> GitReset(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for repository at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "reset", "--hard HEAD");
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteAdd(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteAdd(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Add git remote: {remoteName} to url: {remoteUrl} for repository under: {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"add {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteSetUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetUrl(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git fetch url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url --push <origin> <url>
-        public async Task<int> GitRemoteSetPushUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetPushUrl(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git push url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url --push {remoteName} {remoteUrl}"));
         }
 
         // git submodule foreach --recursive "git clean -ffdx"
-        public async Task<int> GitSubmoduleClean(IBaseContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleClean(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for submodules at {repositoryPath}.");
 
@@ -350,14 +350,14 @@ namespace Agent.Plugins.Repository
         }
 
         // git submodule foreach --recursive "git reset --hard HEAD"
-        public async Task<int> GitSubmoduleReset(IBaseContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleReset(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for submodules at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach --recursive \"git reset --hard HEAD\"");
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        public async Task<int> GitSubmoduleUpdate(IBaseContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleUpdate(IBaseExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Update the registered git submodules.");
             string options = "update --init --force";
@@ -374,7 +374,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git submodule sync [--recursive]
-        public async Task<int> GitSubmoduleSync(IBaseContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleSync(IBaseExecutionContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Synchronizes submodules' remote URL configuration setting.");
             string options = "sync";
@@ -387,7 +387,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git config --get remote.origin.url
-        public async Task<Uri> GitGetFetchUrl(IBaseContext context, string repositoryPath)
+        public async Task<Uri> GitGetFetchUrl(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Inspect remote.origin.url for repository under {repositoryPath}");
             Uri fetchUrl = null;
@@ -426,14 +426,14 @@ namespace Agent.Plugins.Repository
         }
 
         // git config <key> <value>
-        public async Task<int> GitConfig(IBaseContext context, string repositoryPath, string configKey, string configValue)
+        public async Task<int> GitConfig(IBaseExecutionContext context, string repositoryPath, string configKey, string configValue)
         {
             context.Debug($"Set git config {configKey} {configValue}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"{configKey} {configValue}"));
         }
 
         // git config --get-all <key>
-        public async Task<bool> GitConfigExist(IBaseContext context, string repositoryPath, string configKey)
+        public async Task<bool> GitConfigExist(IBaseExecutionContext context, string repositoryPath, string configKey)
         {
             // git config --get-all {configKey} will return 0 and print the value if the config exist.
             context.Debug($"Checking git config {configKey} exist or not");
@@ -446,56 +446,56 @@ namespace Agent.Plugins.Repository
         }
 
         // git config --unset-all <key>
-        public async Task<int> GitConfigUnset(IBaseContext context, string repositoryPath, string configKey)
+        public async Task<int> GitConfigUnset(IBaseExecutionContext context, string repositoryPath, string configKey)
         {
             context.Debug($"Unset git config --unset-all {configKey}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--unset-all {configKey}"));
         }
 
         // git config gc.auto 0
-        public async Task<int> GitDisableAutoGC(IBaseContext context, string repositoryPath)
+        public async Task<int> GitDisableAutoGC(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Disable git auto garbage collection.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", "gc.auto 0");
         }
 
         // git repack -adfl
-        public async Task<int> GitRepack(IBaseContext context, string repositoryPath)
+        public async Task<int> GitRepack(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Compress .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "repack", "-adfl");
         }
 
         // git prune
-        public async Task<int> GitPrune(IBaseContext context, string repositoryPath)
+        public async Task<int> GitPrune(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Delete unreachable objects under .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "prune", "-v");
         }
 
         // git count-objects -v -H
-        public async Task<int> GitCountObjects(IBaseContext context, string repositoryPath)
+        public async Task<int> GitCountObjects(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Inspect .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "count-objects", "-v -H");
         }
 
         // git lfs install --local
-        public async Task<int> GitLFSInstall(IBaseContext context, string repositoryPath)
+        public async Task<int> GitLFSInstall(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Ensure git-lfs installed.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "install --local");
         }
 
         // git lfs logs last
-        public async Task<int> GitLFSLogs(IBaseContext context, string repositoryPath)
+        public async Task<int> GitLFSLogs(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Get git-lfs logs.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "logs last");
         }
 
         // git version
-        public async Task<Version> GitVersion(IBaseContext context)
+        public async Task<Version> GitVersion(IBaseExecutionContext context)
         {
             context.Debug("Get git version.");
             string workingDir = context.GetVariableValueOrDefault("agent.workfolder");
@@ -528,7 +528,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git lfs version
-        public async Task<Version> GitLfsVersion(IBaseContext context)
+        public async Task<Version> GitLfsVersion(IBaseExecutionContext context)
         {
             context.Debug("Get git-lfs version.");
             string workingDir = context.GetVariableValueOrDefault("agent.workfolder");
@@ -560,7 +560,7 @@ namespace Agent.Plugins.Repository
             return version;
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<int> ExecuteGitCommandAsync(IBaseExecutionContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -586,7 +586,7 @@ namespace Agent.Plugins.Repository
                 cancellationToken: cancellationToken);
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, IList<string> output)
+        private async Task<int> ExecuteGitCommandAsync(IBaseExecutionContext context, string repoRoot, string command, string options, IList<string> output)
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -617,7 +617,7 @@ namespace Agent.Plugins.Repository
                 cancellationToken: default(CancellationToken));
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
+        private async Task<int> ExecuteGitCommandAsync(IBaseExecutionContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
         {
             string arg = StringUtil.Format($"{additionalCommandLine} {command} {options}").Trim();
             context.Command($"git {arg}");

--- a/src/Agent.Sdk/CommandPlugin.cs
+++ b/src/Agent.Sdk/CommandPlugin.cs
@@ -97,6 +97,21 @@ namespace Agent.Sdk
                 Console.Error.WriteLine(message);
             }
         }
+        public void Error(Exception ex)
+        {
+            Error(ex.Message);
+            Debug(ex.ToString());
+        }
+
+        public void Warning(string message)
+        {
+            Output($"##[warning]{message}");
+        }
+
+        public void Command(string command)
+        {
+            Output($"##[command]{command}");
+        }
 
         public VssConnection InitializeVssConnection()
         {

--- a/src/Agent.Sdk/IBaseContext.cs
+++ b/src/Agent.Sdk/IBaseContext.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+
+namespace Agent.Sdk
+{
+    public interface IBaseContext : ITraceWriter
+    {
+        string GetVariableValueOrDefault(string variableName);
+        IEnumerable<KeyValuePair<string, string>> EnumeratePublicVariables();
+        void PublishTelemetry(string area, string feature, Dictionary<string, string> properties);
+        void PrependPath(string directory);
+        string GetInput(string name, bool required = false);
+    }
+}

--- a/src/Agent.Sdk/IBaseExecutionContext.cs
+++ b/src/Agent.Sdk/IBaseExecutionContext.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Agent.Sdk
 {
-    public interface IBaseContext : ITraceWriter
+    public interface IBaseExecutionContext : ITraceWriter
     {
         string GetVariableValueOrDefault(string variableName);
         IEnumerable<KeyValuePair<string, string>> EnumeratePublicVariables();

--- a/src/Agent.Sdk/ITraceWriter.cs
+++ b/src/Agent.Sdk/ITraceWriter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 
 namespace Agent.Sdk
 {
@@ -7,5 +8,11 @@ namespace Agent.Sdk
     {
         void Info(string message);
         void Verbose(string message);
+        void Error(Exception ex);
+        void Error(string message);
+        void Warning(string message);
+        void Output(string message);
+        void Command(string message);
+        void Debug(string message);
     }
 }

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -31,7 +31,7 @@ namespace Agent.Sdk
         public static readonly string HasMultipleCheckouts = "HasMultipleCheckouts";
     }
 
-    public class AgentTaskPluginExecutionContext : IBaseContext
+    public class AgentTaskPluginExecutionContext : IBaseExecutionContext
     {
         private VssConnection _connection;
         private readonly object _stdoutLock = new object();

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -22,82 +22,82 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         bool EnsureGitLFSVersion(Version requiredVersion, bool throwOnNotMatch);
 
         // setup git execution info, git location, version, useragent, execpath
-        Task LoadGitExecutionInfo(IExecutionContext context, bool useBuiltInGit);
+        Task LoadGitExecutionInfo(IBaseContext context, bool useBuiltInGit);
 
         // git init <LocalDir>
-        Task<int> GitInit(IExecutionContext context, string repositoryPath);
+        Task<int> GitInit(IBaseContext context, string repositoryPath);
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        Task<int> GitFetch(IExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken);
+        Task<int> GitFetch(IBaseContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken);
 
         // git lfs fetch origin [ref]
-        Task<int> GitLFSFetch(IExecutionContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken);
+        Task<int> GitLFSFetch(IBaseContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken);
 
         // git checkout -f --progress <commitId/branch>
-        Task<int> GitCheckout(IExecutionContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken);
+        Task<int> GitCheckout(IBaseContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken);
 
         // git clean -ffdx
-        Task<int> GitClean(IExecutionContext context, string repositoryPath);
+        Task<int> GitClean(IBaseContext context, string repositoryPath);
 
         // git reset --hard HEAD
-        Task<int> GitReset(IExecutionContext context, string repositoryPath);
+        Task<int> GitReset(IBaseContext context, string repositoryPath);
 
         // get remote add <origin> <url>
-        Task<int> GitRemoteAdd(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
+        Task<int> GitRemoteAdd(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl);
 
         // get remote set-url <origin> <url>
-        Task<int> GitRemoteSetUrl(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
+        Task<int> GitRemoteSetUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl);
 
         // get remote set-url --push <origin> <url>
-        Task<int> GitRemoteSetPushUrl(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
+        Task<int> GitRemoteSetPushUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl);
 
         // git submodule foreach --recursive "git clean -ffdx"
-        Task<int> GitSubmoduleClean(IExecutionContext context, string repositoryPath);
+        Task<int> GitSubmoduleClean(IBaseContext context, string repositoryPath);
 
         // git submodule foreach --recursive "git reset --hard HEAD"
-        Task<int> GitSubmoduleReset(IExecutionContext context, string repositoryPath);
+        Task<int> GitSubmoduleReset(IBaseContext context, string repositoryPath);
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        Task<int> GitSubmoduleUpdate(IExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken);
+        Task<int> GitSubmoduleUpdate(IBaseContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken);
 
         // git submodule sync [--recursive]
-        Task<int> GitSubmoduleSync(IExecutionContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken);
+        Task<int> GitSubmoduleSync(IBaseContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken);
 
         // git config --get remote.origin.url
-        Task<Uri> GitGetFetchUrl(IExecutionContext context, string repositoryPath);
+        Task<Uri> GitGetFetchUrl(IBaseContext context, string repositoryPath);
 
         // git config <key> <value>
-        Task<int> GitConfig(IExecutionContext context, string repositoryPath, string configKey, string configValue);
+        Task<int> GitConfig(IBaseContext context, string repositoryPath, string configKey, string configValue);
 
         // git config --get-all <key>
-        Task<bool> GitConfigExist(IExecutionContext context, string repositoryPath, string configKey);
+        Task<bool> GitConfigExist(IBaseContext context, string repositoryPath, string configKey);
 
         // git config --unset-all <key>
-        Task<int> GitConfigUnset(IExecutionContext context, string repositoryPath, string configKey);
+        Task<int> GitConfigUnset(IBaseContext context, string repositoryPath, string configKey);
 
         // git config gc.auto 0
-        Task<int> GitDisableAutoGC(IExecutionContext context, string repositoryPath);
+        Task<int> GitDisableAutoGC(IBaseContext context, string repositoryPath);
 
         // git lfs version
-        Task<Version> GitLfsVersion(IExecutionContext context);
+        Task<Version> GitLfsVersion(IBaseContext context);
 
         // git lfs install --local
-        Task<int> GitLFSInstall(IExecutionContext context, string repositoryPath);
+        Task<int> GitLFSInstall(IBaseContext context, string repositoryPath);
 
         // git lfs logs last
-        Task<int> GitLFSLogs(IExecutionContext context, string repositoryPath);
+        Task<int> GitLFSLogs(IBaseContext context, string repositoryPath);
 
         // git repack -adfl
-        Task<int> GitRepack(IExecutionContext context, string repositoryPath);
+        Task<int> GitRepack(IBaseContext context, string repositoryPath);
 
         // git prune
-        Task<int> GitPrune(IExecutionContext context, string repositoryPath);
+        Task<int> GitPrune(IBaseContext context, string repositoryPath);
 
         // git count-objects -v -H
-        Task<int> GitCountObjects(IExecutionContext context, string repositoryPath);
+        Task<int> GitCountObjects(IBaseContext context, string repositoryPath);
 
         // git version
-        Task<Version> GitVersion(IExecutionContext context);
+        Task<Version> GitVersion(IBaseContext context);
     }
 
     public class GitCommandManager : AgentService, IGitCommandManager
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             return _gitLfsVersion >= requiredVersion;
         }
 
-        public async Task LoadGitExecutionInfo(IExecutionContext context, bool useBuiltInGit)
+        public async Task LoadGitExecutionInfo(IBaseContext context, bool useBuiltInGit)
         {
             // Resolve the location of git.
             if (useBuiltInGit)
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             ArgUtil.File(_gitPath, nameof(_gitPath));
 
-            // Get the Git version.    
+            // Get the Git version.
             _gitVersion = await GitVersion(context);
             ArgUtil.NotNull(_gitVersion, nameof(_gitVersion));
             context.Debug($"Detect git version: {_gitVersion.ToString()}.");
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git init <LocalDir>
-        public async Task<int> GitInit(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitInit(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Init git repository at: {repositoryPath}.");
             string repoRootEscapeSpace = StringUtil.Format(@"""{0}""", repositoryPath.Replace(@"""", @"\"""));
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        public async Task<int> GitFetch(IExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitFetch(IBaseContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch git repository at: {repositoryPath} remote: {remoteName}.");
             if (refSpec != null && refSpec.Count > 0)
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git lfs fetch origin [ref]
-        public async Task<int> GitLFSFetch(IExecutionContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitLFSFetch(IBaseContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch LFS objects for git repository at: {repositoryPath} remote: {remoteName}.");
 
@@ -255,7 +255,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git checkout -f --progress <commitId/branch>
-        public async Task<int> GitCheckout(IExecutionContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
+        public async Task<int> GitCheckout(IBaseContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
         {
             context.Debug($"Checkout {committishOrBranchSpec}.");
 
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git clean -ffdx
-        public async Task<int> GitClean(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitClean(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for repository at {repositoryPath}.");
 
@@ -293,38 +293,38 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git reset --hard HEAD
-        public async Task<int> GitReset(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitReset(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for repository at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "reset", "--hard HEAD");
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteAdd(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteAdd(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Add git remote: {remoteName} to url: {remoteUrl} for repository under: {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"add {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteSetUrl(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git fetch url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url --push <origin> <url>
-        public async Task<int> GitRemoteSetPushUrl(IExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetPushUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git push url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url --push {remoteName} {remoteUrl}"));
         }
 
         // git submodule foreach --recursive "git clean -ffdx"
-        public async Task<int> GitSubmoduleClean(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleClean(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for submodules at {repositoryPath}.");
-            
+
             // Git 2.4 support git clean -ffdx.
             string options;
             if (_gitVersion >= new Version(2, 4))
@@ -340,14 +340,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git submodule foreach --recursive "git reset --hard HEAD"
-        public async Task<int> GitSubmoduleReset(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleReset(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for submodules at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach --recursive \"git reset --hard HEAD\"");
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        public async Task<int> GitSubmoduleUpdate(IExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleUpdate(IBaseContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Update the registered git submodules.");
             string options = "update --init --force";
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git submodule sync [--recursive]
-        public async Task<int> GitSubmoduleSync(IExecutionContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleSync(IBaseContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Synchronizes submodules' remote URL configuration setting.");
             string options = "sync";
@@ -377,7 +377,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git config --get remote.origin.url
-        public async Task<Uri> GitGetFetchUrl(IExecutionContext context, string repositoryPath)
+        public async Task<Uri> GitGetFetchUrl(IBaseContext context, string repositoryPath)
         {
             context.Debug($"Inspect remote.origin.url for repository under {repositoryPath}");
             Uri fetchUrl = null;
@@ -416,14 +416,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git config <key> <value>
-        public async Task<int> GitConfig(IExecutionContext context, string repositoryPath, string configKey, string configValue)
+        public async Task<int> GitConfig(IBaseContext context, string repositoryPath, string configKey, string configValue)
         {
             context.Debug($"Set git config {configKey} {configValue}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"{configKey} {configValue}"));
         }
 
         // git config --get-all <key>
-        public async Task<bool> GitConfigExist(IExecutionContext context, string repositoryPath, string configKey)
+        public async Task<bool> GitConfigExist(IBaseContext context, string repositoryPath, string configKey)
         {
             // git config --get-all {configKey} will return 0 and print the value if the config exist.
             context.Debug($"Checking git config {configKey} exist or not");
@@ -436,56 +436,56 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git config --unset-all <key>
-        public async Task<int> GitConfigUnset(IExecutionContext context, string repositoryPath, string configKey)
+        public async Task<int> GitConfigUnset(IBaseContext context, string repositoryPath, string configKey)
         {
             context.Debug($"Unset git config --unset-all {configKey}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--unset-all {configKey}"));
         }
 
         // git config gc.auto 0
-        public async Task<int> GitDisableAutoGC(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitDisableAutoGC(IBaseContext context, string repositoryPath)
         {
             context.Debug("Disable git auto garbage collection.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", "gc.auto 0");
         }
 
         // git repack -adfl
-        public async Task<int> GitRepack(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitRepack(IBaseContext context, string repositoryPath)
         {
             context.Debug("Compress .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "repack", "-adfl");
         }
 
         // git prune
-        public async Task<int> GitPrune(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitPrune(IBaseContext context, string repositoryPath)
         {
             context.Debug("Delete unreachable objects under .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "prune", "-v");
         }
 
         // git count-objects -v -H
-        public async Task<int> GitCountObjects(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitCountObjects(IBaseContext context, string repositoryPath)
         {
             context.Debug("Inspect .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "count-objects", "-v -H");
         }
 
         // git lfs install --local
-        public async Task<int> GitLFSInstall(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitLFSInstall(IBaseContext context, string repositoryPath)
         {
             context.Debug("Ensure git-lfs installed.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "install --local");
         }
 
         // git lfs logs last
-        public async Task<int> GitLFSLogs(IExecutionContext context, string repositoryPath)
+        public async Task<int> GitLFSLogs(IBaseContext context, string repositoryPath)
         {
             context.Debug("Get git-lfs logs.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "logs last");
         }
 
         // git version
-        public async Task<Version> GitVersion(IExecutionContext context)
+        public async Task<Version> GitVersion(IBaseContext context)
         {
             context.Debug("Get git version.");
             Version version = null;
@@ -516,7 +516,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git lfs version
-        public async Task<Version> GitLfsVersion(IExecutionContext context)
+        public async Task<Version> GitLfsVersion(IBaseContext context)
         {
             context.Debug("Get git-lfs version.");
             Version version = null;
@@ -545,7 +545,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             return version;
         }
-        private async Task<int> ExecuteGitCommandAsync(IExecutionContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -571,7 +571,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 cancellationToken: cancellationToken);
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IExecutionContext context, string repoRoot, string command, string options, IList<string> output)
+        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, IList<string> output)
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -609,7 +609,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 cancellationToken: default(CancellationToken));
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IExecutionContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
+        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
         {
             string arg = StringUtil.Format($"{additionalCommandLine} {command} {options}").Trim();
             context.Command($"git {arg}");
@@ -635,7 +635,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 cancellationToken: cancellationToken);
         }
 
-        private IDictionary<string, string> GetGitEnvironmentVariables(IExecutionContext context)
+        private IDictionary<string, string> GetGitEnvironmentVariables(IBaseContext context)
         {
             Dictionary<string, string> gitEnv = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -648,16 +648,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
 
             // Add the public variables.
-            foreach (KeyValuePair<string, string> pair in context.Variables.Public)
+            foreach (KeyValuePair<string, string> pair in context.EnumeratePublicVariables())
             {
                 // Add the variable using the formatted name.
                 string formattedKey = (pair.Key ?? string.Empty).Replace('.', '_').Replace(' ', '_').ToUpperInvariant();
 
                 // Skip any GIT_TRACE variable since GIT_TRACE will affect ouput from every git command.
                 // This will fail the parse logic for detect git version, remote url, etc.
-                // Ex. 
+                // Ex.
                 //      SET GIT_TRACE=true
-                //      git version 
+                //      git version
                 //      11:39:58.295959 git.c:371               trace: built-in: git 'version'
                 //      git version 2.11.1.windows.1
                 if (formattedKey == "GIT_TRACE" || formattedKey.StartsWith("GIT_TRACE_"))

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -22,82 +22,82 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         bool EnsureGitLFSVersion(Version requiredVersion, bool throwOnNotMatch);
 
         // setup git execution info, git location, version, useragent, execpath
-        Task LoadGitExecutionInfo(IBaseContext context, bool useBuiltInGit);
+        Task LoadGitExecutionInfo(IBaseExecutionContext context, bool useBuiltInGit);
 
         // git init <LocalDir>
-        Task<int> GitInit(IBaseContext context, string repositoryPath);
+        Task<int> GitInit(IBaseExecutionContext context, string repositoryPath);
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        Task<int> GitFetch(IBaseContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken);
+        Task<int> GitFetch(IBaseExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken);
 
         // git lfs fetch origin [ref]
-        Task<int> GitLFSFetch(IBaseContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken);
+        Task<int> GitLFSFetch(IBaseExecutionContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken);
 
         // git checkout -f --progress <commitId/branch>
-        Task<int> GitCheckout(IBaseContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken);
+        Task<int> GitCheckout(IBaseExecutionContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken);
 
         // git clean -ffdx
-        Task<int> GitClean(IBaseContext context, string repositoryPath);
+        Task<int> GitClean(IBaseExecutionContext context, string repositoryPath);
 
         // git reset --hard HEAD
-        Task<int> GitReset(IBaseContext context, string repositoryPath);
+        Task<int> GitReset(IBaseExecutionContext context, string repositoryPath);
 
         // get remote add <origin> <url>
-        Task<int> GitRemoteAdd(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl);
+        Task<int> GitRemoteAdd(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
 
         // get remote set-url <origin> <url>
-        Task<int> GitRemoteSetUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl);
+        Task<int> GitRemoteSetUrl(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
 
         // get remote set-url --push <origin> <url>
-        Task<int> GitRemoteSetPushUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl);
+        Task<int> GitRemoteSetPushUrl(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl);
 
         // git submodule foreach --recursive "git clean -ffdx"
-        Task<int> GitSubmoduleClean(IBaseContext context, string repositoryPath);
+        Task<int> GitSubmoduleClean(IBaseExecutionContext context, string repositoryPath);
 
         // git submodule foreach --recursive "git reset --hard HEAD"
-        Task<int> GitSubmoduleReset(IBaseContext context, string repositoryPath);
+        Task<int> GitSubmoduleReset(IBaseExecutionContext context, string repositoryPath);
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        Task<int> GitSubmoduleUpdate(IBaseContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken);
+        Task<int> GitSubmoduleUpdate(IBaseExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken);
 
         // git submodule sync [--recursive]
-        Task<int> GitSubmoduleSync(IBaseContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken);
+        Task<int> GitSubmoduleSync(IBaseExecutionContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken);
 
         // git config --get remote.origin.url
-        Task<Uri> GitGetFetchUrl(IBaseContext context, string repositoryPath);
+        Task<Uri> GitGetFetchUrl(IBaseExecutionContext context, string repositoryPath);
 
         // git config <key> <value>
-        Task<int> GitConfig(IBaseContext context, string repositoryPath, string configKey, string configValue);
+        Task<int> GitConfig(IBaseExecutionContext context, string repositoryPath, string configKey, string configValue);
 
         // git config --get-all <key>
-        Task<bool> GitConfigExist(IBaseContext context, string repositoryPath, string configKey);
+        Task<bool> GitConfigExist(IBaseExecutionContext context, string repositoryPath, string configKey);
 
         // git config --unset-all <key>
-        Task<int> GitConfigUnset(IBaseContext context, string repositoryPath, string configKey);
+        Task<int> GitConfigUnset(IBaseExecutionContext context, string repositoryPath, string configKey);
 
         // git config gc.auto 0
-        Task<int> GitDisableAutoGC(IBaseContext context, string repositoryPath);
+        Task<int> GitDisableAutoGC(IBaseExecutionContext context, string repositoryPath);
 
         // git lfs version
-        Task<Version> GitLfsVersion(IBaseContext context);
+        Task<Version> GitLfsVersion(IBaseExecutionContext context);
 
         // git lfs install --local
-        Task<int> GitLFSInstall(IBaseContext context, string repositoryPath);
+        Task<int> GitLFSInstall(IBaseExecutionContext context, string repositoryPath);
 
         // git lfs logs last
-        Task<int> GitLFSLogs(IBaseContext context, string repositoryPath);
+        Task<int> GitLFSLogs(IBaseExecutionContext context, string repositoryPath);
 
         // git repack -adfl
-        Task<int> GitRepack(IBaseContext context, string repositoryPath);
+        Task<int> GitRepack(IBaseExecutionContext context, string repositoryPath);
 
         // git prune
-        Task<int> GitPrune(IBaseContext context, string repositoryPath);
+        Task<int> GitPrune(IBaseExecutionContext context, string repositoryPath);
 
         // git count-objects -v -H
-        Task<int> GitCountObjects(IBaseContext context, string repositoryPath);
+        Task<int> GitCountObjects(IBaseExecutionContext context, string repositoryPath);
 
         // git version
-        Task<Version> GitVersion(IBaseContext context);
+        Task<Version> GitVersion(IBaseExecutionContext context);
     }
 
     public class GitCommandManager : AgentService, IGitCommandManager
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             return _gitLfsVersion >= requiredVersion;
         }
 
-        public async Task LoadGitExecutionInfo(IBaseContext context, bool useBuiltInGit)
+        public async Task LoadGitExecutionInfo(IBaseExecutionContext context, bool useBuiltInGit)
         {
             // Resolve the location of git.
             if (useBuiltInGit)
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git init <LocalDir>
-        public async Task<int> GitInit(IBaseContext context, string repositoryPath)
+        public async Task<int> GitInit(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Init git repository at: {repositoryPath}.");
             string repoRootEscapeSpace = StringUtil.Format(@"""{0}""", repositoryPath.Replace(@"""", @"\"""));
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        public async Task<int> GitFetch(IBaseContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitFetch(IBaseExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch git repository at: {repositoryPath} remote: {remoteName}.");
             if (refSpec != null && refSpec.Count > 0)
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git lfs fetch origin [ref]
-        public async Task<int> GitLFSFetch(IBaseContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitLFSFetch(IBaseExecutionContext context, string repositoryPath, string remoteName, string refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch LFS objects for git repository at: {repositoryPath} remote: {remoteName}.");
 
@@ -255,7 +255,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git checkout -f --progress <commitId/branch>
-        public async Task<int> GitCheckout(IBaseContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
+        public async Task<int> GitCheckout(IBaseExecutionContext context, string repositoryPath, string committishOrBranchSpec, CancellationToken cancellationToken)
         {
             context.Debug($"Checkout {committishOrBranchSpec}.");
 
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git clean -ffdx
-        public async Task<int> GitClean(IBaseContext context, string repositoryPath)
+        public async Task<int> GitClean(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for repository at {repositoryPath}.");
 
@@ -293,35 +293,35 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git reset --hard HEAD
-        public async Task<int> GitReset(IBaseContext context, string repositoryPath)
+        public async Task<int> GitReset(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for repository at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "reset", "--hard HEAD");
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteAdd(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteAdd(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Add git remote: {remoteName} to url: {remoteUrl} for repository under: {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"add {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url <origin> <url>
-        public async Task<int> GitRemoteSetUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetUrl(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git fetch url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url {remoteName} {remoteUrl}"));
         }
 
         // get remote set-url --push <origin> <url>
-        public async Task<int> GitRemoteSetPushUrl(IBaseContext context, string repositoryPath, string remoteName, string remoteUrl)
+        public async Task<int> GitRemoteSetPushUrl(IBaseExecutionContext context, string repositoryPath, string remoteName, string remoteUrl)
         {
             context.Debug($"Set git push url to: {remoteUrl} for remote: {remoteName}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "remote", StringUtil.Format($"set-url --push {remoteName} {remoteUrl}"));
         }
 
         // git submodule foreach --recursive "git clean -ffdx"
-        public async Task<int> GitSubmoduleClean(IBaseContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleClean(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Delete untracked files/folders for submodules at {repositoryPath}.");
 
@@ -340,14 +340,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git submodule foreach --recursive "git reset --hard HEAD"
-        public async Task<int> GitSubmoduleReset(IBaseContext context, string repositoryPath)
+        public async Task<int> GitSubmoduleReset(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Undo any changes to tracked files in the working tree for submodules at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "submodule", "foreach --recursive \"git reset --hard HEAD\"");
         }
 
         // git submodule update --init --force [--depth=15] [--recursive]
-        public async Task<int> GitSubmoduleUpdate(IBaseContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleUpdate(IBaseExecutionContext context, string repositoryPath, int fetchDepth, string additionalCommandLine, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Update the registered git submodules.");
             string options = "update --init --force";
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git submodule sync [--recursive]
-        public async Task<int> GitSubmoduleSync(IBaseContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
+        public async Task<int> GitSubmoduleSync(IBaseExecutionContext context, string repositoryPath, bool recursive, CancellationToken cancellationToken)
         {
             context.Debug("Synchronizes submodules' remote URL configuration setting.");
             string options = "sync";
@@ -377,7 +377,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git config --get remote.origin.url
-        public async Task<Uri> GitGetFetchUrl(IBaseContext context, string repositoryPath)
+        public async Task<Uri> GitGetFetchUrl(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug($"Inspect remote.origin.url for repository under {repositoryPath}");
             Uri fetchUrl = null;
@@ -416,14 +416,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git config <key> <value>
-        public async Task<int> GitConfig(IBaseContext context, string repositoryPath, string configKey, string configValue)
+        public async Task<int> GitConfig(IBaseExecutionContext context, string repositoryPath, string configKey, string configValue)
         {
             context.Debug($"Set git config {configKey} {configValue}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"{configKey} {configValue}"));
         }
 
         // git config --get-all <key>
-        public async Task<bool> GitConfigExist(IBaseContext context, string repositoryPath, string configKey)
+        public async Task<bool> GitConfigExist(IBaseExecutionContext context, string repositoryPath, string configKey)
         {
             // git config --get-all {configKey} will return 0 and print the value if the config exist.
             context.Debug($"Checking git config {configKey} exist or not");
@@ -436,56 +436,56 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git config --unset-all <key>
-        public async Task<int> GitConfigUnset(IBaseContext context, string repositoryPath, string configKey)
+        public async Task<int> GitConfigUnset(IBaseExecutionContext context, string repositoryPath, string configKey)
         {
             context.Debug($"Unset git config --unset-all {configKey}");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--unset-all {configKey}"));
         }
 
         // git config gc.auto 0
-        public async Task<int> GitDisableAutoGC(IBaseContext context, string repositoryPath)
+        public async Task<int> GitDisableAutoGC(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Disable git auto garbage collection.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "config", "gc.auto 0");
         }
 
         // git repack -adfl
-        public async Task<int> GitRepack(IBaseContext context, string repositoryPath)
+        public async Task<int> GitRepack(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Compress .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "repack", "-adfl");
         }
 
         // git prune
-        public async Task<int> GitPrune(IBaseContext context, string repositoryPath)
+        public async Task<int> GitPrune(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Delete unreachable objects under .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "prune", "-v");
         }
 
         // git count-objects -v -H
-        public async Task<int> GitCountObjects(IBaseContext context, string repositoryPath)
+        public async Task<int> GitCountObjects(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Inspect .git directory.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "count-objects", "-v -H");
         }
 
         // git lfs install --local
-        public async Task<int> GitLFSInstall(IBaseContext context, string repositoryPath)
+        public async Task<int> GitLFSInstall(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Ensure git-lfs installed.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "install --local");
         }
 
         // git lfs logs last
-        public async Task<int> GitLFSLogs(IBaseContext context, string repositoryPath)
+        public async Task<int> GitLFSLogs(IBaseExecutionContext context, string repositoryPath)
         {
             context.Debug("Get git-lfs logs.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "logs last");
         }
 
         // git version
-        public async Task<Version> GitVersion(IBaseContext context)
+        public async Task<Version> GitVersion(IBaseExecutionContext context)
         {
             context.Debug("Get git version.");
             Version version = null;
@@ -516,7 +516,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
 
         // git lfs version
-        public async Task<Version> GitLfsVersion(IBaseContext context)
+        public async Task<Version> GitLfsVersion(IBaseExecutionContext context)
         {
             context.Debug("Get git-lfs version.");
             Version version = null;
@@ -545,7 +545,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             return version;
         }
-        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
+        private async Task<int> ExecuteGitCommandAsync(IBaseExecutionContext context, string repoRoot, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -571,7 +571,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 cancellationToken: cancellationToken);
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, IList<string> output)
+        private async Task<int> ExecuteGitCommandAsync(IBaseExecutionContext context, string repoRoot, string command, string options, IList<string> output)
         {
             string arg = StringUtil.Format($"{command} {options}").Trim();
             context.Command($"git {arg}");
@@ -609,7 +609,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 cancellationToken: default(CancellationToken));
         }
 
-        private async Task<int> ExecuteGitCommandAsync(IBaseContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
+        private async Task<int> ExecuteGitCommandAsync(IBaseExecutionContext context, string repoRoot, string command, string options, string additionalCommandLine, CancellationToken cancellationToken)
         {
             string arg = StringUtil.Format($"{additionalCommandLine} {command} {options}").Trim();
             context.Command($"git {arg}");
@@ -635,7 +635,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 cancellationToken: cancellationToken);
         }
 
-        private IDictionary<string, string> GetGitEnvironmentVariables(IBaseContext context)
+        private IDictionary<string, string> GetGitEnvironmentVariables(IBaseExecutionContext context)
         {
             Dictionary<string, string> gitEnv = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     }
 
     [ServiceLocator(Default = typeof(ExecutionContext))]
-    public interface IExecutionContext : IAgentService, IBaseContext
+    public interface IExecutionContext : IAgentService, IBaseExecutionContext
     {
         Guid Id { get; }
         Task ForceCompleted { get; }
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         Variables TaskVariables { get; }
         HashSet<string> OutputVariables { get; }
         List<IAsyncCommandContext> AsyncCommands { get; }
-        List<string> PrependPathList { get; }
+        List<string> PathsToPrepend { get; }
         List<ContainerInfo> Containers { get; }
         List<ContainerInfo> SidecarContainers { get; }
 
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public Variables TaskVariables { get; private set; }
         public HashSet<string> OutputVariables => _outputvariables;
         public bool WriteDebug { get; private set; }
-        public List<string> PrependPathList { get; private set; }
+        public List<string> PathsToPrepend { get; private set; }
         public List<ContainerInfo> Containers { get; private set; }
         public List<ContainerInfo> SidecarContainers { get; private set; }
         public List<IAsyncCommandContext> AsyncCommands => _asyncCommands;
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             child._cancellationTokenSource = new CancellationTokenSource();
             child.WriteDebug = WriteDebug;
             child._parentExecutionContext = this;
-            child.PrependPathList = PrependPathList;
+            child.PathsToPrepend = PathsToPrepend;
             child.Containers = Containers;
             child.SidecarContainers = SidecarContainers;
             child._outputForward = outputForward;
@@ -419,7 +419,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             Variables.StringTranslator = TranslatePathForStepTarget;
 
             // Prepend Path
-            PrependPathList = new List<string>();
+            PathsToPrepend = new List<string>();
 
             // Docker (JobContainer)
             string imageName = Variables.Get("_PREVIEW_VSTS_DOCKER_IMAGE");
@@ -809,7 +809,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public void PrependPath(string directory)
         {
-            PrependPathList.Insert(0, directory);
+            PathsToPrepend.Insert(0, directory);
         }
 
         public string GetInput(string name, bool required = false)

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -271,8 +271,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         {
             // Validate args.
             Trace.Entering();
-            ArgUtil.NotNull(ExecutionContext.PrependPath, nameof(ExecutionContext.PrependPath));
-            if (ExecutionContext.PrependPath.Count == 0)
+            ArgUtil.NotNull(ExecutionContext.PrependPathList, nameof(ExecutionContext.PrependPathList));
+            if (ExecutionContext.PrependPathList.Count == 0)
             {
                 return;
             }
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (containerStepHost != null)
             {
                 List<string> prepend = new List<string>();
-                foreach (var path in ExecutionContext.PrependPath)
+                foreach (var path in ExecutionContext.PrependPathList)
                 {
                     prepend.Add(ExecutionContext.TranslatePathForStepTarget(path));
                 }
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             }
             else
             {
-                string prepend = string.Join(Path.PathSeparator.ToString(), ExecutionContext.PrependPath.Reverse<string>());
+                string prepend = string.Join(Path.PathSeparator.ToString(), ExecutionContext.PrependPathList.Reverse<string>());
                 string taskEnvPATH;
                 Environment.TryGetValue(Constants.PathVariable, out taskEnvPATH);
                 string originalPath = RuntimeVariables.Get(Constants.PathVariable) ?? // Prefer a job variable.

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -271,8 +271,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         {
             // Validate args.
             Trace.Entering();
-            ArgUtil.NotNull(ExecutionContext.PrependPathList, nameof(ExecutionContext.PrependPathList));
-            if (ExecutionContext.PrependPathList.Count == 0)
+            ArgUtil.NotNull(ExecutionContext.PathsToPrepend, nameof(ExecutionContext.PathsToPrepend));
+            if (ExecutionContext.PathsToPrepend.Count == 0)
             {
                 return;
             }
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (containerStepHost != null)
             {
                 List<string> prepend = new List<string>();
-                foreach (var path in ExecutionContext.PrependPathList)
+                foreach (var path in ExecutionContext.PathsToPrepend)
                 {
                     prepend.Add(ExecutionContext.TranslatePathForStepTarget(path));
                 }
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             }
             else
             {
-                string prepend = string.Join(Path.PathSeparator.ToString(), ExecutionContext.PrependPathList.Reverse<string>());
+                string prepend = string.Join(Path.PathSeparator.ToString(), ExecutionContext.PathsToPrepend.Reverse<string>());
                 string taskEnvPATH;
                 Environment.TryGetValue(Constants.PathVariable, out taskEnvPATH);
                 string originalPath = RuntimeVariables.Get(Constants.PathVariable) ?? // Prefer a job variable.

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -735,8 +735,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var data = command.Data;
 
             ArgUtil.NotNullOrEmpty(data, this.Name);
-            context.PrependPathList.RemoveAll(x => string.Equals(x, data, StringComparison.CurrentCulture));
-            context.PrependPathList.Add(data);
+            context.PathsToPrepend.RemoveAll(x => string.Equals(x, data, StringComparison.CurrentCulture));
+            context.PathsToPrepend.Add(data);
         }
     }
 

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -735,8 +735,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var data = command.Data;
 
             ArgUtil.NotNullOrEmpty(data, this.Name);
-            context.PrependPath.RemoveAll(x => string.Equals(x, data, StringComparison.CurrentCulture));
-            context.PrependPath.Add(data);
+            context.PrependPathList.RemoveAll(x => string.Equals(x, data, StringComparison.CurrentCulture));
+            context.PrependPathList.Add(data);
         }
     }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/Tracing.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Tracing.cs
@@ -104,6 +104,21 @@ namespace Microsoft.VisualStudio.Services.Agent
             Trace(TraceEventType.Verbose, $"Leaving {name}");
         }
 
+        public void Output(string message)
+        {
+            Trace(TraceEventType.Information, message);
+        }
+
+        public void Command(string message)
+        {
+            Trace(TraceEventType.Information, message);
+        }
+
+        public void Debug(string message)
+        {
+            Trace(TraceEventType.Verbose, message);
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/Test/L0/NodeHandlerL0.cs
+++ b/src/Test/L0/NodeHandlerL0.cs
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             Dictionary<string, VariableValue> variables = null)
         {
             var trace = tc.GetTrace();
-            var executionContext = new Mock<IExecutionContext>();
+            var executionContext = tc.CreateExecutionContext();
             List<string> warnings;
             variables = variables ?? new Dictionary<string, VariableValue>();
 

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -14,7 +14,10 @@ using System.Reflection;
 using Microsoft.TeamFoundation.DistributedTask.Logging;
 using System.Net.Http.Headers;
 using Agent.Sdk;
+using Microsoft.VisualStudio.Services.Agent.Worker;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Moq;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests
 {
@@ -388,6 +391,34 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             return containerInfo;
         }
 
+        public Mock<IExecutionContext> CreateExecutionContext()
+        {
+            var context = new Mock<IExecutionContext>();
+            context.Setup(x => x.Error(It.IsAny<Exception>())).Callback( (Exception ex) => {
+                context.Object.AddIssue(new Issue() { Type = IssueType.Error, Message = ex.Message });
+                //Console.WriteLine(ex.ToString());
+            });
+            context.Setup(x => x.Error(It.IsAny<string>())).Callback( (string message) => {
+                context.Object.AddIssue(new Issue() { Type = IssueType.Error, Message = message });
+            });
+            context.Setup(x => x.Warning(It.IsAny<string>())).Callback( (string message) => {
+                context.Object.AddIssue(new Issue() { Type = IssueType.Warning, Message = message });
+            });
+            context.Setup(x => x.Output(It.IsAny<string>())).Callback( (string message) => {
+                //Console.WriteLine(message);
+            });
+            context.Setup(x => x.Command(It.IsAny<string>())).Callback( (string message) => {
+                //Console.WriteLine(message);
+            });
+            context.Setup(x => x.Debug(It.IsAny<string>())).Callback( (string message) => {
+                //Console.WriteLine(message);
+            });
+            context.Setup(x => x.Section(It.IsAny<string>())).Callback( (string message) => {
+                //Console.WriteLine(message);
+            });
+
+            return context;
+        }
         public void ShutdownAgent(ShutdownReason reason)
         {
             ArgUtil.NotNull(reason, nameof(reason));

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -396,7 +396,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             var context = new Mock<IExecutionContext>();
             context.Setup(x => x.Error(It.IsAny<Exception>())).Callback( (Exception ex) => {
                 context.Object.AddIssue(new Issue() { Type = IssueType.Error, Message = ex.Message });
-                //Console.WriteLine(ex.ToString());
             });
             context.Setup(x => x.Error(It.IsAny<string>())).Callback( (string message) => {
                 context.Object.AddIssue(new Issue() { Type = IssueType.Error, Message = message });
@@ -405,16 +404,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 context.Object.AddIssue(new Issue() { Type = IssueType.Warning, Message = message });
             });
             context.Setup(x => x.Output(It.IsAny<string>())).Callback( (string message) => {
-                //Console.WriteLine(message);
             });
             context.Setup(x => x.Command(It.IsAny<string>())).Callback( (string message) => {
-                //Console.WriteLine(message);
             });
             context.Setup(x => x.Debug(It.IsAny<string>())).Callback( (string message) => {
-                //Console.WriteLine(message);
             });
             context.Setup(x => x.Section(It.IsAny<string>())).Callback( (string message) => {
-                //Console.WriteLine(message);
             });
 
             return context;

--- a/src/Test/L0/Worker/Build/BuildDirectoryManagerL0.cs
+++ b/src/Test/L0/Worker/Build/BuildDirectoryManagerL0.cs
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
             hc.SetSingleton<IConfigurationStore>(configStore.Object);
 
             // Setup the execution context.
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             List<string> warnings;
             _variables = new Variables(hc, new Dictionary<string, VariableValue>(), out warnings);
             _variables.Set(Constants.Variables.System.CollectionId, CollectionId);

--- a/src/Test/L0/Worker/Build/GitSourceProviderL0.cs
+++ b/src/Test/L0/Worker/Build/GitSourceProviderL0.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
         private Mock<IExecutionContext> GetTestExecutionContext(TestHostContext tc, string sourceFolder, string sourceBranch, string sourceVersion, bool enableAuth)
         {
             var trace = tc.GetTrace();
-            var executionContext = new Mock<IExecutionContext>();
+            var executionContext = tc.CreateExecutionContext();
             List<string> warnings;
             executionContext
                 .Setup(x => x.Variables)

--- a/src/Test/L0/Worker/Build/TfsVCSourceProvider.WorkspaceUtilL0.cs
+++ b/src/Test/L0/Worker/Build/TfsVCSourceProvider.WorkspaceUtilL0.cs
@@ -456,7 +456,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 },
             };
 
-            _executionContext = new Mock<IExecutionContext>();
+            _executionContext = hostContext.CreateExecutionContext();
             _executionContext
                 .Setup(x => x.WriteDebug)
                 .Returns(true);

--- a/src/Test/L0/Worker/Build/TrackingConfigHashAlgorithmL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingConfigHashAlgorithmL0.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 // Arrange.
                 var collectionId = "7aee6dde-6381-4098-93e7-50a8264cf066";
                 var definitionId = "7";
-                var executionContext = new Mock<IExecutionContext>();
+                var executionContext = tc.CreateExecutionContext();
                 List<string> warnings;
                 executionContext
                     .Setup(x => x.Variables)
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
 
                 // Make sure that only the coll, def, identifier, and url are used in the hash
                 Assert.Equal(
-                    TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1, repo2 }), 
+                    TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1, repo2 }),
                     TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1, repo2_newPath }));
 
                 // Make sure that different coll creates different hash

--- a/src/Test/L0/Worker/Build/TrackingConfigL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingConfigL0.cs
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
             var tc = new TestHostContext(this);
 
             // Setup the execution context.
-            mockExecutionContext = new Mock<IExecutionContext>();
+            mockExecutionContext = tc.CreateExecutionContext();
             List<string> warnings;
             var variables = new Variables(tc, new Dictionary<string, VariableValue>(), out warnings);
             variables.Set(Constants.Variables.System.CollectionId, CollectionId);

--- a/src/Test/L0/Worker/Build/TrackingManagerL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingManagerL0.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
             _workFolder = hc.GetDirectory(WellKnownDirectory.Work);
 
             // Setup the execution context.
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             List<string> warnings;
             _variables = new Variables(hc, new Dictionary<string, VariableValue>(), out warnings);
             _variables.Set(Constants.Variables.System.CollectionId, CollectionId);
@@ -142,11 +142,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 string sourceFolder = Path.Combine(_workFolder, "b00335b6");
 
                 // It doesn't matter for this test whether the line endings are CRLF or just LF.
-                string Contents = @"{ 
-    ""system"" : ""build"", 
-    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"", 
-    ""definitionId"" = ""7"", 
-    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"", 
+                string Contents = @"{
+    ""system"" : ""build"",
+    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"",
+    ""definitionId"" = ""7"",
+    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"",
     ""sourceFolder"" = """ + sourceFolder + @""",
     ""hashKey"" = ""b00335b6923adfa64f46f3abb7da1cdc0d9bae6c""
 }";
@@ -177,11 +177,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 string sourceFolder = Path.Combine(_workFolder, "b00335b6");
 
                 // It doesn't matter for this test whether the line endings are CRLF or just LF.
-                string contents = @"{ 
-    ""system"" : ""build"", 
-    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"", 
-    ""definitionId"" = ""7"", 
-    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"", 
+                string contents = @"{
+    ""system"" : ""build"",
+    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"",
+    ""definitionId"" = ""7"",
+    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"",
     ""sourceFolder"" = """ + sourceFolder + @""",
     ""hashKey"" = """"
 }";
@@ -208,11 +208,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 string sourceFolder = Path.Combine(_workFolder, "b00335b6");
 
                 // It doesn't matter for this test whether the line endings are CRLF or just LF.
-                string contents = @"{ 
-    ""system"" : ""build"", 
-    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"", 
-    ""definitionId"" = ""7"", 
-    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"", 
+                string contents = @"{
+    ""system"" : ""build"",
+    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"",
+    ""definitionId"" = ""7"",
+    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"",
     ""sourceFolder"" = """ + sourceFolder + @""",
     ""hashKey"" = ""b00335b6923adfa64f46f3abb7da1cdc0d9bae6c""
 }";
@@ -520,10 +520,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
 
                 // It doesn't matter for this test whether the line endings are CRLF or just LF.
                 string trackingContents = @"{
-    ""system"" : ""build"", 
-    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"", 
-    ""definitionId"" = ""7"", 
-    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"", 
+    ""system"" : ""build"",
+    ""collectionId"" = ""7aee6dde-6381-4098-93e7-50a8264cf066"",
+    ""definitionId"" = ""7"",
+    ""repositoryUrl"" = ""http://contoso:8080/tfs/DefaultCollection/_git/gitTest"",
     ""sourceFolder"" = """ + sourceFolder + @""",
     ""hashKey"" = ""b00335b6923adfa64f46f3abb7da1cdc0d9bae6c""
 }";

--- a/src/Test/L0/Worker/CodeCoverage/CoberturaSummaryReaderTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CoberturaSummaryReaderTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
         private void SetupMocks([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             _ec.Setup(x => x.AddIssue(It.IsAny<Issue>()))
             .Callback<Issue>
             ((issue) =>

--- a/src/Test/L0/Worker/CodeCoverage/CodeCoverageCommandExtensionTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CodeCoverageCommandExtensionTests.cs
@@ -344,7 +344,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
             _variables.Set("system.hostType", "build");
             endpointAuthorization.Parameters[EndpointAuthorizationParameters.AccessToken] = "accesstoken";
 
-            _ec = new Mock<IExecutionContext>();
+            _ec = _hc.CreateExecutionContext();
             _ec.Setup(x => x.Endpoints).Returns(new List<ServiceEndpoint> { new ServiceEndpoint { Url = new Uri("http://dummyurl"), Name = WellKnownServiceEndpointNames.SystemVssConnection, Authorization = endpointAuthorization } });
             _ec.Setup(x => x.Variables).Returns(_variables);
             _ec.Setup(x => x.TranslateToHostPath(It.IsAny<string>())).Returns( (string x) => x );

--- a/src/Test/L0/Worker/CodeCoverage/CodeCoverageUtilitiesTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CodeCoverageUtilitiesTests.cs
@@ -106,7 +106,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
 
         private void SetupMocks()
         {
-            _ec = new Mock<IExecutionContext>();
+            var tc = new TestHostContext(this);
+            _ec = tc.CreateExecutionContext();
             _ec.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>()))
                 .Callback<string, string>
                 ((tag, message) =>

--- a/src/Test/L0/Worker/CodeCoverage/JacocoSummaryReaderTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/JacocoSummaryReaderTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
         private void SetupMocks([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             _ec.Setup(x => x.AddIssue(It.IsAny<Issue>()))
            .Callback<Issue>
            ((issue) =>

--- a/src/Test/L0/Worker/ExpressionManagerL0.cs
+++ b/src/Test/L0/Worker/ExpressionManagerL0.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 hostContext: hc,
                 copy: new Dictionary<string, VariableValue>(),
                 warnings: out warnings);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             _ec.SetupAllProperties();
             _ec.Setup(x => x.Variables).Returns(_variables);
         }

--- a/src/Test/L0/Worker/Release/GitHubArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/GitHubArtifactL0.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
 
             _artifactDefinition = new ArtifactDefinition
             {

--- a/src/Test/L0/Worker/Release/JenkinsArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/JenkinsArtifactL0.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             _httpClient = new Mock<IGenericHttpClient>();
             _artifactDefinition = new ArtifactDefinition
             {

--- a/src/Test/L0/Worker/Release/ReleaseJobExtensionL0.cs
+++ b/src/Test/L0/Worker/Release/ReleaseJobExtensionL0.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
                 Directory.CreateDirectory(this.stubWorkFolder);
             }
 
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
 
             _extensionManager = new Mock<IExtensionManager>();
             _sourceProvider = new Mock<ISourceProvider>();

--- a/src/Test/L0/Worker/Release/TfsGitArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/TfsGitArtifactL0.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
 
             _artifactDefinition = new ArtifactDefinition
             {

--- a/src/Test/L0/Worker/Release/TfsVCArtifactL0.cs
+++ b/src/Test/L0/Worker/Release/TfsVCArtifactL0.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
         private TestHostContext Setup([CallerMemberName] string name = "")
         {
             TestHostContext hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
 
             _artifactDefinition = new ArtifactDefinition
             {

--- a/src/Test/L0/Worker/StepsRunnerL0.cs
+++ b/src/Test/L0/Worker/StepsRunnerL0.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 hostContext: hc,
                 copy: variablesToCopy,
                 warnings: out warnings);
-            _ec = new Mock<IExecutionContext>();
+            _ec = hc.CreateExecutionContext();
             _ec.SetupAllProperties();
             _ec.Setup(x => x.Variables).Returns(_variables);
             _stepsRunner = new StepsRunner();
@@ -53,9 +53,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 // Arrange.
                 var variableSets = new[]
                 {
-                    new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded)  },
-                    new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
-                    new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) }
+                    new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded)  },
+                    new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
+                    new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) }
                 };
                 foreach (var variableSet in variableSets)
                 {
@@ -85,12 +85,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 // Arrange.
                 var variableSets = new[]
                 {
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded)  },
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true)  },
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(TaskResult.Failed, ExpressionManager.SucceededOrFailed, true) },
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(TaskResult.Failed, ExpressionManager.Always, true) }
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded)  },
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true)  },
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(hc, TaskResult.Failed, ExpressionManager.SucceededOrFailed, true) },
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, true), CreateStep(hc, TaskResult.Failed, ExpressionManager.Always, true) }
                 };
                 foreach (var variableSet in variableSets)
                 {
@@ -122,12 +122,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 {
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
                         Expected = false,
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
                         Expected = true,
                     },
                 };
@@ -161,27 +161,27 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 {
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
                         Expected = TaskResult.Succeeded,
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
                         Expected = TaskResult.Failed,
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
                         Expected = TaskResult.Failed,
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Failed, ExpressionManager.Always) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Failed, ExpressionManager.Always) },
                         Expected = TaskResult.Failed,
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Failed, ExpressionManager.Always, true) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Failed, ExpressionManager.Always, true) },
                         Expected = TaskResult.SucceededWithIssues,
                     },
                 };
@@ -215,57 +215,57 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 {
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
                         Expected = TaskResult.Failed
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
                         Expected = TaskResult.Failed
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
                         Expected = TaskResult.Failed
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true), CreateStep(TaskResult.Failed, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true), CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded) },
                         Expected = TaskResult.Failed
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
                         Expected = TaskResult.SucceededWithIssues
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true), CreateStep(TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true), CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded, continueOnError: true) },
                         Expected = TaskResult.SucceededWithIssues
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
                         Expected = TaskResult.Succeeded
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Failed, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded) },
                         Expected = TaskResult.Failed
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.SucceededWithIssues, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.SucceededWithIssues, ExpressionManager.Succeeded) },
                         Expected = TaskResult.SucceededWithIssues
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.SucceededWithIssues, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.SucceededWithIssues, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
                         Expected = TaskResult.SucceededWithIssues
                     },
                     new
                     {
-                        Steps = new[] { CreateStep(TaskResult.SucceededWithIssues, ExpressionManager.Succeeded), CreateStep(TaskResult.Failed, ExpressionManager.Succeeded) },
+                        Steps = new[] { CreateStep(hc, TaskResult.SucceededWithIssues, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded) },
                         Expected = TaskResult.Failed
                     },
                 //  Abandoned
@@ -304,17 +304,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 {
                     new
                     {
-                        Step = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                        Step = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
                         Expected = false
                     },
                     new
                     {
-                        Step = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
+                        Step = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.SucceededOrFailed) },
                         Expected = true
                     },
                     new
                     {
-                        Step = new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
+                        Step = new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
                         Expected = true
                     }
                 };
@@ -345,10 +345,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 // Arrange.
                 var variableSets = new[]
                 {
-                    new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
-                    new[] { CreateStep(TaskResult.SucceededWithIssues, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
-                    new[] { CreateStep(TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) },
-                    new[] { CreateStep(TaskResult.Canceled, ExpressionManager.Succeeded), CreateStep(TaskResult.Succeeded, ExpressionManager.Always) }
+                    new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
+                    new[] { CreateStep(hc, TaskResult.SucceededWithIssues, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
+                    new[] { CreateStep(hc, TaskResult.Failed, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) },
+                    new[] { CreateStep(hc, TaskResult.Canceled, ExpressionManager.Succeeded), CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Always) }
                 };
                 foreach (var variableSet in variableSets)
                 {
@@ -382,8 +382,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 // Arrange.
                 var variableSets = new[]
                 {
-                    new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
-                    new[] { CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                    new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
+                    new[] { CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded) },
                 };
                 foreach (var variableSet in variableSets)
                 {
@@ -410,11 +410,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var stepTarget = new Pipelines.StepTarget {
                     Target = "container"
                 };
-                var step = CreateStep(TaskResult.Succeeded, ExpressionManager.Succeeded);
+                var step = CreateStep(hc, TaskResult.Succeeded, ExpressionManager.Succeeded);
                 step.Setup(x => x.Target).Returns(stepTarget);
 
                 // Override step context
-                var stepContext = new Mock<IExecutionContext>();
+                var stepContext = hc.CreateExecutionContext();
                 stepContext.SetupAllProperties();
                 stepContext.Setup(x => x.Variables).Returns(_variables);
                 stepContext.Setup(x => x.Complete(It.IsAny<TaskResult?>(), It.IsAny<string>(), It.IsAny<string>()))
@@ -437,7 +437,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             }
         }
 
-        private Mock<IStep> CreateStep(TaskResult result, IExpressionNode condition, Boolean continueOnError = false)
+        private Mock<IStep> CreateStep(TestHostContext hc, TaskResult result, IExpressionNode condition, Boolean continueOnError = false)
         {
             // Setup the step.
             var step = new Mock<IStep>();
@@ -447,7 +447,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             step.Setup(x => x.RunAsync()).Returns(Task.CompletedTask);
 
             // Setup the step execution context.
-            var stepContext = new Mock<IExecutionContext>();
+            var stepContext = hc.CreateExecutionContext();
             stepContext.SetupAllProperties();
             stepContext.Setup(x => x.Variables).Returns(_variables);
             stepContext.Setup(x => x.Complete(It.IsAny<TaskResult?>(), It.IsAny<string>(), It.IsAny<string>()))

--- a/src/Test/L0/Worker/TaskCommandExtensionL0.cs
+++ b/src/Test/L0/Worker/TaskCommandExtensionL0.cs
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         private void SetupMocks([CallerMemberName] string name = "")
         {
             _hc = new TestHostContext(this, name);
-            _ec = new Mock<IExecutionContext>();
+            _ec = _hc.CreateExecutionContext();
 
             _endpoint = new ServiceEndpoint()
             {

--- a/src/Test/L0/Worker/TaskManagerL0.cs
+++ b/src/Test/L0/Worker/TaskManagerL0.cs
@@ -261,7 +261,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 }
                 else
                 {
-                    Assert.Null(definition.Data.Execution.Process);    
+                    Assert.Null(definition.Data.Execution.Process);
                 }
             }
             finally
@@ -413,7 +413,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Trait("Category", "Worker")]
         public void ExtractsAnAlreadyDownloadedZipToTheCorrectLocation()
         {
-            try 
+            try
             {
                 // Arrange
                 Setup(signatureVerificationEnabled: true);
@@ -754,14 +754,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             _ecTokenSource?.Dispose();
             _ecTokenSource = new CancellationTokenSource();
 
+            // Test host context.
+            _hc = new TestHostContext(this, name);
+
             // Mocks.
             _jobServer = new Mock<IJobServer>();
             _taskServer = new Mock<ITaskServer>();
-            _ec = new Mock<IExecutionContext>();
+            _ec = _hc.CreateExecutionContext();
             _ec.Setup(x => x.CancellationToken).Returns(_ecTokenSource.Token);
-
-            // Test host context.
-            _hc = new TestHostContext(this, name);
 
             // Random work folder.
             _workFolder = _hc.GetDirectory(WellKnownDirectory.Work);

--- a/src/Test/L0/Worker/Telemetry/TelemetryCommandExtensionTests.cs
+++ b/src/Test/L0/Worker/Telemetry/TelemetryCommandExtensionTests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Telemetry
             var variables = new Variables(_hc, new Dictionary<string, VariableValue>(), out warnings);
             endpointAuthorization.Parameters[EndpointAuthorizationParameters.AccessToken] = "accesstoken";
 
-            _ec = new Mock<IExecutionContext>();
+            _ec = _hc.CreateExecutionContext();
             _ec.Setup(x => x.Endpoints).Returns(new List<ServiceEndpoint> { new ServiceEndpoint { Url = new Uri("http://dummyurl"), Name = WellKnownServiceEndpointNames.SystemVssConnection, Authorization = endpointAuthorization } });
             _ec.Setup(x => x.Variables).Returns(variables);
             var asyncCommands = new List<IAsyncCommandContext>();


### PR DESCRIPTION
This PR has two goals:

1. Make IExecutionContext and AgentTaskPluginExecutionContext share a common interface
2. Update GitCliManager and GitCommandManger to use this common interface

