### PR TITLE
Enable one linting rule, changes for another

### DIFF
--- a/src/Agent.Listener/Configuration.Windows/AutoLogonManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/AutoLogonManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 if (!command.GetOverwriteAutoLogon(currentAutoLogonAccount))
                 {
                     Trace.Error("Marking the agent configuration as failed due to the denial of autologon setting overwriting by the user.");
-                    throw new Exception(StringUtil.Loc("AutoLogonOverwriteDeniedError", currentAutoLogonAccount));
+                    throw new InvalidOperationException(StringUtil.Loc("AutoLogonOverwriteDeniedError", currentAutoLogonAccount));
                 }
                 Trace.Info($"Continuing with the autologon configuration.");
             }

--- a/src/Agent.Listener/Configuration.Windows/AutoLogonRegistryManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/AutoLogonRegistryManager.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 if(string.IsNullOrEmpty(securityId))
                 {
                     Trace.Error($"Could not find the Security ID for the user '{domainName}\\{userName}'. AutoLogon will not be configured.");
-                    throw new Exception(StringUtil.Loc("InvalidSIDForUser", domainName, userName));
+                    throw new ArgumentException(StringUtil.Loc("InvalidSIDForUser", domainName, userName));
                 }
 
                 //check if the registry exists for the user, if not load the user profile
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             if(string.IsNullOrEmpty(securityId))
             {
                 Trace.Error($"Could not find the Security ID for the user '{domainName}\\{userName}'. Unconfiguration of AutoLogon is not possible.");
-                throw new Exception(StringUtil.Loc("InvalidSIDForUser", domainName, userName));
+                throw new ArgumentException(StringUtil.Loc("InvalidSIDForUser", domainName, userName));
             }
 
             //machine specific
@@ -327,7 +327,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             if (string.IsNullOrEmpty(cmdExePath))
             {
                 Trace.Error("Unable to get the path for cmd.exe.");
-                throw new Exception(StringUtil.Loc("FilePathNotFound", "cmd.exe"));
+                throw new ArgumentException(StringUtil.Loc("FilePathNotFound", "cmd.exe"));
             }
 
             //file to run in cmd.exe

--- a/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
+++ b/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                         throw new UnauthorizedAccessException(StringUtil.Loc("AccessDenied"));
 
                     default:
-                        throw new Exception(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupGetInfo), returnCode));
+                        throw new InvalidOperationException(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupGetInfo), returnCode));
                 }
             }
             finally
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     throw new ArgumentException(StringUtil.Loc("InvalidGroupName", groupName));
 
                 default:
-                    throw new Exception(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupAdd), returnCode));
+                    throw new InvalidOperationException(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupAdd), returnCode));
             }
         }
 
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     throw new UnauthorizedAccessException(StringUtil.Loc("AccessDenied"));
 
                 default:
-                    throw new Exception(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupDel), returnCode));
+                    throw new InvalidOperationException(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupDel), returnCode));
             }
         }
 
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     throw new UnauthorizedAccessException(StringUtil.Loc("AccessDenied"));
 
                 default:
-                    throw new Exception(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupAddMembers), returnCode));
+                    throw new InvalidOperationException(StringUtil.Loc("OperationFailed", nameof(NetLocalGroupAddMembers), returnCode));
             }
         }
 
@@ -485,7 +485,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 scmHndl = OpenSCManager(null, null, ServiceManagerRights.AllAccess);
                 if (scmHndl.ToInt64() <= 0)
                 {
-                    throw new Exception(StringUtil.Loc("FailedToOpenSCM"));
+                    throw new InvalidOperationException(StringUtil.Loc("FailedToOpenSCM"));
                 }
 
                 Trace.Verbose(StringUtil.Format("Opened SCManager. Trying to create service {0}", serviceName));
@@ -522,7 +522,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 svcLock = LockServiceDatabase(scmHndl);
                 if (svcLock.ToInt64() <= 0)
                 {
-                    throw new Exception(StringUtil.Loc("FailedToLockServiceDB"));
+                    throw new InvalidOperationException(StringUtil.Loc("FailedToLockServiceDB"));
                 }
 
                 int[] actions = new int[failureActions.Count * 2];
@@ -636,7 +636,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
             if (scmHndl.ToInt64() <= 0)
             {
-                throw new Exception(StringUtil.Loc("FailedToOpenSCManager"));
+                throw new InvalidOperationException(StringUtil.Loc("FailedToOpenSCManager"));
             }
 
             try
@@ -996,7 +996,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 uint hr = LsaOpenPolicy(ref system, ref attrib, (uint)access, out handle);
                 if (hr != 0 || handle == IntPtr.Zero)
                 {
-                    throw new Exception(StringUtil.Loc("OperationFailed", nameof(LsaOpenPolicy), hr));
+                    throw new InvalidOperationException(StringUtil.Loc("OperationFailed", nameof(LsaOpenPolicy), hr));
                 }
 
                 Handle = handle;
@@ -1033,7 +1033,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 uint winErrorCode = LsaNtStatusToWinError(result);
                 if (winErrorCode != 0)
                 {
-                    throw new Exception(StringUtil.Loc("OperationFailed", nameof(LsaNtStatusToWinError), winErrorCode));
+                    throw new InvalidOperationException(StringUtil.Loc("OperationFailed", nameof(LsaNtStatusToWinError), winErrorCode));
                 }
             }
 

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -408,7 +408,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 // 2. The bearer token is not valid until {jwt.ValidFrom}. Current server time is {DateTime.UtcNow}.
                 Trace.Error("Catch exception during test agent connection.");
                 Trace.Error(ex);
-                throw new Exception(StringUtil.Loc("LocalClockSkewed"));
+                throw new InvalidOperationException(StringUtil.Loc("LocalClockSkewed"));
             }
 
             // We will Combine() what's stored with root.  Defaults to string a relative path
@@ -504,12 +504,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     else if (PlatformUtil.RunningOnLinux)
                     {
                         // unconfig systemd service first
-                        throw new Exception(StringUtil.Loc("UnconfigureServiceDService"));
+                        throw new InvalidOperationException(StringUtil.Loc("UnconfigureServiceDService"));
                     }
                     else if (PlatformUtil.RunningOnMacOS)
                     {
                         // unconfig macOS service first
-                        throw new Exception(StringUtil.Loc("UnconfigureOSXService"));
+                        throw new InvalidOperationException(StringUtil.Loc("UnconfigureOSXService"));
                     }
                 }
                 else

--- a/src/Agent.Listener/Configuration/PromptManager.cs
+++ b/src/Agent.Listener/Configuration/PromptManager.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 }
 
                 // Otherwise throw.
-                throw new Exception(StringUtil.Loc("InvalidConfigFor0TerminatingUnattended", argName));
+                throw new ArgumentNullException(StringUtil.Loc("InvalidConfigFor0TerminatingUnattended", argName));
             }
 
             // Prompt until a valid value is read.

--- a/src/Agent.Listener/DistributedTask.Pipelines/Yaml/PipelineParser.cs
+++ b/src/Agent.Listener/DistributedTask.Pipelines/Yaml/PipelineParser.cs
@@ -124,7 +124,7 @@ namespace Microsoft.TeamFoundation.DistributedTask.Orchestration.Server.Pipeline
                         // Validate "checkout" is only used as the first step within a phase.
                         if (phase.Steps.Any(x => x is CheckoutStep))
                         {
-                            throw new Exception($"Step '{YamlConstants.Checkout}' is currently only supported as the first step within a phase.");
+                            throw new InvalidOperationException($"Step '{YamlConstants.Checkout}' is currently only supported as the first step within a phase.");
                         }
                     }
                 }

--- a/src/Agent.Worker/Build/FileContainerServer.cs
+++ b/src/Agent.Worker/Build/FileContainerServer.cs
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 catch (Exception ex)
                 {
                     context.Output(StringUtil.Loc("FileUploadFileOpenFailed", ex.Message, fileToUpload));
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
+++ b/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
@@ -123,14 +123,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 Trace.Verbose("AzurePowerShellHandler.UpdatePowerShellEnvironment - Could not find {0}, so looking for DeploymentEnvironmentName.", connectedServiceName);
                 if (!inputs.TryGetValue("DeploymentEnvironmentName", out environment))
                 {
-                    throw new Exception($"The required {connectedServiceName} parameter was not found by the AzurePowerShellRunner.");
+                    throw new ArgumentNullException($"The required {connectedServiceName} parameter was not found by the AzurePowerShellRunner.");
                 }
             }
 
             string connectedServiceNameValue = environment;
             if (String.IsNullOrEmpty(connectedServiceNameValue))
             {
-                throw new Exception($"The required {connectedServiceName} parameter was either null or empty. Ensure you have provisioned a Deployment Environment using services tab in Admin UI.");
+                throw new ArgumentNullException($"The required {connectedServiceName} parameter was either null or empty. Ensure you have provisioned a Deployment Environment using services tab in Admin UI.");
             }
 
             return connectedServiceNameValue;
@@ -318,7 +318,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                         }
                         else
                         {
-                            throw new Exception($"Found value {match.Value} with no corresponding named parameter");
+                            throw new ArgumentException($"Found value {match.Value} with no corresponding named parameter");
                         }
                     }
                 }

--- a/src/Agent.Worker/Handlers/PowerShellExeHandler.cs
+++ b/src/Agent.Worker/Handlers/PowerShellExeHandler.cs
@@ -162,14 +162,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                         }
                         else
                         {
-                            throw new Exception(StringUtil.Loc("ProcessCompletedWithCode0Errors1", exitCode, _errorCount));
+                            throw new InvalidOperationException(StringUtil.Loc("ProcessCompletedWithCode0Errors1", exitCode, _errorCount));
                         }
                     }
 
                     // Fail on non-zero exit code.
                     if (exitCode != 0)
                     {
-                        throw new Exception(StringUtil.Loc("ProcessCompletedWithExitCode0", exitCode));
+                        throw new InvalidOperationException(StringUtil.Loc("ProcessCompletedWithExitCode0", exitCode));
                     }
                 }
             }

--- a/src/Agent.Worker/PluginInternalCommandExtension.cs
+++ b/src/Agent.Worker/PluginInternalCommandExtension.cs
@@ -37,18 +37,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String alias;
             if (!eventProperties.TryGetValue(PluginInternalUpdateRepositoryEventProperties.Alias, out alias) || String.IsNullOrEmpty(alias))
             {
-                throw new Exception(StringUtil.Loc("MissingRepositoryAlias"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingRepositoryAlias"));
             }
 
             var repository = context.Repositories.FirstOrDefault(x => string.Equals(x.Alias, alias, StringComparison.OrdinalIgnoreCase));
             if (repository == null)
             {
-                throw new Exception(StringUtil.Loc("RepositoryNotExist"));
+                throw new ArgumentNullException(StringUtil.Loc("RepositoryNotExist"));
             }
 
             if (string.IsNullOrEmpty(data))
             {
-                throw new Exception(StringUtil.Loc("MissingRepositoryPath"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingRepositoryPath"));
             }
 
             var currentPath = repository.Properties.Get<string>(RepositoryPropertyNames.Path);

--- a/src/Agent.Worker/Release/Artifacts/GenericHttpClient.cs
+++ b/src/Agent.Worker/Release/Artifacts/GenericHttpClient.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
             }
             else 
             {
-                throw new Exception(StringUtil.Loc("RMApiFailure", url, response.StatusCode));
+                throw new InvalidOperationException(StringUtil.Loc("RMApiFailure", url, response.StatusCode));
             }
         }
 

--- a/src/Agent.Worker/Release/ContainerFetchEngine/FetchEngine.cs
+++ b/src/Agent.Worker/Release/ContainerFetchEngine/FetchEngine.cs
@@ -335,7 +335,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEng
 
                     if (lastAttempt)
                     {
-                        throw new Exception(StringUtil.Loc("RMErrorDownloadingContainerItem", tmpDownloadPath, exception));
+                        throw new InvalidOperationException(StringUtil.Loc("RMErrorDownloadingContainerItem", tmpDownloadPath, exception));
                     }
 
                     lock (_lock)

--- a/src/Agent.Worker/Release/ReleaseCommandExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseCommandExtension.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
                 }
                 else
                 {
-                    throw new Exception(StringUtil.Loc("RMReleaseNameRequired"));
+                    throw new ArgumentNullException(StringUtil.Loc("RMReleaseNameRequired"));
                 }
             }
 

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -313,12 +313,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             char[] s_invalidFileChars = Path.GetInvalidFileNameChars();
             if (type.IndexOfAny(s_invalidFileChars) != -1)
             {
-                throw new ArgumentException($"Type contain invalid characters. ({String.Join(",", s_invalidFileChars)})");
+                throw new ArgumentException($"Type contains invalid characters. ({String.Join(",", s_invalidFileChars)})");
             }
 
             if (name.IndexOfAny(s_invalidFileChars) != -1)
             {
-                throw new ArgumentException($"Name contain invalid characters. ({String.Join(", ", s_invalidFileChars)})");
+                throw new ArgumentException($"Name contains invalid characters. ({String.Join(", ", s_invalidFileChars)})");
             }
 
             // Translate file path back from container path

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 string.IsNullOrEmpty(timelineRecord) ||
                 new Guid(timelineRecord).Equals(Guid.Empty))
             {
-                throw new Exception(StringUtil.Loc("MissingTimelineRecordId"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingTimelineRecordId"));
             }
             else
             {
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 if (record.ParentId != null &&
                     record.ParentId != trackingRecord.ParentId)
                 {
-                    throw new Exception(StringUtil.Loc("CannotChangeParentTimelineRecord"));
+                    throw new InvalidOperationException(StringUtil.Loc("CannotChangeParentTimelineRecord"));
                 }
                 else if (record.ParentId == null)
                 {
@@ -169,19 +169,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // make sure we have name/type and parent record has created.
                 if (string.IsNullOrEmpty(record.Name))
                 {
-                    throw new Exception(StringUtil.Loc("NameRequiredForTimelineRecord"));
+                    throw new ArgumentNullException(StringUtil.Loc("NameRequiredForTimelineRecord"));
                 }
 
                 if (string.IsNullOrEmpty(record.RecordType))
                 {
-                    throw new Exception(StringUtil.Loc("TypeRequiredForTimelineRecord"));
+                    throw new ArgumentNullException(StringUtil.Loc("TypeRequiredForTimelineRecord"));
                 }
 
                 if (record.ParentId != null && record.ParentId != Guid.Empty)
                 {
                     if (!_timelineRecordsTracker.ContainsKey(record.ParentId.Value))
                     {
-                        throw new Exception(StringUtil.Loc("ParentTimelineNotCreated"));
+                        throw new ArgumentNullException(StringUtil.Loc("ParentTimelineNotCreated"));
                     }
                 }
 
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-                throw new Exception(StringUtil.Loc("CannotUploadSummary"));
+                throw new InvalidOperationException(StringUtil.Loc("CannotUploadSummary"));
             }
         }
     }
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-                throw new Exception(StringUtil.Loc("CannotUploadFile"));
+                throw new InvalidOperationException(StringUtil.Loc("CannotUploadFile"));
             }
         }
     }
@@ -301,24 +301,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String type;
             if (!eventProperties.TryGetValue(TaskAddAttachmentEventProperties.Type, out type) || String.IsNullOrEmpty(type))
             {
-                throw new Exception(StringUtil.Loc("MissingAttachmentType"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingAttachmentType"));
             }
 
             String name;
             if (!eventProperties.TryGetValue(TaskAddAttachmentEventProperties.Name, out name) || String.IsNullOrEmpty(name))
             {
-                throw new Exception(StringUtil.Loc("MissingAttachmentName"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingAttachmentName"));
             }
 
             char[] s_invalidFileChars = Path.GetInvalidFileNameChars();
             if (type.IndexOfAny(s_invalidFileChars) != -1)
             {
-                throw new Exception($"Type contain invalid characters. ({String.Join(",", s_invalidFileChars)})");
+                throw new ArgumentException($"Type contain invalid characters. ({String.Join(",", s_invalidFileChars)})");
             }
 
             if (name.IndexOfAny(s_invalidFileChars) != -1)
             {
-                throw new Exception($"Name contain invalid characters. ({String.Join(", ", s_invalidFileChars)})");
+                throw new ArgumentException($"Name contain invalid characters. ({String.Join(", ", s_invalidFileChars)})");
             }
 
             // Translate file path back from container path
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-                throw new Exception(StringUtil.Loc("MissingAttachmentFile"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingAttachmentFile"));
             }
         }
     }
@@ -384,7 +384,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-                throw new Exception($"issue type {issueType} is not an expected issue type.");
+                throw new ArgumentException($"issue type {issueType} is not an expected issue type.");
             }
 
             String sourcePath;
@@ -478,7 +478,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 String.IsNullOrEmpty(resultText) ||
                 !Enum.TryParse<TaskResult>(resultText, out result))
             {
-                throw new Exception(StringUtil.Loc("InvalidCommandResult"));
+                throw new ArgumentException(StringUtil.Loc("InvalidCommandResult"));
             }
 
             context.Result = TaskResultUtil.MergeTaskResults(context.Result, result);
@@ -558,7 +558,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String name;
             if (!eventProperties.TryGetValue(TaskSetVariableEventProperties.Variable, out name) || String.IsNullOrEmpty(name))
             {
-                throw new Exception(StringUtil.Loc("MissingVariableName"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingVariableName"));
             }
 
             String isSecretValue;
@@ -588,7 +588,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // TODO - remove this and just always throw once the feature has been fully rolled out.
                 if (context.Variables.Read_Only_Variables)
                 {
-                    throw new Exception(StringUtil.Loc("ReadOnlyVariable", name));
+                    throw new InvalidOperationException(StringUtil.Loc("ReadOnlyVariable", name));
                 }
                 else
                 {
@@ -649,7 +649,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String name;
             if (!eventProperties.TryGetValue(TaskSetTaskVariableEventProperties.Variable, out name) || String.IsNullOrEmpty(name))
             {
-                throw new Exception(StringUtil.Loc("MissingTaskVariableName"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingTaskVariableName"));
             }
 
             String isSecretValue;
@@ -672,7 +672,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // TODO - remove this and just always throw once the feature has been fully rolled out.
                 if (context.Variables.Read_Only_Variables)
                 {
-                    throw new Exception(StringUtil.Loc("ReadOnlyTaskVariable", name));
+                    throw new InvalidOperationException(StringUtil.Loc("ReadOnlyTaskVariable", name));
                 }
                 else
                 {
@@ -715,13 +715,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (string.IsNullOrEmpty(data))
             {
-                throw new Exception(StringUtil.Loc("EnterValidValueFor0", "setendpoint"));
+                throw new ArgumentNullException(StringUtil.Loc("EnterValidValueFor0", "setendpoint"));
             }
 
             String field;
             if (!eventProperties.TryGetValue(TaskSetEndpointEventProperties.Field, out field) || String.IsNullOrEmpty(field))
             {
-                throw new Exception(StringUtil.Loc("MissingEndpointField"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingEndpointField"));
             }
 
             // Mask auth parameter data upfront to avoid accidental secret exposure by invalid endpoint/key/data
@@ -733,19 +733,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String endpointIdInput;
             if (!eventProperties.TryGetValue(TaskSetEndpointEventProperties.EndpointId, out endpointIdInput) || String.IsNullOrEmpty(endpointIdInput))
             {
-                throw new Exception(StringUtil.Loc("MissingEndpointId"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingEndpointId"));
             }
 
             Guid endpointId;
             if (!Guid.TryParse(endpointIdInput, out endpointId))
             {
-                throw new Exception(StringUtil.Loc("InvalidEndpointId"));
+                throw new ArgumentNullException(StringUtil.Loc("InvalidEndpointId"));
             }
 
             var endpoint = context.Endpoints.Find(a => a.Id == endpointId);
             if (endpoint == null)
             {
-                throw new Exception(StringUtil.Loc("InvalidEndpointId"));
+                throw new ArgumentNullException(StringUtil.Loc("InvalidEndpointId"));
             }
 
             if (String.Equals(field, "url", StringComparison.OrdinalIgnoreCase))
@@ -753,7 +753,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Uri uri;
                 if (!Uri.TryCreate(data, UriKind.Absolute, out uri))
                 {
-                    throw new Exception(StringUtil.Loc("InvalidEndpointUrl"));
+                    throw new ArgumentNullException(StringUtil.Loc("InvalidEndpointUrl"));
                 }
 
                 endpoint.Url = uri;
@@ -763,7 +763,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String key;
             if (!eventProperties.TryGetValue(TaskSetEndpointEventProperties.Key, out key) || String.IsNullOrEmpty(key))
             {
-                throw new Exception(StringUtil.Loc("MissingEndpointKey"));
+                throw new ArgumentNullException(StringUtil.Loc("MissingEndpointKey"));
             }
 
             if (String.Equals(field, "dataParameter", StringComparison.OrdinalIgnoreCase))
@@ -776,7 +776,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-                throw new Exception(StringUtil.Loc("InvalidEndpointField"));
+                throw new ArgumentException(StringUtil.Loc("InvalidEndpointField"));
             }
         }
     }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                     else
                     {
-                        throw new Exception("Task signature verification failed.");
+                        throw new InvalidOperationException("Task signature verification failed.");
                     }
                 }
 
@@ -122,10 +122,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 {
                     if (PlatformUtil.RunningOnWindows)
                     {
-                        throw new Exception(StringUtil.Loc("SupportedTaskHandlerNotFoundWindows", $"{PlatformUtil.HostOS}({PlatformUtil.HostArchitecture})"));
+                        throw new InvalidOperationException(StringUtil.Loc("SupportedTaskHandlerNotFoundWindows", $"{PlatformUtil.HostOS}({PlatformUtil.HostArchitecture})"));
                     }
 
-                    throw new Exception(StringUtil.Loc("SupportedTaskHandlerNotFoundLinux"));
+                    throw new InvalidOperationException(StringUtil.Loc("SupportedTaskHandlerNotFoundLinux"));
                 }
                 Trace.Info($"Handler data is of type {handlerData}");
 

--- a/src/Microsoft.VisualStudio.Services.Agent/Util/PowerShellExeUtil.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Util/PowerShellExeUtil.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             PowerShellInfo latest = infos.OrderByDescending(x => x.Version).FirstOrDefault();
             if (latest == null)
             {
-                throw new Exception(StringUtil.Loc("PowerShellNotInstalledMinVersion0", MinimumVersion));
+                throw new InvalidOperationException(StringUtil.Loc("PowerShellNotInstalledMinVersion0", MinimumVersion));
             }
 
             return latest.Path;

--- a/src/Test/L0/Listener/Configuration/PromptManagerTestsL0.cs
+++ b/src/Test/L0/Listener/Configuration/PromptManagerTestsL0.cs
@@ -199,10 +199,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
                     // Assert.
                     throw new InvalidOperationException();
                 }
-                catch (Exception ex)
+                catch (ArgumentNullException ex)
                 {
                     // Assert.
-                    Assert.Equal(_unattendedExceptionMessage, ex.Message);
+                    Assert.True(ex.Message.Contains(_unattendedExceptionMessage));
                 }
             }
         }

--- a/src/Test/L0/ProcessExtensionL0.cs
+++ b/src/Test/L0/ProcessExtensionL0.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                                     retries--;
                                     if (retries < 0)
                                     {
-                                        throw ex;
+                                        throw;
                                     }
                                     trace.Info($"Unable to get the environment variable, will retry. {retries} retries remaining");
                                     await Task.Delay(2000);

--- a/src/Test/L0/Worker/PluginInternalUpdateRepositoryPathCommandL0.cs
+++ b/src/Test/L0/Worker/PluginInternalUpdateRepositoryPathCommandL0.cs
@@ -27,15 +27,15 @@ namespace Test.L0.Worker
                 var command = new Microsoft.VisualStudio.Services.Agent.Command("area", "event");
 
                 // missing alias
-                Assert.Throws<Exception>(() => updateRepoPath.Execute(_ec.Object, command));
+                Assert.Throws<ArgumentNullException>(() => updateRepoPath.Execute(_ec.Object, command));
 
                 // add alias, still missing matching repository                
                 command.Properties.Add("alias", "repo1");
-                Assert.Throws<Exception>(() => updateRepoPath.Execute(_ec.Object, command));
+                Assert.Throws<ArgumentNullException>(() => updateRepoPath.Execute(_ec.Object, command));
 
                 // add repository, still missing data
                 _repositories.Add(new RepositoryResource() { Alias = "repo1" });
-                Assert.Throws<Exception>(() => updateRepoPath.Execute(_ec.Object, command));
+                Assert.Throws<ArgumentNullException>(() => updateRepoPath.Execute(_ec.Object, command));
             }
         }
 

--- a/src/Test/L0/Worker/TaskCommandExtensionL0.cs
+++ b/src/Test/L0/Worker/TaskCommandExtensionL0.cs
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             {
                 TaskCommandExtension commandExtension = new TaskCommandExtension();
                 var cmd = new Command("task", "setEndpoint");
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 TaskCommandExtension commandExtension = new TaskCommandExtension();
                 var cmd = new Command("task", "setEndpoint");
 
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var cmd = new Command("task", "setEndpoint");
                 cmd.Properties.Add("field", "blah");
 
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var cmd = new Command("task", "setEndpoint");
                 cmd.Properties.Add("field", "url");
 
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "url");
                 cmd.Properties.Add("id", "blah");
 
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "authParameter");
                 cmd.Properties.Add("id", Guid.Empty.ToString());
 
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "url");
                 cmd.Properties.Add("id", Guid.Empty.ToString());
 
-                Assert.Throws<Exception>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
             }
         }
 

--- a/src/rules.ruleset
+++ b/src/rules.ruleset
@@ -107,7 +107,7 @@
       <Rule Id="CA2101" Action="Warning" />          <!-- Specify marshaling for P/Invoke string arguments -->
       <Rule Id="CA2119" Action="Error" />            <!-- Seal methods that satisfy private interfaces -->
       <Rule Id="CA2153" Action="Error" />            <!-- Do Not Catch Corrupted State Exceptions -->
-      <Rule Id="CA2200" Action="Warning" />          <!-- Rethrow to preserve stack details. -->
+      <Rule Id="CA2200" Action="Error" />            <!-- Rethrow to preserve stack details. -->
       <Rule Id="CA2201" Action="Warning" />          <!-- Do not raise reserved exception types -->
       <Rule Id="CA2207" Action="Error" />            <!-- Initialize value type static fields inline -->
       <Rule Id="CA2208" Action="Warning" />          <!-- Instantiate argument exceptions correctly -->


### PR DESCRIPTION
This has changes to allow us to turn on CA2200 (Rethrow to preserve stack details) and starts to get us towards CA2201 (Do not raise reserved exception types)