### PR TITLE
Hide uri rules

### DIFF
--- a/src/rules.ruleset
+++ b/src/rules.ruleset
@@ -36,9 +36,9 @@
       <Rule Id="CA1050" Action="Error" />            <!-- Declare types in namespaces -->
       <Rule Id="CA1051" Action="Warning" />          <!-- Do not declare visible instance fields -->
       <Rule Id="CA1052" Action="Warning" />          <!-- Static holder types should be Static or NotInheritable -->
-      <Rule Id="CA1054" Action="Warning" />          <!-- Uri parameters should not be strings -->
-      <Rule Id="CA1055" Action="Warning" />          <!-- Uri return values should not be strings -->
-      <Rule Id="CA1056" Action="Warning" />          <!-- Uri properties should not be strings -->
+      <Rule Id="CA1054" Action="Hidden" />           <!-- Uri parameters should not be strings -->
+      <Rule Id="CA1055" Action="Hidden" />           <!-- Uri return values should not be strings -->
+      <Rule Id="CA1056" Action="Hidden" />           <!-- Uri properties should not be strings -->
       <Rule Id="CA1058" Action="Error" />            <!-- Types should not extend certain base types -->
       <Rule Id="CA1060" Action="Warning" />          <!-- Move pinvokes to native methods class -->
       <Rule Id="CA1061" Action="Error" />            <!-- Do not hide base class methods -->


### PR DESCRIPTION
These rules prohibit having a parameter or variable with the substring uri or url in the variable name, or having a similarly named function that returns a string.

This flags a lot of methods that are fine IMO and type safety keeps us from running into any actual bugs from this.

Example function this flags because of an invalid parameter:

https://github.com/microsoft/azure-pipelines-agent/blob/356402a8f986ec69f3daa176886d9774e0eda262/src/Agent.Sdk/Util/RepositoryUtil.cs#L149

I think functions like this benefit from being able to take in a string url since they're doing string manipulation anyways