### PR TITLE
Fix overzealous argument null checking

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/JobNotification.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/JobNotification.cs
@@ -119,7 +119,6 @@ namespace Microsoft.VisualStudio.Services.Agent
         public void StartClient(string socketAddress, string monitorSocketAddress)
         {
             ArgUtil.NotNull(socketAddress, nameof(socketAddress));
-            ArgUtil.NotNull(monitorSocketAddress, nameof(monitorSocketAddress));
 
             ConnectMonitor(monitorSocketAddress);
 


### PR DESCRIPTION
Address issue found https://developercommunity.visualstudio.com/content/problem/979242/ado-agent-starting-at-version-21661-fails-with-arg.html?childToView=980875