### PR TITLE
Added knob support to set task variables

### DIFF
--- a/src/Agent.Sdk/ITaskVariableStore.cs
+++ b/src/Agent.Sdk/ITaskVariableStore.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Agent.Sdk
+{
+    public interface ITaskVariableStore
+    {
+        void SetTaskVariable(string variable, string value, bool isSecret = false);
+
+    }
+}

--- a/src/Agent.Sdk/Knob/Knob.cs
+++ b/src/Agent.Sdk/Knob/Knob.cs
@@ -29,6 +29,8 @@ namespace Agent.Sdk.Knob
         public string Name { get; private set; }
         public IKnobSource Source { get; private set;}
         public string Description { get; private set; }
+        public string TaskVariableName { get; private set; }
+        public bool TaskVariableIsSecret { get; private set; } = false;
         public virtual bool IsDeprecated => false;  // is going away at a future date
         public virtual bool IsExperimental => false; // may go away at a future date
 
@@ -49,6 +51,27 @@ namespace Agent.Sdk.Knob
             ArgUtil.NotNull(Source, nameof(Source));
 
             return Source.GetValue(context);
+        }
+
+        public void PublishToTaskVariable(IKnobValueContext context, ITaskVariableStore store)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(store, nameof(store));
+
+            if (string.IsNullOrWhiteSpace(TaskVariableName))
+            {
+                return;
+            }
+            var value = GetValue(context).AsString();
+            store.SetTaskVariable(TaskVariableName, value, TaskVariableIsSecret);
+        }
+
+        public Knob AssociateWithTaskVariable(string name, bool isSecret=false)
+        {
+            ArgUtil.NotNull(name, nameof(name));
+            TaskVariableName = name;
+            TaskVariableIsSecret = isSecret;
+            return this;
         }
 
         public static List<Knob> GetAllKnobsFor<T>()

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -32,7 +32,7 @@ namespace Agent.Sdk
         public static readonly string FirstRepositoryCheckedOut = "FirstRepositoryCheckedOut";
     }
 
-    public class AgentTaskPluginExecutionContext : ITraceWriter
+    public class AgentTaskPluginExecutionContext : ITraceWriter, ITaskVariableStore
     {
         private VssConnection _connection;
         private readonly object _stdoutLock = new object();

--- a/src/Test/L0/KnobL0.cs
+++ b/src/Test/L0/KnobL0.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Agent.Sdk;
 using Agent.Sdk.Knob;
 using Microsoft.VisualStudio.Services.Agent.Worker;
@@ -19,6 +20,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             public static Knob A = new Knob("A", "Test Knob", new RuntimeKnobSource("A"), new EnvironmentKnobSource("A"), new BuiltInDefaultKnobSource("false"));
             public static Knob B = new DeprecatedKnob("B", "Deprecated Knob", new BuiltInDefaultKnobSource("true"));
             public static Knob C = new ExperimentalKnob("C", "Experimental Knob", new BuiltInDefaultKnobSource("foo"));
+            public static Knob D = new Knob("D", "Test Knob", new EnvironmentKnobSource("D")).AssociateWithTaskVariable("task.D");
+            public static Knob E = new Knob("E", "Test Knob", new EnvironmentKnobSource("E")).AssociateWithTaskVariable("task.E", true);
         }
 
         [Fact]
@@ -26,7 +29,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Trait("Category", "Common")]
         public void HasAgentKnobs()
         {
-            Assert.True(Knob.GetAllKnobsFor<TestKnobs>().Count == 3, "GetAllKnobsFor returns the right amount");
+            Assert.True(Knob.GetAllKnobsFor<TestKnobs>().Count == 5, "GetAllKnobsFor returns the right amount");
         }
 
         [Fact]
@@ -86,6 +89,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 Assert.True(!knobValue.AsBoolean());
                 Assert.True(string.Equals(knobValue.AsString(), "false", StringComparison.OrdinalIgnoreCase));
             }
+
         }
 
         [Fact]
@@ -104,6 +108,64 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         {
             Assert.True(TestKnobs.C.IsExperimental, "C is Experimental");
             Assert.True(!TestKnobs.C.IsDeprecated, "C is NOT Deprecated");
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void TaskVariableKnobTests()
+        {
+            Assert.True(TestKnobs.A.TaskVariableName is null, "A is not associated with a task variable");
+            Assert.False(TestKnobs.D.TaskVariableName is null, "D is associated with a task variable");
+            Assert.False(TestKnobs.D.TaskVariableIsSecret, "D is associated with a task variable that is not secret");
+            Assert.False(TestKnobs.E.TaskVariableName is null, "E is associated with a task variable");
+            Assert.True(TestKnobs.E.TaskVariableIsSecret, "E is associated with a task variable that is secret");
+
+            var environment = new LocalEnvironment();
+
+            var executionContext = new Mock<IExecutionContext>();
+                executionContext
+                    .Setup(x => x.GetScopedEnvironment())
+                    .Returns(environment);
+
+            var taskVariables = new Dictionary<string, string>();
+            var secretTaskVariables = new Dictionary<string, bool>();
+            var taskVariableStore = new Mock<ITaskVariableStore>();
+            taskVariableStore
+                .Setup( x => x.SetTaskVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Callback( (string name, string value, bool isSecret) => {
+                    taskVariables.Add(name, value);
+                    secretTaskVariables.Add(name, isSecret);
+                });
+
+
+            environment.SetEnvironmentVariable("A","true");
+            TestKnobs.A.PublishToTaskVariable(executionContext.Object, taskVariableStore.Object);
+            Assert.True(taskVariables.Count == 0, "Knob A does not contribute any task variables");
+
+            environment.SetEnvironmentVariable("D", "true");
+            TestKnobs.D.PublishToTaskVariable(executionContext.Object, taskVariableStore.Object);
+            Assert.True(taskVariables.Count == 1, "Knob D does contribute one task variable");
+            Assert.True(String.Equals(taskVariables.GetValueOrDefault(TestKnobs.D.TaskVariableName), Boolean.TrueString, StringComparison.OrdinalIgnoreCase), "Knob D properly sets task variable");
+            Assert.True(secretTaskVariables.GetValueOrDefault(TestKnobs.D.TaskVariableName) == TestKnobs.D.TaskVariableIsSecret, "Knob D sets task variable secret properly");
+            taskVariables.Clear();
+            secretTaskVariables.Clear();
+
+            environment.SetEnvironmentVariable("D", "false");
+            TestKnobs.D.PublishToTaskVariable(executionContext.Object, taskVariableStore.Object);
+            Assert.True(taskVariables.Count == 1, "Knob D does contribute one task variable");
+            Assert.True(String.Equals(taskVariables.GetValueOrDefault(TestKnobs.D.TaskVariableName), Boolean.FalseString, StringComparison.OrdinalIgnoreCase), "Knob D properly sets task variable");
+            Assert.True(secretTaskVariables.GetValueOrDefault(TestKnobs.D.TaskVariableName) == TestKnobs.D.TaskVariableIsSecret, "Knob D sets task variable secret properly");
+            taskVariables.Clear();
+            secretTaskVariables.Clear();
+
+            environment.SetEnvironmentVariable("E", "true");
+            TestKnobs.E.PublishToTaskVariable(executionContext.Object, taskVariableStore.Object);
+            Assert.True(taskVariables.Count == 1, "Knob E does contribute one task variable");
+            Assert.True(String.Equals(taskVariables.GetValueOrDefault(TestKnobs.E.TaskVariableName), Boolean.TrueString, StringComparison.OrdinalIgnoreCase), "Knob E properly sets task variable");
+            Assert.True(secretTaskVariables.GetValueOrDefault(TestKnobs.E.TaskVariableName) == TestKnobs.E.TaskVariableIsSecret, "Knob E sets task variable secret properly");
+            taskVariables.Clear();
+            secretTaskVariables.Clear();
         }
     }
 }


### PR DESCRIPTION
Added linkage between knobs and task variables. This is done with a builder pattern as most knobs probably will not need to publish task variables.