### PR TITLE
Fixing bug, where while downloading commits for jenkins artifact we were creating releaseWorkingFolder inside the bin directory

### DIFF
--- a/src/Agent.Worker/Release/ReleaseJobExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseJobExtension.cs
@@ -154,9 +154,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
             IList<AgentArtifactDefinition> agentArtifactDefinitions)
         {
             Trace.Entering();
+            string commitsWorkFolder = String.Empty;
 
-            Trace.Info("Creating commit work folder");
-            string commitsWorkFolder = GetCommitsWorkFolder(executionContext);
+            if (agentArtifactDefinitions?.Any(x => x.ArtifactType == AgentArtifactType.Jenkins) == true)
+            {
+                Trace.Info("Creating commit work folder");
+                commitsWorkFolder = GetCommitsWorkFolder(executionContext);
+            }
 
             // Note: We are having an explicit type here. For other artifact types we are planning to go with tasks
             // Only for jenkins we are making the agent to download
@@ -315,7 +319,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
                 executionContext.Variables.System_TeamProjectId.ToString(),
                 releaseDefinition);
 
-            ReleaseWorkingFolder = releaseTrackingConfig.ReleaseDirectory;
+            ReleaseWorkingFolder = Path.Combine(
+                        HostContext.GetDirectory(WellKnownDirectory.Work),
+                        releaseTrackingConfig.ReleaseDirectory);
+
             ArtifactsWorkingFolder = string.IsNullOrEmpty(executionContext.Variables.Release_ArtifactsDirectory)
                 ? Path.Combine(
                         HostContext.GetDirectory(WellKnownDirectory.Work),


### PR DESCRIPTION
There is a bug in agent code, where while downloading commits for a release artifacts it was creating the release working folder inside the agent's bin directory. This PR fixes two things:
1) First of all, we dont create the release working folder unless it is a `Jenkins `type artifact. Because the download commit functionality for release artifacts needs that folder only for jenkins
2) We are correcting the release working folder to point to agent's `_work `directory instead of `bin `directory