### PR TITLE
Command Line Parser Fixes

### DIFF
--- a/src/Agent.Listener/CommandLine/ConfigureAgent.cs
+++ b/src/Agent.Listener/CommandLine/ConfigureAgent.cs
@@ -117,9 +117,6 @@ namespace Agent.Listener.CommandLine
         [Option(Constants.Agent.CommandLine.Flags.SslSkipCertValidation)]
         public bool SslSkipCertValidation { get; set; }
 
-        [Option(Constants.Agent.CommandLine.Args.StartupType)]
-        public string StartupType { get; set; }
-
         [Option(Constants.Agent.CommandLine.Args.Url)]
         public string Url { get; set; }
 

--- a/src/Agent.Listener/CommandLine/RunAgent.cs
+++ b/src/Agent.Listener/CommandLine/RunAgent.cs
@@ -15,5 +15,8 @@ namespace Agent.Listener.CommandLine
 
         [Option(Constants.Agent.CommandLine.Flags.Once)]
         public bool RunOnce { get; set; }
+
+        [Option(Constants.Agent.CommandLine.Args.StartupType)]
+        public string StartupType { get; set; }
     }
 }

--- a/src/Agent.Listener/CommandSettings.cs
+++ b/src/Agent.Listener/CommandSettings.cs
@@ -419,7 +419,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         // This is used to find out the source from where the agent.listener.exe was launched at the time of run
         public string GetStartupType()
         {
-            return GetArg(Configure?.StartupType, Constants.Agent.CommandLine.Args.StartupType);
+            return GetArg(Run?.StartupType, Constants.Agent.CommandLine.Args.StartupType);
         }
         
         public string GetProxyUrl()
@@ -724,6 +724,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             {
                 config.AutoHelp = false;
                 config.AutoVersion = false;
+                config.CaseSensitive = false;
 
                 // We should consider making this false, but it will break people adding unknown arguments
                 config.IgnoreUnknownArguments = ignoreErrors;

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -42,6 +42,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", nameof(CommandSettings))]
+        public void GetsArgCaseInsensitive()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange.
+                var command = new CommandSettings(hc, args: new string[] { "configure", "--AgenT", "some agent" });
+
+                // Act.
+                string actual = command.GetAgentName();
+
+                // Assert.
+                Assert.Equal("some agent", actual);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", nameof(CommandSettings))]
         public void GetsArgFromEnvVar()
         {
             using (TestHostContext hc = CreateTestContext())
@@ -282,6 +300,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
 
                 // Assert.
                 Assert.True(actual);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", nameof(CommandSettings))]
+        public void GetsStartUpType()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                string expected = "test";
+
+                // Arrange.
+                var command = new CommandSettings(hc, args: new string[] { "run", "--startuptype", expected });
+
+                // Act.
+                string actual = command.GetStartupType();
+
+                // Assert.
+                Assert.Equal(expected, actual);
             }
         }
 


### PR DESCRIPTION
- Make arguments case insensitive
- Move StartUpType to Run command