### PR TITLE
Enable hotfixing from release branch

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -13,6 +13,7 @@ stages:
   ################################################################################
   - job: Create_Release_Branch
   ################################################################################
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: Create Release Branch
     pool:
       vmImage: ubuntu-18.04
@@ -252,7 +253,7 @@ stages:
         git config user.name "azure-pipelines-bot"
         git checkout -f origin/releases/$(version)
       displayName: Checkout release branch
-      condition: ne(variables['version'], '')
+      condition: and(ne(variables['version'], ''), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
     # Download all agent packages from all previous phases
     - task: DownloadBuildArtifacts@0
@@ -339,9 +340,12 @@ stages:
     steps:
     - checkout: self
 
+    - script: git checkout releases/$(version)
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Checkout release branch
+
     - bash: |
         set -x
-        git checkout releases/$(version)
         cd release
         npm install
         ls

--- a/.vsts.template.nonwindows.yml
+++ b/.vsts.template.nonwindows.yml
@@ -20,7 +20,7 @@ steps:
     git config user.name "azure-pipelines-bot"
     git checkout -f origin/releases/$(version)
   displayName: Checkout release branch
-  condition: ne(variables['version'], '')
+  condition: and(ne(variables['version'], ''), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
 # Build agent layout
 - script: ./dev.sh layout Release

--- a/.vsts.template.windows.yml
+++ b/.vsts.template.windows.yml
@@ -19,7 +19,7 @@ steps:
     git config user.name "azure-pipelines-bot"
     git checkout -f origin/releases/$(version)
   displayName: Checkout release branch
-  condition: ne(variables['version'], '')
+  condition: and(ne(variables['version'], ''), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
 # Build agent layout
 - script: dev.cmd layout Release


### PR DESCRIPTION
This allows us to perform releases from a release branch that already exists. This is useful during hotfixes where we want to control exactly what goes in