### PR TITLE
Make sure we get the actual most recent version of the branch

### DIFF
--- a/.vsts.template.nonwindows.yml
+++ b/.vsts.template.nonwindows.yml
@@ -15,7 +15,10 @@ steps:
 - checkout: self
   clean: true
 
-- script: git checkout releases/$(version)
+- script: |
+    git config user.email "azure-pipelines-bot@microsoft.com"
+    git config user.name "azure-pipelines-bot"
+    git checkout -f origin/releases/$(version)
   displayName: Checkout release branch
   condition: ne(variables['version'], '')
 

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -14,7 +14,10 @@ steps:
 - checkout: self
   clean: true
 
-- script: git checkout releases/$(version)
+- script: |
+    git config user.email "azure-pipelines-bot@microsoft.com"
+    git config user.name "azure-pipelines-bot"
+    git checkout -f origin/releases/$(version)
   displayName: Checkout release branch
   condition: ne(variables['version'], '')
 


### PR DESCRIPTION
Right now, when we checkout the release branch, we check out the version that we have locally. For reasons I don't fully understand, this is diverging from the version in source control on our x86 branch. This change guarantees that we will grab the most recent version of the release branch