### PR TITLE
Remove recently added Dispose

### DIFF
--- a/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
+++ b/src/Agent.Worker/Release/Artifacts/BuildArtifact.cs
@@ -248,15 +248,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.Artifacts
                 executionContext.Output(StringUtil.Loc("RMParallelDownloadLimit", containerFetchEngineOptions.ParallelDownloadLimit));
                 executionContext.Output(StringUtil.Loc("RMDownloadBufferSize", containerFetchEngineOptions.DownloadBufferSize));
 
-                using (var containerProviderFactory = new ContainerProviderFactory(buildArtifactDetails, rootLocation, containerId, executionContext))
+                IContainerProvider containerProvider =
+                    new ContainerProviderFactory(buildArtifactDetails, rootLocation, containerId, executionContext).GetContainerProvider(
+                    ArtifactResourceTypes.Container);
+
+                using (var engine = new ContainerFetchEngine.ContainerFetchEngine(containerProvider, rootLocation, rootDestinationDir))
                 {
-                    var containerProvider = containerProviderFactory.GetContainerProvider(ArtifactResourceTypes.Container);
-                    using (var engine = new ContainerFetchEngine.ContainerFetchEngine(containerProvider, rootLocation, rootDestinationDir))
-                    {
-                        engine.ContainerFetchEngineOptions = containerFetchEngineOptions;
-                        engine.ExecutionLogger = new ExecutionLogger(executionContext);
-                        await engine.FetchAsync(executionContext.CancellationToken);
-                    }
+                    engine.ContainerFetchEngineOptions = containerFetchEngineOptions;
+                    engine.ExecutionLogger = new ExecutionLogger(executionContext);
+                    await engine.FetchAsync(executionContext.CancellationToken);
                 }
             }
             else

--- a/src/Agent.Worker/Release/ContainerProvider/Helpers/ContainerProviderFactory.cs
+++ b/src/Agent.Worker/Release/ContainerProvider/Helpers/ContainerProviderFactory.cs
@@ -10,7 +10,8 @@ using Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerFetchEngine;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerProvider.Helpers
 {
-    public sealed class ContainerProviderFactory : IDisposable
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1001:Types that own disposable fields should be disposable ", MessageId = "_retryOnTimeoutMessageHandler")]
+    public sealed class ContainerProviderFactory
     {
         private readonly BuildArtifactDetails _buildArtifactDetails;
         private readonly string _rootLocation;
@@ -60,11 +61,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release.ContainerProvider
                 default:
                     throw new ArtifactDownloadException((StringUtil.Loc("RMArtifactTypeNotSupported", containerType)));
             }
-        }
-
-        public void Dispose()
-        {
-            _retryOnTimeoutMessageHandler?.Dispose();
         }
     }
 }


### PR DESCRIPTION
It appears the HttpRetryOnTimeoutMessageHandler reference
lives longer than the factory object and shouldn't be
disposed by it.