### PR TITLE
Adding Task.Util.exe to the agent

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -167,6 +167,34 @@ namespace Microsoft.VisualStudio.Services.Agent
             }
         }
 
+        public static class TaskUtil
+        {
+            public static class CommandLine
+            {
+                public static class Args
+                {
+                    public const string Server = "server";
+                    public const string FolderPath = "folder-path";
+                    public const string PAT = "pat";
+                    public const string SigningThumprint = "signing-thumbprint";
+                    public const string TaskId = "task-id";
+                    public const string TaskName = "task-name";
+                    public const string ZipPath = "zip-path";
+                }
+
+                public static class Commands
+                {
+                    public const string Generate = "generate";
+                    public const string Upload = "upload";
+                }
+
+                public static class Flags
+                {
+                    public const string Overwrite = "overwrite";
+                }
+            }
+        }
+
         public static class Build
         {
             public static readonly string NoCICheckInComment = "***NO_CI***";

--- a/src/Microsoft.VisualStudio.Services.Agent/TaskServer.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/TaskServer.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
+using System.Net.Http;
 
 namespace Microsoft.VisualStudio.Services.Agent
 {
@@ -18,6 +19,8 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         // task download
         Task<Stream> GetTaskContentZipAsync(Guid taskId, TaskVersion taskVersion, CancellationToken token);
+
+        Task<HttpResponseMessage> UploadTaskZipAsync(Guid taskId, Stream fileStream, bool overwrite, CancellationToken token);
 
         Task<bool> TaskDefinitionEndpointExist();
     }
@@ -69,6 +72,12 @@ namespace Microsoft.VisualStudio.Services.Agent
         {
             CheckConnection();
             return _taskAgentClient.GetTaskContentZipAsync(taskId, taskVersion, cancellationToken: token);
+        }
+
+        public Task<HttpResponseMessage> UploadTaskZipAsync(Guid taskId, Stream fileStream, bool overwrite, CancellationToken token)
+        {
+            CheckConnection();
+            return _taskAgentClient.UploadTaskZipAsync(taskId, fileStream, overwrite, cancellationToken: token);
         }
 
         public async Task<bool> TaskDefinitionEndpointExist()

--- a/src/Task.Util/Generator.cs
+++ b/src/Task.Util/Generator.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using CommandLine;
+using Microsoft.VisualStudio.Services.Agent;
+
+namespace Task.Util
+{
+    [Verb(Constants.TaskUtil.CommandLine.Commands.Generate)]
+    public class GenerateCommand
+    {
+        [Option(Constants.TaskUtil.CommandLine.Args.FolderPath, Required = true)]
+        public string FolderPath { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.TaskId)]
+        public string TaskId { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.TaskName)]
+        public string TaskName { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Flags.Overwrite)]
+        public bool Overwrite { get; set; }
+    }
+
+    public class Generator
+    {
+        public Generator(IHostContext hostContext)
+        {
+            _hostContext = hostContext;
+            _trace = _hostContext.GetTrace(nameof(Uploader));
+        }
+
+        public void GenerateTaskFiles(string folderPath, string taskId, string taskName, bool overwrite, object agentShutdownToken)
+        {
+            if (Directory.Exists(folderPath))
+            {
+                if (!overwrite)
+                {
+                    throw new Exception($"The folder {folderPath} already exists.");
+                }
+
+                Directory.Delete(folderPath, true);
+            }
+
+            Directory.CreateDirectory(folderPath);
+            Directory.SetCurrentDirectory(folderPath);
+
+            // Create task.json
+            taskId = String.IsNullOrEmpty(taskId) ? Guid.NewGuid().ToString() : taskId;
+            taskName = String.IsNullOrEmpty(taskName) ? "MyNewTask" : taskName;
+            string taskJson = 
+                "{\n" +
+                "    \"$schema\": \"https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json\",\n" +
+                $"    \"id\": \"{taskId}\",\n" +
+                $"    \"name\": \"{taskName}\",\n" +
+                $"    \"friendlyName\": \"{taskName}\",\n" +
+                "    \"description\": \"\",\n" +
+                "    \"helpMarkDown\": \"\",\n" +
+                "    \"category\": \"Utility\",\n" +
+                "    \"author\": \"\",\n" +
+                "    \"version\": {\n" +
+                "        \"Major\": 0,\n" +
+                "        \"Minor\": 1,\n" +
+                "        \"Patch\": 0\n" +
+                "    },\n" +
+                $"    \"instanceNameFormat\": \"{taskName} $(samplestring)\",\n" +
+                "    \"inputs\": [\n" +
+                "        {\n" +
+                "            \"name\": \"samplestring\",\n" +
+                "            \"type\": \"string\",\n" +
+                "            \"label\": \"Sample String\",\n" +
+                "            \"defaultValue\": \"\",\n" +
+                "            \"required\": true,\n" +
+                "            \"helpMarkDown\": \"A sample string\"\n" +
+                "        }\n" +
+                "    ],\n" +
+                "    \"execution\": {\n" +
+                "        \"Node\": {\n" +
+                "            \"target\": \"index.js\"\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
+            File.WriteAllText("task.json", taskJson);
+
+            // Create package.json
+            string packageJson =
+                "{\n" +
+                $"  \"name\": \"{taskName}\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"description\": \"\",\n" +
+                "  \"main\": \"index.js\",\n" +
+                "  \"scripts\": {\n" +
+                "    \"test\": \"test\"\n" +
+                "  },\n" +
+                "  \"author\": \"\",\n" +
+                "  \"license\": \"ISC\",\n" +
+                "  \"dependencies\": {\n" +
+                "    \"azure-pipelines-task-lib\": \"^2.9.3\"\n" +
+                "  },\n" +
+                "  \"devDependencies\": {\n" +
+                "    \"@types/node\": \"^13.7.7\",\n" +
+                "    \"@types/q\": \"^1.5.2\"\n" +
+                "  }\n" +
+                "}\n";
+            File.WriteAllText("package.json", packageJson);
+
+            // Create the minimal typescript file
+            string tsFile =
+                "import tl = require('azure-pipelines-task-lib/task');\n" +
+                "\n" +
+                "function run() {\n" +
+                "    try {\n" +
+                "        const inputString: string | undefined = tl.getInput('samplestring', true);\n" +
+                "        if (inputString == 'bad') {\n" +
+                "            tl.setResult(tl.TaskResult.Failed, 'Bad input was given');\n" +
+                "            return;\n" +
+                "        }\n" +
+                "        console.log('Hello', inputString);\n" +
+                "    }\n" +
+                "    catch (err) {\n" +
+                "        tl.setResult(tl.TaskResult.Failed, err.message);\n" +
+                "    }\n" +
+                "};\n" +
+                "\n" +
+                "run();\n";
+            File.WriteAllText("index.ts", tsFile);
+
+            // Create nuspec file (for signing)
+            string nuspecFile =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<package xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\">\n" +
+                "    <metadata>\n" +
+                "        <id>Task</id>\n" +
+                "        <version>0.0.0</version>\n" +
+                "        <description></description>\n" +
+                "        <authors></authors>\n" +
+                "    </metadata>\n" +
+                "</package>\n";
+            File.WriteAllText("task.nuspec", nuspecFile);
+        }
+
+        private IHostContext _hostContext;
+        private Tracing _trace;
+    }
+}

--- a/src/Task.Util/NuGet.Config
+++ b/src/Task.Util/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Task.Util/Program.cs
+++ b/src/Task.Util/Program.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Agent.Sdk;
+using CommandLine;
+using Microsoft.VisualStudio.Services.Agent;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Common;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Task.Util
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            // We can't use the new SocketsHttpHandler for now for both Windows and Linux
+            // On linux, Negotiate auth is not working if the TFS url is behind Https
+            // On windows, Proxy is not working
+            AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
+            using (HostContext context = new HostContext("Agent"))
+            {
+                return MainAsync(context, args).GetAwaiter().GetResult();
+            }
+        }
+
+        public async static Task<int> MainAsync(IHostContext context, string[] args)
+        {
+            Tracing trace = context.GetTrace(nameof(Program));
+            trace.Info($"Agent package {BuildConstants.AgentPackage.PackageName}.");
+            trace.Info($"Running on {PlatformUtil.HostOS} ({PlatformUtil.HostArchitecture}).");
+            trace.Info($"RuntimeInformation: {RuntimeInformation.OSDescription}.");
+            var terminal = context.GetService<ITerminal>();
+
+            try
+            {
+                trace.Info($"Version: {BuildConstants.AgentPackage.Version}");
+                trace.Info($"Commit: {BuildConstants.Source.CommitHash}");
+                trace.Info($"Culture: {CultureInfo.CurrentCulture.Name}");
+                trace.Info($"UI Culture: {CultureInfo.CurrentUICulture.Name}");
+
+                bool success = Parser.Default.ParseArguments<UploadCommand, GenerateCommand>(args)
+                    .MapResult(
+                      (UploadCommand opts) => RunUploadCommand(context, opts).Result,
+                      (GenerateCommand opts) => RunGenerateCommand(context, opts),
+                      errors => false
+                    );
+
+                if (!success)
+                {
+                    return Constants.Agent.ReturnCode.TerminatedError;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                Console.WriteLine(e.ToString());
+
+                trace.Error(e);
+                return Constants.Agent.ReturnCode.RetryableError;
+            }
+
+            return Constants.Agent.ReturnCode.Success;
+        }
+
+        private static async Task<bool> RunUploadCommand(IHostContext context, UploadCommand uploadArgs)
+        {
+            // create a connection
+            VssBasicCredential basicCred = new VssBasicCredential("VstsAgent", uploadArgs.PAT);
+            VssCredentials credentials = new VssCredentials(null, basicCred, CredentialPromptType.DoNotPrompt);
+            var connection = VssUtil.CreateConnection(new Uri(uploadArgs.Server), credentials);
+
+            // Get path
+            // XORing the results here because one of these should be not null, but not both.
+            if (!(String.IsNullOrEmpty(uploadArgs.ZipPath) ^ String.IsNullOrEmpty(uploadArgs.FolderPath)))
+            {
+                throw new Exception("You must specify either zip-path or folder-path but not both.");
+            }
+
+            bool signZip = !String.IsNullOrEmpty(uploadArgs.SigningThumprint);
+            bool isZip = !String.IsNullOrEmpty(uploadArgs.ZipPath);
+            bool success;
+
+            var uploader = new Uploader(context, connection);
+
+            if (isZip)
+            {
+                if (!File.Exists(uploadArgs.ZipPath))
+                {
+                    throw new Exception($"The file specified by zip-path {uploadArgs.ZipPath} does not exist.");
+                }
+
+                if (signZip)
+                {
+                    throw new Exception($"You cannot use the sign-zip option if the files are already zipped.");
+                }
+
+                success = await uploader.Upload(new Guid(uploadArgs.TaskId), uploadArgs.ZipPath, uploadArgs.Overwrite, context.AgentShutdownToken);
+            }
+            else
+            {
+                if (!Directory.Exists(uploadArgs.FolderPath))
+                {
+                    throw new Exception($"The folder specified by folder-path {uploadArgs.FolderPath} does not exist.");
+                }
+
+                success = await uploader.ZipAndUpload(uploadArgs.FolderPath, uploadArgs.Overwrite, signZip, uploadArgs.SigningThumprint, context.AgentShutdownToken);
+            }
+
+            return success;
+        }
+
+        private static bool RunGenerateCommand(IHostContext context, GenerateCommand generateArgs)
+        {
+            var generator = new Generator(context);
+            Console.WriteLine($"Generating a task into {generateArgs.FolderPath}");
+            generator.GenerateTaskFiles(generateArgs.FolderPath, generateArgs.TaskId, generateArgs.TaskName, generateArgs.Overwrite, context.AgentShutdownToken);
+            Console.WriteLine($"Done generating files.");
+            Console.WriteLine($"Recommeneded next steps...");
+            Console.WriteLine($"   cd {generateArgs.FolderPath}");
+            Console.WriteLine($"   npm install");
+            Console.WriteLine($"   tsc *.ts");
+            Console.WriteLine();
+
+            return true;
+        }
+    }
+}

--- a/src/Task.Util/Task.Util.csproj
+++ b/src/Task.Util/Task.Util.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Common.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Agent.Sdk\Agent.Sdk.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.Services.Agent\Microsoft.VisualStudio.Services.Agent.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.7.82" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
+    <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/Task.Util/Uploader.cs
+++ b/src/Task.Util/Uploader.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using CommandLine;
+using Microsoft.VisualStudio.Services.Agent;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.WebApi;
+using Newtonsoft.Json;
+
+namespace Task.Util
+{
+    [Verb(Constants.TaskUtil.CommandLine.Commands.Upload)]
+    public class UploadCommand
+    {
+        [Option(Constants.TaskUtil.CommandLine.Args.Server, Required = true)]
+        public string Server { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.FolderPath, Group = "path")]
+        public string FolderPath { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.ZipPath, Group = "path")]
+        public string ZipPath { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.PAT, Required = true)]
+        public string PAT { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.SigningThumprint)]
+        public string SigningThumprint { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Args.TaskId)]
+        public string TaskId { get; set; }
+
+        [Option(Constants.TaskUtil.CommandLine.Flags.Overwrite)]
+        public bool Overwrite { get; set; }
+    }
+
+    public class Uploader
+    {
+        public Uploader(IHostContext hostContext, VssConnection connection)
+        {
+            _hostContext = hostContext;
+            _trace = _hostContext.GetTrace(nameof(Uploader));
+            _connection = connection;
+        }
+
+        public async Task<bool> Upload(Guid taskId, string zipFile, bool overwrite, CancellationToken cancellationToken)
+        {
+            var taskServer = _hostContext.GetService<ITaskServer>();
+            await taskServer.ConnectAsync(_connection);
+
+            try
+            {
+                _trace.Info($"Starting task upload: {taskId} {zipFile}");
+                using (FileStream fs = new FileStream(zipFile, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: _defaultFileStreamBufferSize, useAsync: true))
+                {
+                    await taskServer.UploadTaskZipAsync(taskId, fs, overwrite, cancellationToken);
+                }
+                return true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+
+                _trace.Info($"Task upload has been cancelled.");
+                throw;
+            }
+        }
+
+        public async Task<bool> ZipAndUpload(string taskFolderPath, bool overwrite, bool signZip, string fingerprint, CancellationToken cancellationToken)
+        {
+            if (Directory.Exists(taskFolderPath))
+            {
+                // Read the task.json file to get the name and id
+                var task = GetTaskJsonAttributes(Path.Combine(taskFolderPath, Constants.Path.TaskJsonFile));
+
+                var zipFile = taskFolderPath + ".zip";
+                
+                if (File.Exists(zipFile))
+                {
+                    File.Delete(zipFile);
+                }
+                
+                ZipFile.CreateFromDirectory(taskFolderPath, zipFile);
+
+                if (signZip)
+                {
+                    var nugetFile = taskFolderPath + ".nupkg";
+                    String nugetPath = WhichUtil.Which("nuget", require: true);
+
+                    if (File.Exists(nugetFile))
+                    {
+                        File.Delete(nugetFile);
+                    }
+
+                    File.Move(zipFile, nugetFile);
+
+                    var processInvoker = _hostContext.GetService<IProcessInvoker>();
+                    processInvoker.ErrorDataReceived += (Object sender, ProcessDataReceivedEventArgs args) => { Console.Error.WriteLine(args.Data); };
+                    processInvoker.OutputDataReceived += (Object sender, ProcessDataReceivedEventArgs args) => { Console.WriteLine(args.Data); };
+                    int exitCode = await processInvoker.ExecuteAsync(Directory.GetCurrentDirectory(), nugetPath, $"sign \"{nugetFile}\" -CertificateFingerprint {fingerprint}", new Dictionary<string, string>(), cancellationToken);
+
+                    if (exitCode != 0)
+                    {
+                        throw new Exception("Unable to sign the task after zipping it. Task not uploaded.");
+                    }
+
+                    File.Move(nugetFile, zipFile);
+                }
+
+                return await Upload(task.Id, zipFile, overwrite, cancellationToken);
+            }
+
+            return false;
+        }
+
+        private TaskJson GetTaskJsonAttributes(string filePath)
+        {
+            _trace.Info($"Loading task definition '{filePath}'.");
+            string json = File.ReadAllText(filePath);
+            var task = JsonConvert.DeserializeObject<TaskJson>(json);
+            return task;
+        }
+
+        private IHostContext _hostContext;
+        private Tracing _trace;
+        private VssConnection _connection;
+        private int _defaultFileStreamBufferSize = 4096;
+    }
+
+    public sealed class TaskJson
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string FriendlyName { get; set; }
+        public string Description { get; set; }
+        public string Author { get; set; }
+    }
+}

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -7,6 +7,7 @@
     <ProjectFiles Include="Agent.PluginHost/Agent.PluginHost.csproj" />
     <ProjectFiles Include="Agent.Sdk/Agent.Sdk.csproj" />
     <ProjectFiles Include="Agent.Plugins/Agent.Plugins.csproj" />
+    <ProjectFiles Include="Task.Util/Task.Util.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(LayoutRoot)'==''">
@@ -132,6 +133,8 @@
     <RemoveDir  Directories="Agent.Sdk/obj" />
     <RemoveDir  Directories="Agent.Plugins/bin" />
     <RemoveDir  Directories="Agent.Plugins/obj" />
+    <RemoveDir  Directories="Task.Util/bin" />
+    <RemoveDir  Directories="Task.Util/obj" />
     <RemoveDir  Directories="Test/bin" />
     <RemoveDir  Directories="Test/obj" />
   </Target>


### PR DESCRIPTION
- this CLI adds the ability to upload a task to the server
- It also includes a generator to create a task folder with the basic files you need for a node task.

This exe is just for convenience. It replaces the need to use the tfx-cli (that hasn't shipped in a while) to upload tasks. It does not currently have the ability to list or get tasks, but that can be easily added. This is just the first step.

**Examples**
```
>Task.Util.exe --help
Task.Util 2.999.999
Copyright (C) 2020 Task.Util
  upload
  generate
  help        Display more information on a specific command.
  version     Display version information.
```

```
>Task.Util.exe upload --folder-path mytask --pat **** --server https://dev.azure.com/jpricket
```
