### PR TITLE
Calculating the right test outcome to set the context result.

### DIFF
--- a/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
@@ -363,7 +363,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
                     default: break;
                 }
 
-                if(!_calculateTestRunSummary)
+                if(!_calculateTestRunSummary && anyFailedTests)
                 {
                     return anyFailedTests;
                 }

--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                         default: break;
                     }
 
-                    if(!_calculateTestRunSummary)
+                    if(!_calculateTestRunSummary && anyFailedTests)
                     {
                         return anyFailedTests;
                     }


### PR DESCRIPTION
### Change
When tests were failed, while calculating the outcome the loop was not considering the all outcomes.
It was returning after the first result check. Hence fixed to consider until we find the failed result.

### Details
It's a Bug when trying to calculate the test run summary. But when FF was not enabled we wanted to return as soon as get the failed tests.

### Impact
User pipelines are passing even when there are failed tests are getting published.