### PR TITLE
Make CA1303 hidden

### DIFF
--- a/src/rules.ruleset
+++ b/src/rules.ruleset
@@ -42,7 +42,7 @@
       <Rule Id="CA1067" Action="Warning" />          <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
       <Rule Id="CA1068" Action="Warning" />          <!-- CancellationToken parameters must come last -->
       <Rule Id="CA1200" Action="Warning" />          <!-- Avoid using cref tags with a prefix -->
-      <Rule Id="CA1303" Action="Warning" />          <!-- Do not pass literals as localized parameters -->
+      <Rule Id="CA1303" Action="Hidden" />           <!-- Do not pass literals as localized parameters -->
       <Rule Id="CA1304" Action="Warning" />          <!-- Specify CultureInfo -->
       <Rule Id="CA1305" Action="Warning" />          <!-- Specify IFormatProvider -->
       <Rule Id="CA1307" Action="Warning" />          <!-- Specify StringComparison -->


### PR DESCRIPTION
Testing out marking a rule as hidden and this one seems unimportant given all the other ones.