### PR TITLE
Fix random "JsonReaderException" on OpenShift

### DIFF
--- a/src/Agent.Listener/JobDispatcher.cs
+++ b/src/Agent.Listener/JobDispatcher.cs
@@ -369,11 +369,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     // The worker will shutdown after 30 seconds if it hasn't received the job message.
                     processChannel.StartServer(
                         // Delegate to start the child process.
-                        startProcess: (string pipeHandleOut, string pipeHandleIn) =>
+                        startProcess: (string host, int port) =>
                         {
                             // Validate args.
-                            ArgUtil.NotNullOrEmpty(pipeHandleOut, nameof(pipeHandleOut));
-                            ArgUtil.NotNullOrEmpty(pipeHandleIn, nameof(pipeHandleIn));
+                            ArgUtil.NotNullOrEmpty(host, nameof(host));
+                            ArgUtil.NotNull(port, nameof(port));
 
                             // Save STDOUT from worker, worker will use STDOUT report unhandle exception.
                             processInvoker.OutputDataReceived += delegate (object sender, ProcessDataReceivedEventArgs stdout)
@@ -407,7 +407,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                             workerProcessTask = processInvoker.ExecuteAsync(
                                 workingDirectory: assemblyDirectory,
                                 fileName: workerFileName,
-                                arguments: "spawnclient " + pipeHandleOut + " " + pipeHandleIn,
+                                arguments: "spawnclient " + host + " " + port,
                                 environment: null,
                                 requireExitCodeZero: false,
                                 outputEncoding: null,

--- a/src/Agent.Worker/Program.cs
+++ b/src/Agent.Worker/Program.cs
@@ -47,8 +47,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 // Run the worker.
                 return await worker.RunAsync(
-                    pipeIn: args[1],
-                    pipeOut: args[2]);
+                    host: args[1],
+                    port: int.Parse(args[2]));
             }
             catch (Exception ex)
             {

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     [ServiceLocator(Default = typeof(Worker))]
     public interface IWorker : IAgentService
     {
-        Task<int> RunAsync(string pipeIn, string pipeOut);
+        Task<int> RunAsync(string host, int port);
     }
 
     public sealed class Worker : AgentService, IWorker
@@ -24,11 +24,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         private static readonly char[] _quoteLikeChars = new char[] {'\'', '"'};
 
 
-        public async Task<int> RunAsync(string pipeIn, string pipeOut)
+        public async Task<int> RunAsync(string host, int port)
         {
             // Validate args.
-            ArgUtil.NotNullOrEmpty(pipeIn, nameof(pipeIn));
-            ArgUtil.NotNullOrEmpty(pipeOut, nameof(pipeOut));
+            ArgUtil.NotNullOrEmpty(host, nameof(host));
+            ArgUtil.NotNull(port, nameof(port));
             var agentWebProxy = HostContext.GetService<IVstsAgentWebProxy>();
             var agentCertManager = HostContext.GetService<IAgentCertificateManager>();
             VssUtil.InitializeVssClientSettings(HostContext.UserAgent, agentWebProxy.WebProxy, agentCertManager.VssClientCertificateManager);
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             using (var channelTokenSource = new CancellationTokenSource())
             {
                 // Start the channel.
-                channel.StartClient(pipeIn, pipeOut);
+                channel.StartClient(host, port);
 
                 // Wait for up to 30 seconds for a message from the channel.
                 HostContext.WritePerfCounter("WorkerWaitingForJobMessage");

--- a/src/Test/L0/Listener/JobDispatcherL0.cs
+++ b/src/Test/L0/Listener/JobDispatcherL0.cs
@@ -64,12 +64,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage();
                 string strMessage = JsonUtility.ToString(message);
 
-                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 127.0.0.1 12345", null, It.IsAny<CancellationToken>()))
+                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 127.0.0.1 0", null, It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult<int>(56));
 
-
                 _processChannel.Setup(x => x.StartServer(It.IsAny<StartProcessDelegate>(), It.IsAny<bool>()))
-                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 12345); });
+                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 0); });
                 _processChannel.Setup(x => x.SendAsync(MessageType.NewJobRequest, It.Is<string>(s => s.Equals(strMessage)), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask);
 
@@ -472,12 +471,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage();
                 string strMessage = JsonUtility.ToString(message);
 
-                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 127.0.0.1 12345", null, It.IsAny<CancellationToken>()))
+                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 127.0.0.1 0", null, It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult<int>(56));
 
-
                 _processChannel.Setup(x => x.StartServer(It.IsAny<StartProcessDelegate>(), It.IsAny<bool>()))
-                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 12345); });
+                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 0); });
                 _processChannel.Setup(x => x.SendAsync(MessageType.NewJobRequest, It.Is<string>(s => s.Equals(strMessage)), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask);
 

--- a/src/Test/L0/Listener/JobDispatcherL0.cs
+++ b/src/Test/L0/Listener/JobDispatcherL0.cs
@@ -64,11 +64,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage();
                 string strMessage = JsonUtility.ToString(message);
 
-                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 1 2", null, It.IsAny<CancellationToken>()))
+                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 127.0.0.1 12345", null, It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult<int>(56));
 
+
                 _processChannel.Setup(x => x.StartServer(It.IsAny<StartProcessDelegate>(), It.IsAny<bool>()))
-                    .Callback((StartProcessDelegate startDel, bool disposeClient) => { startDel("1", "2"); });
+                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 12345); });
                 _processChannel.Setup(x => x.SendAsync(MessageType.NewJobRequest, It.Is<string>(s => s.Equals(strMessage)), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask);
 
@@ -471,11 +472,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage();
                 string strMessage = JsonUtility.ToString(message);
 
-                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 1 2", null, It.IsAny<CancellationToken>()))
+                _processInvoker.Setup(x => x.ExecuteAsync(It.IsAny<String>(), It.IsAny<String>(), "spawnclient 127.0.0.1 12345", null, It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult<int>(56));
 
+
                 _processChannel.Setup(x => x.StartServer(It.IsAny<StartProcessDelegate>(), It.IsAny<bool>()))
-                    .Callback((StartProcessDelegate startDel, bool disposeClient) => { startDel("1", "2"); });
+                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 12345); });
                 _processChannel.Setup(x => x.SendAsync(MessageType.NewJobRequest, It.Is<string>(s => s.Equals(strMessage)), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask);
 

--- a/src/Test/L0/Listener/JobDispatcherL0.cs
+++ b/src/Test/L0/Listener/JobDispatcherL0.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                     .Returns(Task.FromResult<int>(56));
 
                 _processChannel.Setup(x => x.StartServer(It.IsAny<StartProcessDelegate>(), It.IsAny<bool>()))
-                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 0); });
+                    .Callback((StartProcessDelegate startDel, bool disposeClient) => { startDel("127.0.0.1", 0); });
                 _processChannel.Setup(x => x.SendAsync(MessageType.NewJobRequest, It.Is<string>(s => s.Equals(strMessage)), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask);
 
@@ -475,7 +475,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                     .Returns(Task.FromResult<int>(56));
 
                 _processChannel.Setup(x => x.StartServer(It.IsAny<StartProcessDelegate>(), It.IsAny<bool>()))
-                    .Callback((StartProcessDelegate startDel) => { startDel("127.0.0.1", 0); });
+                    .Callback((StartProcessDelegate startDel, bool disposeClient) => { startDel("127.0.0.1", 0); });
                 _processChannel.Setup(x => x.SendAsync(MessageType.NewJobRequest, It.Is<string>(s => s.Equals(strMessage)), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask);
 

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -110,10 +110,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                     .Returns(Task.FromResult<TaskResult>(TaskResult.Succeeded));
 
                 //Act
-                await worker.RunAsync(pipeIn: "1", pipeOut: "2");
+                await worker.RunAsync(host: "127.0.0.1", port: 12345);
 
                 //Assert
-                _processChannel.Verify(x => x.StartClient("1", "2"), Times.Once());
+                _processChannel.Verify(x => x.StartClient("127.0.0.1", 12345), Times.Once());
                 _jobRunner.Verify(x => x.RunAsync(
                     It.Is<Pipelines.AgentJobRequestMessage>(y => IsMessageIdentical(y, jobMessage)), It.IsAny<CancellationToken>()));
                 tokenSource.Cancel();
@@ -164,10 +164,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
                 //Act
                 await Assert.ThrowsAsync<TaskCanceledException>(
-                    async () => await worker.RunAsync("1", "2"));
+                    async () => await worker.RunAsync("127.0.0.1", 12345));
 
                 //Assert
-                _processChannel.Verify(x => x.StartClient("1", "2"), Times.Once());
+                _processChannel.Verify(x => x.StartClient("127.0.0.1", 12345), Times.Once());
                 _jobRunner.Verify(x => x.RunAsync(
                     It.Is<Pipelines.AgentJobRequestMessage>(y => IsMessageIdentical(y, jobMessage)), It.IsAny<CancellationToken>()));
             }

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -110,10 +110,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                     .Returns(Task.FromResult<TaskResult>(TaskResult.Succeeded));
 
                 //Act
-                await worker.RunAsync(host: "127.0.0.1", port: 12345);
+                await worker.RunAsync(host: "127.0.0.1", port: 0);
 
                 //Assert
-                _processChannel.Verify(x => x.StartClient("127.0.0.1", 12345), Times.Once());
+                _processChannel.Verify(x => x.StartClient("127.0.0.1", 0), Times.Once());
                 _jobRunner.Verify(x => x.RunAsync(
                     It.Is<Pipelines.AgentJobRequestMessage>(y => IsMessageIdentical(y, jobMessage)), It.IsAny<CancellationToken>()));
                 tokenSource.Cancel();
@@ -164,10 +164,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
                 //Act
                 await Assert.ThrowsAsync<TaskCanceledException>(
-                    async () => await worker.RunAsync("127.0.0.1", 12345));
+                    async () => await worker.RunAsync("127.0.0.1", 0));
 
                 //Assert
-                _processChannel.Verify(x => x.StartClient("127.0.0.1", 12345), Times.Once());
+                _processChannel.Verify(x => x.StartClient("127.0.0.1", 0), Times.Once());
                 _jobRunner.Verify(x => x.RunAsync(
                     It.Is<Pipelines.AgentJobRequestMessage>(y => IsMessageIdentical(y, jobMessage)), It.IsAny<CancellationToken>()));
             }

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -188,13 +188,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             // Setup the anonymous pipes to use for communication with the worker.
             using (var processChannel = HostContext.CreateService<IProcessChannel>())
             {
-                processChannel.StartServer(startProcess: (string pipeHandleOut, string pipeHandleIn) =>
+                processChannel.StartServer(startProcess: (string host, int port) =>
                 {
                     // Run the worker
                     // Note: this happens on the same process as the test
                     workerTask = worker.RunAsync(
-                        pipeIn: pipeHandleOut,
-                        pipeOut: pipeHandleIn);
+                        host: host,
+                        port: port);
                 }, disposeClient: false);
 
                 // Send the job request message to the worker


### PR DESCRIPTION
I am facing a problem where the pipeline randomly fails due to a "parse" error.
```
##[error]Newtonsoft.Json.JsonReaderException: After parsing a value an unexpected character was encountered: m. Path 'mask[2].value', line 1, position 671.
   at Newtonsoft.Json.JsonTextReader.ParsePostValue(Boolean ignoreComments)
   at Newtonsoft.Json.JsonTextReader.Read()
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Microsoft.VisualStudio.Services.WebApi.JsonUtility.FromString[T](String toDeserialize, JsonSerializerSettings settings)
   at Microsoft.VisualStudio.Services.Agent.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at Microsoft.VisualStudio.Services.Agent.Worker.Program.MainAsync(IHostContext context, String[] args)
Error reported in diagnostic logs. Please examine the log for more details.
    - /azp/agent/_diag/Worker_20200206-183547-utc.log
,##[error]We stopped hearing from agent vsts-agent-master-0. Verify the agent machine is running and has a healthy network connection. Anything that terminates an agent process, starves it for CPU, or blocks its network access can cause this error. For more information, see: https://go.microsoft.com/fwlink/?linkid=846610
```
The agents are running within OpenShift and the error usually occurs during the day, that is, at the peak time.
After debugging I found that the communication message between the "agent" and the "worker" was being corrupted. I don't understand how internally the "AnonymousPipe" protocol works, so I changed it to use TCP socket due to packet delivery reliability.
We are using the agent with these changes and we have not had the described problem.

OpenShift Master:
    v3.11.117 
Kubernetes Master:
    v1.11.0+d4cacc0 