### PR TITLE
Fixed to specify bash instead of script

### DIFF
--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -16,9 +16,9 @@ steps:
 
 # Build agent layout
 - script: |
-    echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-    echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-    echo "##vso[task.prependpath]C:\Program Files\Git\bin"
+    @echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+    @echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+    @echo "##vso[task.prependpath]C:\Program Files\Git\bin"
     dev.cmd layout Release
   workingDirectory: src
   displayName: Build & Layout Release
@@ -26,9 +26,9 @@ steps:
 
 # Run test
 - script: |
-    echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-    echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-    echo "##vso[task.prependpath]C:\Program Files\Git\bin"
+    @echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+    @echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+    @echo "##vso[task.prependpath]C:\Program Files\Git\bin"
     dev.cmd test
   workingDirectory: src
   displayName: Test

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -14,6 +14,14 @@ steps:
 - checkout: self
   clean: true
 
+- script: |
+    echo Begin Path Setup
+    echo ##vso[task.prependpath]C:\Program Files\Git\mingw64\bin
+    echo ##vso[task.prependpath]C:\Program Files\Git\usr\bin
+    echo ##vso[task.prependpath]C:\Program Files\Git\bin
+    echo End Path Setup
+  displayName: Setup Path
+
 # Build agent layout
 - script: dev.cmd layout Release
   workingDirectory: src

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -16,9 +16,9 @@ steps:
 
 # Build agent layout
 - script: |
-    Write-Host "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-    Write-Host "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-    Write-Host "##vso[task.prependpath]C:\Program Files\Git\bin"
+    echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+    echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+    echo "##vso[task.prependpath]C:\Program Files\Git\bin"
     dev.cmd layout Release
   workingDirectory: src
   displayName: Build & Layout Release
@@ -26,9 +26,9 @@ steps:
 
 # Run test
 - script: |
-    Write-Host "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-    Write-Host "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-    Write-Host "##vso[task.prependpath]C:\Program Files\Git\bin"
+    echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+    echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+    echo "##vso[task.prependpath]C:\Program Files\Git\bin"
     dev.cmd test
   workingDirectory: src
   displayName: Test

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -15,12 +15,21 @@ steps:
   clean: true
 
 # Build agent layout
-- bash: ./dev.sh layout Release
+- script: |
+    Write-Host "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+    Write-Host "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+    Write-Host "##vso[task.prependpath]C:\Program Files\Git\bin"
+    dev.cmd layout Release
   workingDirectory: src
   displayName: Build & Layout Release
 
+
 # Run test
-- bash: ./dev.sh test
+- script: |
+    Write-Host "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+    Write-Host "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+    Write-Host "##vso[task.prependpath]C:\Program Files\Git\bin"
+    dev.cmd test
   workingDirectory: src
   displayName: Test
 

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -15,12 +15,12 @@ steps:
   clean: true
 
 # Build agent layout
-- script: dev.cmd layout Release
+- bash: ./dev.sh layout Release
   workingDirectory: src
   displayName: Build & Layout Release
 
 # Run test
-- script: dev.cmd test
+- bash: ./dev.sh test
   workingDirectory: src
   displayName: Test
 

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -15,21 +15,13 @@ steps:
   clean: true
 
 # Build agent layout
-- script: |
-    @echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-    @echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-    @echo "##vso[task.prependpath]C:\Program Files\Git\bin"
-    dev.cmd layout Release
+- script: dev.cmd layout Release
   workingDirectory: src
   displayName: Build & Layout Release
 
 
 # Run test
-- script: |
-    @echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-    @echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-    @echo "##vso[task.prependpath]C:\Program Files\Git\bin"
-    dev.cmd test
+- script: dev.cmd test
   workingDirectory: src
   displayName: Test
 

--- a/src/dev.cmd
+++ b/src/dev.cmd
@@ -23,8 +23,8 @@ echo Unable to resolve location of sh.exe. 1>&2
 exit /b 1
 
 :run
-echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
-echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
-echo "##vso[task.prependpath]C:\Program Files\Git\bin"
+echo ##vso[task.prependpath]"C:\Program Files\Git\mingw64\bin"
+echo ##vso[task.prependpath]"C:\Program Files\Git\usr\bin"
+echo ##vso[task.prependpath]"C:\Program Files\Git\bin"
 echo on
 "%SH_PATH%" "%~dp0dev.sh" %*

--- a/src/dev.cmd
+++ b/src/dev.cmd
@@ -23,10 +23,6 @@ echo Unable to resolve location of sh.exe. 1>&2
 exit /b 1
 
 :run
-echo "Prepending Paths"
-echo ##vso[task.prependpath]"C:\Program Files\Git\mingw64\bin"
-echo ##vso[task.prependpath]"C:\Program Files\Git\usr\bin"
-echo ##vso[task.prependpath]"C:\Program Files\Git\bin"
-echo "%PATH%"
+echo Path=%PATH%
 echo on
 "%SH_PATH%" "%~dp0dev.sh" %*

--- a/src/dev.cmd
+++ b/src/dev.cmd
@@ -23,8 +23,10 @@ echo Unable to resolve location of sh.exe. 1>&2
 exit /b 1
 
 :run
+echo "Prepending Paths"
 echo ##vso[task.prependpath]"C:\Program Files\Git\mingw64\bin"
 echo ##vso[task.prependpath]"C:\Program Files\Git\usr\bin"
 echo ##vso[task.prependpath]"C:\Program Files\Git\bin"
+echo "%PATH%"
 echo on
 "%SH_PATH%" "%~dp0dev.sh" %*

--- a/src/dev.cmd
+++ b/src/dev.cmd
@@ -23,5 +23,8 @@ echo Unable to resolve location of sh.exe. 1>&2
 exit /b 1
 
 :run
+echo "##vso[task.prependpath]C:\Program Files\Git\mingw64\bin"
+echo "##vso[task.prependpath]C:\Program Files\Git\usr\bin"
+echo "##vso[task.prependpath]C:\Program Files\Git\bin"
 echo on
 "%SH_PATH%" "%~dp0dev.sh" %*


### PR DESCRIPTION
Testing to see if this fixes the issue we are seeing with an issue where 'find' is no longer
available in the installed version of git bash on the windows x64 image