### PR TITLE
Sign 3rd party CommandLine.dll

### DIFF
--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -137,6 +137,7 @@ steps:
     FolderPath: '${{ parameters.layoutRoot }}'
     Pattern: |
       bin\Ben.Demystifier.dll
+      bin\CommandLine.dll
       bin\DotNet.Glob.dll
       bin\Minimatch.dll
       bin\NCrontab.Signed.dll


### PR DESCRIPTION
The CommandLine.dll dependency was recently added and needed to be signed to pass the Codesign validation step in the release pipeline.