### PR TITLE
Fix multiline masking issue

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -62,8 +62,8 @@ namespace Microsoft.VisualStudio.Services.Agent
         // a zero-width positive lookahead to find the "@".
         // It only matches on the password part.
         private const string _urlSecretMaskerPattern
-            = "(?<=//[^:/?#]+:)"    // lookbehind
-            + "[^@]+"               // actual match
+            = "(?<=//[^:/?#\\n]+:)" // lookbehind
+            + "[^@\n]+"             // actual match
             + "(?=@)";              // lookahead
 
         private static int _defaultLogRetentionDays = 30;

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -78,6 +78,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [InlineData("ftp://user:pass@example.com/path", "ftp://user:***@example.com/path")]
         [InlineData("https://user:pass@example.com/weird:thing@path", "https://user:***@example.com/weird:thing@path")]
         [InlineData("https://user:pass@example.com:8080/path", "https://user:***@example.com:8080/path")]
+        [InlineData("https://user:pass@example.com:8080/path\nhttps://user2:pass2@example.com:8080/path", "https://user:***@example.com:8080/path\nhttps://user2:***@example.com:8080/path")]
+        [InlineData("https://user@example.com:8080/path\nhttps://user2:pass2@example.com:8080/path", "https://user@example.com:8080/path\nhttps://user2:***@example.com:8080/path")]
+        [InlineData("https://user:pass@example.com:8080/path\nhttps://user2@example.com:8080/path", "https://user:***@example.com:8080/path\nhttps://user2@example.com:8080/path")]
         // some URLs without secrets to mask
         [InlineData("https://example.com/path", "https://example.com/path")]
         [InlineData("http://example.com/path", "http://example.com/path")]


### PR DESCRIPTION
Right now, our regex is overly aggressive here. For example, if you have:

```
https://abc.def
https://ghi.jkl
https://mno.pqr
https://password@example.com
```
the following gets masked by our regex

```
//ghi.jkl
https://mno.pqr
https://password
```

This fixes the issue by stopping at EOL