### PR TITLE
Ensure agent does not receive new work in runOnce mode

### DIFF
--- a/src/Agent.Listener/JobDispatcher.cs
+++ b/src/Agent.Listener/JobDispatcher.cs
@@ -90,6 +90,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             if (runOnce)
             {
                 Trace.Info("Start dispatcher for one time used agent.");
+                jobRequestMessage.Variables[Constants.Variables.Agent.RunMode] = new VariableValue(Constants.Agent.CommandLine.Flags.Once);
                 newDispatch.WorkerDispatch = RunOnceAsync(jobRequestMessage, currentDispatch, newDispatch.WorkerCancellationTokenSource.Token, newDispatch.WorkerCancelTimeoutKillTokenSource.Token);
             }
             else

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -375,7 +375,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
 
             Trace.Info("Raising job completed event.");
-            var jobCompletedEvent = new JobCompletedEvent(message.RequestId, message.JobId, result);
+            var jobCompletedEvent = new JobCompletedEvent(message.RequestId, message.JobId, result,
+                jobContext.Variables.Get(Constants.Variables.Agent.RunMode) == Constants.Agent.CommandLine.Flags.Once);
 
             var completeJobRetryLimit = 5;
             var exceptions = new List<Exception>();

--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.147-private</VssApiVersion>
+    <VssApiVersion>0.5.148-private</VssApiVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -287,6 +287,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 public static readonly string RetainDefaultEncoding = "agent.retainDefaultEncoding";
                 public static readonly string ReadOnlyVariables = "agent.readOnlyVariables";
                 public static readonly string RootDirectory = "agent.RootDirectory";
+                public static readonly string RunMode = "agent.runMode";
                 public static readonly string ServerOMDirectory = "agent.ServerOMDirectory";
                 public static readonly string ServicePortPrefix = "agent.services";
                 public static readonly string SslCAInfo = "agent.cainfo";
@@ -450,6 +451,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 Agent.RetainDefaultEncoding,
                 Agent.ReadOnlyVariables,
                 Agent.RootDirectory,
+                Agent.RunMode,
                 Agent.ServerOMDirectory,
                 Agent.ServicePortPrefix,
                 Agent.SslCAInfo,


### PR DESCRIPTION
Send back whether the agent is going to be shutting down as soon as we report work is finished.

This way the server will know not to send new work to the agent in the time between the JobCompletedEvent and process shutdown.