### PR TITLE
SelfUpdater: Add `--no-same-owner` to `tar` invocation

### DIFF
--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     
                     if (string.IsNullOrEmpty(tar))
                     {
-                        throw new NotSupportedException($"tar -xzf");
+                        throw new NotSupportedException($"tar --no-same-owner -xzf");
                     }
 
                     // tar -xzf
@@ -272,10 +272,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                             }
                         });
 
-                        int exitCode = await processInvoker.ExecuteAsync(latestAgentDirectory, tar, $"-xzf \"{archiveFile}\"", null, token);
+                        int exitCode = await processInvoker.ExecuteAsync(latestAgentDirectory, tar, $"--no-same-owner -xzf \"{archiveFile}\"", null, token);
                         if (exitCode != 0)
                         {
-                            throw new NotSupportedException($"Can't use 'tar -xzf' extract archive file: {archiveFile}. return code: {exitCode}.");
+                            throw new NotSupportedException($"Can't use 'tar --no-same-owner -xzf' extract archive file: {archiveFile}. return code: {exitCode}.");
                         }
                     }
                 }


### PR DESCRIPTION
This avoids having `tar` attempt to set the original owner and access times for files when extracting them as `root`.  While not best practice on multi-user systems, single-user systems (such as Alpine, or a chroot user namespace) run all processes as `root`, and it is possible to get a `tar` on that system that will attempt to set e.g. `UID 1000` from a tarball when that doesn't make any sense.  As the Azure Pipelines agent doesn't really care about file ownership in this case, this flag should be completely safe to set, and should have no effect outside of the cases where it is needed.