### PR TITLE
Ensure sourcesToBuild is populated

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -863,7 +863,7 @@ namespace Agent.Plugins.Repository
             {
                 sourcesToBuild = refFetchedByCommit;
             }
-            else if (IsPullRequest(sourceBranch) && string.IsNullOrEmpty(sourceVersion))
+            else if (string.IsNullOrEmpty(sourceVersion))
             {
                 sourcesToBuild = GetRemoteRefName(sourceBranch);
             }


### PR DESCRIPTION
Users are seeing `git checkout --progress --force` with no commit or branch following.  This causes an error on checkout.

I believe [this PR](https://github.com/microsoft/azure-pipelines-agent/pull/2699) introduced the bug by allowing sourcesToBuild to be empty if sourceVersion is empty.

This change preserves the behavior that PR was trying to fix.