### PR TITLE
Correctly updating the repository path in Multi-Checkout mode

### DIFF
--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -90,12 +90,6 @@ namespace Agent.Plugins.Repository
         {
             return executionContext != null && RepositoryUtil.HasMultipleCheckouts(executionContext.JobSettings);
         }
-
-        protected bool ShouldUpdateRepositoryPath(AgentTaskPluginExecutionContext executionContext, string repositoryAlias)
-        {
-            // Only update the repo path if this is the only checkout task or this checkout task is for the 'self' repo
-            return !HasMultipleCheckouts(executionContext) || RepositoryUtil.IsPrimaryRepositoryName(repositoryAlias);
-        }
     }
 
     public class CheckoutTask : RepositoryTask
@@ -158,11 +152,8 @@ namespace Agent.Plugins.Repository
                 expectRepoPath = Path.Combine(buildDirectory, sourcesDirectory);
             }
 
-            // Don't update the repository path for every checkout task (it should only be updated once)
-            if (ShouldUpdateRepositoryPath(executionContext, repo.Alias))
-            {
-                executionContext.UpdateRepositoryPath(repoAlias, expectRepoPath);
-            }
+            // Update the repository path in the worker process
+            executionContext.UpdateRepositoryPath(repoAlias, expectRepoPath);
 
             executionContext.Debug($"Repository requires to be placed at '{expectRepoPath}', current location is '{currentRepoPath}'");
             if (!string.Equals(currentRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), expectRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), IOUtil.FilePathStringComparison))


### PR DESCRIPTION
This fixes issue #2718

Previously, the code was only triggering the UpdateRepositoryPath command in the worker for the "self" repo. This fixes the code so that we always update the repo path in the worker. The part of the worker code that only needs to happen for "self" is now in a code block.

**Testing**
I added a unit test that caught the problem and verified that the fix worked by passing the test.

**TODO**
I am going to manually run the Multi-Checkout build canary scenarios to make sure that nothing got broke for Multi-Checkout.