### PR TITLE
Fix test commands

### DIFF
--- a/src/dev.sh
+++ b/src/dev.sh
@@ -109,17 +109,6 @@ function cmd_layout ()
     bash ./Misc/externals.sh $RUNTIME_ID || checkRC externals.sh
 }
 
-function cmd_test ()
-{
-    heading "Testing"
-
-    if [[ ("$CURRENT_PLATFORM" == "linux") || ("$CURRENT_PLATFORM" == "darwin") ]]; then
-        ulimit -n 1024
-    fi
-
-    dotnet msbuild -t:test -p:PackageRuntime="${RUNTIME_ID}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:SkipOn="${CURRENT_PLATFORM}" || failed "failed tests"
-}
-
 function cmd_test_l0 ()
 {
     heading "Testing L0"
@@ -146,6 +135,13 @@ function cmd_test_l1 ()
     fi
 
     dotnet msbuild -t:testl1 -p:PackageRuntime="${RUNTIME_ID}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:SkipOn="${CURRENT_PLATFORM}" || failed "failed tests"
+}
+
+function cmd_test ()
+{
+    cmd_test_l0
+
+    cmd_test_l1
 }
 
 function cmd_package ()

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -75,11 +75,6 @@
     <Exec Command="%22$(DesktopMSBuild)%22 Agent.Service/Windows/AgentService.csproj /p:Configuration=$(BUILDCONFIG) /p:OutputPath=%22$(LayoutRoot)/bin%22" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86'" />
   </Target>
 
-  <Target Name="Test" DependsOnTargets="GenerateConstant">
-    <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
-    <Exec Command="dotnet test Test/Test.csproj --settings $(MSBuildProjectDirectory)/Test/CodeCoverage.runsettings --no-build --logger:trx --collect:&quot;Code Coverage&quot;  --filter SkipOn!=$(SkipOn)" ConsoleToMSBuild="true" />
-  </Target>
-
   <Target Name="TestL0" DependsOnTargets="GenerateConstant">
     <Exec Command="dotnet build Test/Test.csproj -c $(BUILDCONFIG) /p:PackageRuntime=$(PackageRuntime)" ConsoleToMSBuild="true" />
     <Exec Command="dotnet test Test/Test.csproj --settings $(MSBuildProjectDirectory)/Test/CodeCoverage.runsettings --no-build --logger:trx --collect:&quot;Code Coverage&quot;  --filter &quot;Level=L0&amp;SkipOn!=$(SkipOn)&quot;" ConsoleToMSBuild="true" />


### PR DESCRIPTION
Right now, running `./dev.sh testl0 && ./dev.sh testl1` works, but `./dev.sh test` doesn't set up the l1s correctly. This fixes that problem