### PR TITLE
Sign Linux x64 DLLs

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -90,7 +90,7 @@ stages:
         arch: x64
         branch: ${{ parameters.branch }}
         componentDetection: ${{ parameters.componentDetection }}
-        sign: false
+        sign: ${{ parameters.sign }}
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM)


### PR DESCRIPTION
This is just the Linux x64 build, which I've tested. The ARM and RHEL6 builds still need container updates and I'm planning to do each separately.