### PR TITLE
Sign Mac DLLs

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -159,6 +159,7 @@ jobs:
     - template: signing.yml
       parameters:
         layoutRoot: ${{ variables.layoutRoot }}
+        isWindows: ${{ eq(parameters.os, 'win') }}
 
   # Publish artifacts
   - ${{ if parameters.publishArtifact }}:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -157,7 +157,7 @@ stages:
         arch: x64
         branch: ${{ parameters.branch }}
         componentDetection: ${{ parameters.componentDetection }}
-        sign: false
+        sign: ${{ parameters.sign }}
         publishArtifact: ${{ parameters.publishArtifacts }}
 
 - ${{ parameters.postBuildStages }}

--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -1,37 +1,40 @@
 parameters:
 - name: layoutRoot
   type: string
+- name: isWindows
+  type: boolean
+  default: true
 
 steps:
+- ${{ if parameters.isWindows }}:
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    inputs:
+      ConnectedServiceName: VSTSAgentESRP
+      FolderPath: '${{ parameters.layoutRoot }}/bin'
+      Pattern: AgentService.exe
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [{
+        "keyCode": "CP-235845-SN",
+        "operationSetCode": "StrongNameSign",
+        "parameters": [],
+        "toolName": "sign",
+        "toolVersion": "1.0"
+        },
+        {
+        "keyCode": "CP-235845-SN",
+        "operationSetCode": "StrongNameVerify",
+        "parameters": [],
+        "toolName": "sign",
+        "toolVersion": "1.0"
+        }
+        ]
+    displayName: Sign Agent Assemblies (Strong Name Signing)
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   inputs:
     ConnectedServiceName: VSTSAgentESRP
-    FolderPath: '${{ parameters.layoutRoot }}\bin'
-    Pattern: AgentService.exe
-    signConfigType: inlineSignParams
-    inlineOperation: |
-      [{
-      "keyCode": "CP-235845-SN",
-      "operationSetCode": "StrongNameSign",
-      "parameters": [],
-      "toolName": "sign",
-      "toolVersion": "1.0"
-      },
-      {
-      "keyCode": "CP-235845-SN",
-      "operationSetCode": "StrongNameVerify",
-      "parameters": [],
-      "toolName": "sign",
-      "toolVersion": "1.0"
-      }
-      ]
-  displayName: Sign Agent Assemblies (Strong Name Signing)
-
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  inputs:
-    ConnectedServiceName: VSTSAgentESRP
-    FolderPath: '${{ parameters.layoutRoot }}\bin'
+    FolderPath: '${{ parameters.layoutRoot }}/bin'
     Pattern: |
       Agent.*.dll
       Agent.*.exe


### PR DESCRIPTION
Sign all the Authenticode signable things on the mac for consistency. Since the AgentService.exe is Windows only, put its strong naming behind a Windows only flag. The fact that the other signing tasks reference some Windows-only patterns (exes) is OK. Those non-existent paths are just ignored by the task when invoked on the non-Windows layout root.