### PR TITLE
Use the SystemVssConnection endpoint for the forked PR builds for azure repos

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -277,6 +277,7 @@ namespace Agent.Plugins.Repository
                 }
             }
 
+            executionContext.Debug($"total endpoints={executionContext.Endpoints.Count}");
             // retrieve credential from endpoint.
             ServiceEndpoint endpoint = null;
             if (repository.Endpoint != null)
@@ -287,6 +288,11 @@ namespace Agent.Plugins.Repository
                     x => (repository.Endpoint.Id != Guid.Empty && x.Id == repository.Endpoint.Id) ||
                     (repository.Endpoint.Id == Guid.Empty && string.Equals(x.Name, repository.Endpoint.Name.ToString(), StringComparison.OrdinalIgnoreCase)));
             }
+
+            executionContext.Debug($"endpoint auth scheme={endpoint.Authorization.Scheme}");
+            executionContext.Debug($"endpoint Id={endpoint.Id}");
+            executionContext.Debug($"endpoint Name={endpoint.Name}");
+            executionContext.Debug($"Access Token={endpoint.Authorization.Parameters[EndpointAuthorizationParameters.AccessToken]}");
 
             if (endpoint != null && endpoint.Data.TryGetValue(EndpointData.AcceptUntrustedCertificates, out string endpointAcceptUntrustedCerts))
             {
@@ -399,6 +405,7 @@ namespace Agent.Plugins.Repository
                 switch (endpoint.Authorization.Scheme)
                 {
                     case EndpointAuthorizationSchemes.OAuth:
+                        executionContext.Debug($"Inside OAuth");
                         username = EndpointAuthorizationSchemes.OAuth;
                         useBearerAuthType = UseBearerAuthenticationForOAuth();
                         if (!endpoint.Authorization.Parameters.TryGetValue(EndpointAuthorizationParameters.AccessToken, out password))
@@ -407,6 +414,7 @@ namespace Agent.Plugins.Repository
                         }
                         break;
                     case EndpointAuthorizationSchemes.PersonalAccessToken:
+                        executionContext.Debug($"Inside PAT");
                         username = EndpointAuthorizationSchemes.PersonalAccessToken;
                         if (!endpoint.Authorization.Parameters.TryGetValue(EndpointAuthorizationParameters.AccessToken, out password))
                         {
@@ -414,6 +422,7 @@ namespace Agent.Plugins.Repository
                         }
                         break;
                     case EndpointAuthorizationSchemes.Token:
+                        executionContext.Debug($"Inside Token");
                         username = "x-access-token";
                         if (!endpoint.Authorization.Parameters.TryGetValue(EndpointAuthorizationParameters.AccessToken, out password))
                         {
@@ -425,6 +434,7 @@ namespace Agent.Plugins.Repository
                         }
                         break;
                     case EndpointAuthorizationSchemes.UsernamePassword:
+                        executionContext.Debug($"Inside UserNamePassword");
                         if (!endpoint.Authorization.Parameters.TryGetValue(EndpointAuthorizationParameters.Username, out username))
                         {
                             // leave the username as empty, the username might in the url, like: http://username@repository.git

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -470,7 +470,6 @@ namespace Agent.Plugins.Repository
 
             // prepare credentail embedded urls
             repositoryUrlWithCred = UrlUtil.GetCredentialEmbeddedUrl(repositoryUrl, username, password);
-            executionContext.Debug($"repositoryUrlWithCred: {repositoryUrlWithCred}"); 
             var agentProxy = executionContext.GetProxyConfiguration();
             if (agentProxy != null && !string.IsNullOrEmpty(agentProxy.ProxyAddress) && !agentProxy.WebProxy.IsBypassed(repositoryUrl))
             {
@@ -488,8 +487,7 @@ namespace Agent.Plugins.Repository
                     proxyUrlWithCredString = proxyUrlWithCred.OriginalString;
                 }
             }
-            executionContext.Debug($"proxyUrlWithCredString: {proxyUrlWithCredString}"); 
-            executionContext.Debug("Before agent cert");    
+    
             // prepare askpass for client cert private key, if the repository's endpoint url match the TFS/VSTS url
             var systemConnection = executionContext.Endpoints.Single(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
             if (agentCert != null && Uri.Compare(repositoryUrl, systemConnection.Url, UriComponents.SchemeAndServer, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0)
@@ -504,7 +502,6 @@ namespace Agent.Plugins.Repository
                 {
                     useClientCert = true;
 
-                    executionContext.Debug($"agentCert.ClientCertificatePassword: {agentCert.ClientCertificatePassword}");
                     // prepare askpass for client cert password
                     if (!string.IsNullOrEmpty(agentCert.ClientCertificatePassword))
                     {
@@ -516,7 +513,6 @@ namespace Agent.Plugins.Repository
 
                         if (!PlatformUtil.RunningOnWindows)
                         {
-                            executionContext.Debug("Inside !PlatformUtil.RunningOnWindows");
                             string toolPath = WhichUtil.Which("chmod", true);
                             string argLine = $"775 {clientCertPrivateKeyAskPassFile}";
                             executionContext.Command($"chmod {argLine}");


### PR DESCRIPTION
Forked PR builds for Azure Repos should use the access token with restricted scope due to security reasons. The resticted access token is set on the SystemVssConnection endpoint which build agent cannot access. This fix will allow the agent to use the SystemVssConnection endpoint for the forked PR builds for the Azure Repos. 

Tests Performed:

- [x]  Azure forked builds for the forked repo in the same project are authenticating without any error during the checkout.
- [x] Azure forked builds with forked repo in the different project are authenticating without any error during the checkout.
- [x] Regular Azure builds are working as before.
- [x] Github forked and regular builds are working as before.