### PR TITLE
Translate variables on expand

### DIFF
--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -66,6 +66,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
 
                 // Variable expansion.
+                step.ExecutionContext.SetStepTarget(step.Target);
                 List<string> expansionWarnings;
                 step.ExecutionContext.Variables.RecalculateExpanded(out expansionWarnings);
                 expansionWarnings?.ForEach(x => step.ExecutionContext.Warning(x));
@@ -205,7 +206,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             Trace.Info("Starting the step.");
             step.ExecutionContext.Section(StringUtil.Loc("StepStarting", step.DisplayName));
             step.ExecutionContext.SetTimeout(timeout: step.Timeout);
-            step.ExecutionContext.SetStepTarget(step.Target);
 
             // Windows may not be on the UTF8 codepage; try to fix that
             await SwitchToUtf8Codepage(step);

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -539,7 +539,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                     }
 
                                     stack.Push(state);
-                                    state = new RecursionState(name: nestedName, value: nestedVariable.Value ?? string.Empty);
+                                    state = new RecursionState(name: nestedName, value: StringTranslator(nestedVariable.Value ?? string.Empty));
                                 }
                             }
                             else

--- a/src/Test/L0/Worker/VariablesL0.cs
+++ b/src/Test/L0/Worker/VariablesL0.cs
@@ -633,6 +633,41 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public void RecalculateExpanded_PathTranslator()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                // Arrange.
+                var copy = new Dictionary<string, VariableValue>
+                {
+                    { "variable1", "run $(variable2)" },
+                    { "variable2", "/path/to/something" },
+                };
+
+                List<string> warnings;
+                var variables = new Variables(hc, copy, out warnings);
+                variables.StringTranslator = (str) => {
+                    if (str.StartsWith("/path/to")) {
+                        return str.Replace("/path/to", "/another/path");
+                    }
+                    return str;
+                };;
+
+                Assert.Equal(0, warnings.Count);
+
+                // Act.
+                variables.RecalculateExpanded(out warnings);
+
+                // Assert.
+                Assert.Equal(0, warnings.Count);
+                Assert.Equal("run /another/path/something", variables.Get("variable1"));
+                Assert.Equal("/another/path/something", variables.Get("variable2"));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public void Set_CanConvertAPublicValueIntoASecretValue()
         {
             using (TestHostContext hc = new TestHostContext(this))


### PR DESCRIPTION
In steps with containers, paths are not being translated properly if they are constructed from other variables.

This fixes that by moving the code to set the step target to where variable expansions are recalculated and then translating them during expansion.