### PR TITLE
Add parameter for build target selection

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -17,6 +17,18 @@ parameters:
 - name: branch
   type: string
   default: ''
+- name: target
+  type: string
+  default: all
+  values:
+  - all
+  - win-x64
+  - win-x86
+  - linux-x64
+  - linux-arm
+  - linux-arm64
+  - rhel.6-x64
+  - osx-x64
 
 resources:
   containers:
@@ -34,110 +46,119 @@ stages:
   jobs:
 
   # Windows x64
-  - template: build-job.yml
-    parameters:
-      jobName: build_windows_x64_agent
-      displayName: Windows Agent (x64)
-      pool:
-        vmImage: vs2017-win2016
-      os: win
-      arch: x64
-      branch: ${{ parameters.branch }}
-      codeCoverage: true
-      componentDetection: ${{ parameters.componentDetection }}
-      sign: ${{ parameters.sign }}
-      verifySigning: ${{ parameters.sign }}
-      publishArtifact: ${{ parameters.publishArtifacts }}
+  - ${{ if or(eq(parameters.target, 'win-x64'), eq(parameters.target, 'all')) }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_windows_x64_agent
+        displayName: Windows Agent (x64)
+        pool:
+          vmImage: vs2017-win2016
+        os: win
+        arch: x64
+        branch: ${{ parameters.branch }}
+        codeCoverage: true
+        componentDetection: ${{ parameters.componentDetection }}
+        sign: ${{ parameters.sign }}
+        verifySigning: ${{ parameters.sign }}
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Windows (x86)
-  - template: build-job.yml
-    parameters:
-      jobName: build_windows_x86_agent
-      displayName: Windows Agent (x86)
-      pool:
-        name: buildDevs
-        demands: 'Agent.OSArchitecture -equals X86'
-      os: win
-      arch: x86
-      branch: ${{ parameters.branch }}
-      componentDetection: false
-      sign: ${{ parameters.sign }}
-      publishArtifact: ${{ parameters.publishArtifacts }}
+  - ${{ if or(eq(parameters.target, 'win-x86'), eq(parameters.target, 'all')) }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_windows_x86_agent
+        displayName: Windows Agent (x86)
+        pool:
+          name: buildDevs
+          demands: 'Agent.OSArchitecture -equals X86'
+        os: win
+        arch: x86
+        branch: ${{ parameters.branch }}
+        componentDetection: false
+        sign: ${{ parameters.sign }}
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (x64)
-  - template: build-job.yml
-    parameters:
-      jobName: build_linux_x64_agent
-      displayName: Linux Agent (x64)
-      pool:
-        vmImage: ubuntu-16.04
-      os: linux
-      arch: x64
-      branch: ${{ parameters.branch }}
-      componentDetection: ${{ parameters.componentDetection }}
-      sign: false
-      publishArtifact: ${{ parameters.publishArtifacts }}
+  - ${{ if or(eq(parameters.target, 'linux-x64'), eq(parameters.target, 'all')) }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_linux_x64_agent
+        displayName: Linux Agent (x64)
+        pool:
+          vmImage: ubuntu-16.04
+        os: linux
+        arch: x64
+        branch: ${{ parameters.branch }}
+        componentDetection: ${{ parameters.componentDetection }}
+        sign: false
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM)
-  - template: build-job.yml
-    parameters:
-      jobName: build_linux_arm_agent
-      displayName: Linux Agent (ARM)
-      pool:
-        name: buildDevs
-        demands: 'Agent.OSArchitecture -equals ARM'
-      container: dotnetcore_arm
-      timeoutInMinutes: 75
-      os: linux
-      arch: arm
-      branch: ${{ parameters.branch }}
-      componentDetection: false
-      sign: false
-      publishArtifact: ${{ parameters.publishArtifacts }}
+  - ${{ if or(eq(parameters.target, 'linux-arm'), eq(parameters.target, 'all')) }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_linux_arm_agent
+        displayName: Linux Agent (ARM)
+        pool:
+          name: buildDevs
+          demands: 'Agent.OSArchitecture -equals ARM'
+        container: dotnetcore_arm
+        timeoutInMinutes: 75
+        os: linux
+        arch: arm
+        branch: ${{ parameters.branch }}
+        componentDetection: false
+        sign: false
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
-  # # Linux (ARM64)
-  # - template: build-job.yml
-  #   parameters:
-  #     jobName: build_linux_arm64_agent
-  #     displayName: Linux Agent (ARM64)
-  #     pool:
-  #       name: buildDevs
-  #       demands: 'Agent.OSArchitecture -equals ARM64'
-  #     timeoutInMinutes: 75
-  #     os: linux
-  #     arch: arm64
-  #     branch: ${{ parameters.branch }}
-  #     componentDetection: false
-  #     sign: false
-  #     publishArtifact: ${{ parameters.publishArtifacts }}
+  # Linux (ARM64)
+  # - ${{ if or(eq(parameters.target, 'linux-arm64'), eq(parameters.target, 'all')) }}:
+  - ${{ if false }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_linux_arm64_agent
+        displayName: Linux Agent (ARM64)
+        pool:
+          name: buildDevs
+          demands: 'Agent.OSArchitecture -equals ARM64'
+        timeoutInMinutes: 75
+        os: linux
+        arch: arm64
+        branch: ${{ parameters.branch }}
+        componentDetection: false
+        sign: false
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
   # RHEL6 Agent (x64)
-  - template: build-job.yml
-    parameters:
-      jobName: build_rhel6_x64_agent
-      displayName: RHEL6 Agent (x64)
-      pool:
-        vmImage: ubuntu-16.04
-      container: dotnetcore_centos6
-      os: rhel.6
-      arch: x64
-      branch: ${{ parameters.branch }}
-      componentDetection: false
-      sign: false
-      publishArtifact: ${{ parameters.publishArtifacts }}
+  
+  - ${{ if or(eq(parameters.target, 'rhel.6-x64'), eq(parameters.target, 'all')) }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_rhel6_x64_agent
+        displayName: RHEL6 Agent (x64)
+        pool:
+          vmImage: ubuntu-16.04
+        container: dotnetcore_centos6
+        os: rhel.6
+        arch: x64
+        branch: ${{ parameters.branch }}
+        componentDetection: false
+        sign: false
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
   # macOS x64
-  - template: build-job.yml
-    parameters:
-      jobName: build_osx_agent
-      displayName: macOS Agent (x64)
-      pool:
-        vmImage: macOS-10.14
-      os: osx
-      arch: x64
-      branch: ${{ parameters.branch }}
-      componentDetection: ${{ parameters.componentDetection }}
-      sign: false
-      publishArtifact: ${{ parameters.publishArtifacts }}
+  - ${{ if or(eq(parameters.target, 'osx-x64'), eq(parameters.target, 'all')) }}:
+    - template: build-job.yml
+      parameters:
+        jobName: build_osx_agent
+        displayName: macOS Agent (x64)
+        pool:
+          vmImage: macOS-10.14
+        os: osx
+        arch: x64
+        branch: ${{ parameters.branch }}
+        componentDetection: ${{ parameters.componentDetection }}
+        sign: false
+        publishArtifact: ${{ parameters.publishArtifacts }}
 
 - ${{ parameters.postBuildStages }}

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -19,7 +19,7 @@ parameters:
   default: ''
 - name: target
   type: string
-  default: all
+  default: All
 
 resources:
   containers:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -20,6 +20,15 @@ parameters:
 - name: target
   type: string
   default: All
+  values:
+  - All
+  - Windows (x64)
+  - Windows (x86)
+  - Linux (x64)
+  - Linux (ARM)
+  - Linux (ARM64)
+  - RHEL 6 (x64)
+  - macOS (x64)
 
 resources:
   containers:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -103,8 +103,8 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM64)
-  # - ${{ if or(eq(parameters.target, 'Linux (ARM64)'), eq(parameters.target, 'All')) }}:
-  - ${{ if false }}:
+  #- ${{ if or(eq(parameters.target, 'Linux (ARM64)'), eq(parameters.target, 'All')) }}:
+  - ${{ if eq(parameters.target, 'Linux (ARM64)') }}:
     - template: build-job.yml
       parameters:
         jobName: build_linux_arm64_agent

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -20,15 +20,6 @@ parameters:
 - name: target
   type: string
   default: all
-  values:
-  - all
-  - win-x64
-  - win-x86
-  - linux-x64
-  - linux-arm
-  - linux-arm64
-  - rhel.6-x64
-  - osx-x64
 
 resources:
   containers:
@@ -46,7 +37,7 @@ stages:
   jobs:
 
   # Windows x64
-  - ${{ if or(eq(parameters.target, 'win-x64'), eq(parameters.target, 'all')) }}:
+  - ${{ if or(eq(parameters.target, 'Windows (x64)'), eq(parameters.target, 'All')) }}:
     - template: build-job.yml
       parameters:
         jobName: build_windows_x64_agent
@@ -63,7 +54,7 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Windows (x86)
-  - ${{ if or(eq(parameters.target, 'win-x86'), eq(parameters.target, 'all')) }}:
+  - ${{ if or(eq(parameters.target, 'Windows (x86)'), eq(parameters.target, 'All')) }}:
     - template: build-job.yml
       parameters:
         jobName: build_windows_x86_agent
@@ -79,7 +70,7 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (x64)
-  - ${{ if or(eq(parameters.target, 'linux-x64'), eq(parameters.target, 'all')) }}:
+  - ${{ if or(eq(parameters.target, 'Linux (x64)'), eq(parameters.target, 'All')) }}:
     - template: build-job.yml
       parameters:
         jobName: build_linux_x64_agent
@@ -94,7 +85,7 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM)
-  - ${{ if or(eq(parameters.target, 'linux-arm'), eq(parameters.target, 'all')) }}:
+  - ${{ if or(eq(parameters.target, 'Linux (ARM)'), eq(parameters.target, 'All')) }}:
     - template: build-job.yml
       parameters:
         jobName: build_linux_arm_agent
@@ -112,7 +103,7 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM64)
-  # - ${{ if or(eq(parameters.target, 'linux-arm64'), eq(parameters.target, 'all')) }}:
+  # - ${{ if or(eq(parameters.target, 'Linux (ARM64)'), eq(parameters.target, 'All')) }}:
   - ${{ if false }}:
     - template: build-job.yml
       parameters:
@@ -130,8 +121,7 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # RHEL6 Agent (x64)
-  
-  - ${{ if or(eq(parameters.target, 'rhel.6-x64'), eq(parameters.target, 'all')) }}:
+  - ${{ if or(eq(parameters.target, 'RHEL 6 (x64)'), eq(parameters.target, 'All')) }}:
     - template: build-job.yml
       parameters:
         jobName: build_rhel6_x64_agent
@@ -147,7 +137,7 @@ stages:
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # macOS x64
-  - ${{ if or(eq(parameters.target, 'osx-x64'), eq(parameters.target, 'all')) }}:
+  - ${{ if or(eq(parameters.target, 'macOS (x64)'), eq(parameters.target, 'All')) }}:
     - template: build-job.yml
       parameters:
         jobName: build_osx_agent

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -1,3 +1,17 @@
+parameters:
+- name: target
+  type: string
+  default: all
+  values:
+  - all
+  - win-x64
+  - win-x86
+  - linux-x64
+  - linux-arm
+  - linux-arm64
+  - rhel.6-x64
+  - osx-x64
+
 pr:
   branches:
     include:
@@ -11,3 +25,4 @@ extends:
   parameters:
     componentDetection: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
     publishArtifacts: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
+    target: ${{ parameters.target }}

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -2,7 +2,7 @@ parameters:
 - name: target
   displayName: Target
   type: string
-  default: all
+  default: All
   values:
   - All
   - Windows (x64)

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -1,16 +1,17 @@
 parameters:
 - name: target
+  displayName: Target
   type: string
   default: all
   values:
-  - all
-  - win-x64
-  - win-x86
-  - linux-x64
-  - linux-arm
-  - linux-arm64
-  - rhel.6-x64
-  - osx-x64
+  - All
+  - Windows (x64)
+  - Windows (x86)
+  - Linux (x64)
+  - Linux (ARM)
+  - Linux (ARM64)
+  - RHEL 6 (x64)
+  - macOS (x64)
 
 pr:
   branches:


### PR DESCRIPTION
Adds a new "Target" parameter, so that for manually triggered CI builds, it is easy to build just one target when you want to, without having to temporarily modify the build.

I tested this by queuing each target individually, queuing with the All option, and queuing a release build from this branch to verify it uses the All default.

![image](https://user-images.githubusercontent.com/810595/79009433-6830e100-7b2d-11ea-8871-960869de8bee.png)
