### PR TITLE
Don't unzip tasks for L1 tests

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -40,6 +40,7 @@ function acquireExternalTool() {
                             # directly contains only a nested directory TEE-CLC-14.0.4. When this flag is set, the contents
                             # of the nested TEE-CLC-14.0.4 directory are moved up one directory, and then the empty directory
                             # TEE-CLC-14.0.4 is removed.
+    local dont_uncompress=$4
 
     # Extract the portion of the URL after the protocol. E.g. vstsagenttools.blob.core.windows.net/tools/pdbstr/1/pdbstr.zip
     local relative_url="${download_source#*://}"
@@ -94,7 +95,7 @@ function acquireExternalTool() {
         # Extract to layout.
         mkdir -p "$target_dir" || checkRC 'mkdir'
         local nested_dir=""
-        if [[ "$download_basename" == *.zip  ]]; then
+        if [[ "$download_basename" == *.zip && "$dont_uncompress" != "dont_uncompress" ]]; then
             # Extract the zip.
             echo "Extracting zip from $download_target to $target_dir"
             unzip "$download_target" -d "$target_dir" > /dev/null
@@ -107,7 +108,7 @@ function acquireExternalTool() {
             if [[ "$fix_nested_dir" == "fix_nested_dir" ]]; then
                 nested_dir="${download_basename%.zip}" # Remove the trailing ".zip".
             fi
-        elif [[ "$download_basename" == *.tar.gz ]]; then
+        elif [[ "$download_basename" == *.tar.gz && "$dont_uncompress" != "dont_uncompress" ]]; then
             # Extract the tar gz.
             echo "Extracting tar gz from $download_target to $target_dir"
             tar xzf "$download_target" -C "$target_dir" > /dev/null || checkRC 'tar'
@@ -187,5 +188,5 @@ fi
 
 if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then
     # cmdline task
-    acquireExternalTool "$CONTAINER_URL/l1Tasks/d9bafed4-0b18-4f58-968d-86655b4d2ce9.zip" "Tasks/d9bafed4-0b18-4f58-968d-86655b4d2ce9" ""
+    acquireExternalTool "$CONTAINER_URL/l1Tasks/d9bafed4-0b18-4f58-968d-86655b4d2ce9.zip" "Tasks" false dont_uncompress
 fi

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -136,31 +136,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             _mockedServices.Add(context.SetupService<IAgentPluginManager>(typeof(FakeAgentPluginManager)));
             _mockedServices.Add(context.SetupService<ITaskManager>(typeof(FakeTaskManager)));
             _mockedServices.Add(context.SetupService<ICustomerIntelligenceServer>(typeof(FakeCustomerIntelligenceServer)));
-            LoadTasks();
-        }
-
-        private void LoadTasks()
-        {
-            var baseDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            var taskZipsPath = Path.Join(baseDirectory, "TaskZips");
-            var tasksPath = Path.Join(baseDirectory, "L1", "Tasks");
-            if (!Directory.Exists(tasksPath))
-            {
-                throw new Exception("No mock tasks provided");
-            }
-            if (!Directory.Exists(taskZipsPath))
-            {
-                Directory.CreateDirectory(taskZipsPath);
-            }
-            foreach (var d in Directory.GetDirectories(tasksPath))
-            {
-                var zip = Path.Join(taskZipsPath, Path.GetFileName(d) + ".zip");
-                if (File.Exists(zip))
-                {
-                    File.Delete(zip);
-                }
-                ZipFile.CreateFromDirectory(d, zip);
-            }
         }
 
         private string GetLogFile(object testClass, string testMethod)
@@ -197,7 +172,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
                     workerTask = worker.RunAsync(
                         pipeIn: pipeHandleOut,
                         pipeOut: pipeHandleIn);
-                }, disposeClient: false);
+                }, disposeClient: false); // Don't dispose the client because our process is both the client and the server
 
                 // Send the job request message to the worker
                 var body = JsonUtility.ToString(message);
@@ -485,7 +460,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
       'isReadOnly': true
     },
     'system.accessToken': {
-      'value': 'access',
+      'value': 'thisisanaccesstoken',
       'isSecret': true
     },
     'agent.retainDefaultEncoding': {


### PR DESCRIPTION
Taken from the L1 multi-file PR

This removes the unzipping and zipping of tasks for L1 tests to provide compatibility for signing L1s.