### PR TITLE
libcurl3 still exists on Ubuntu 18.04 servers

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -63,7 +63,12 @@ then
             
             # ubuntu 18 uses libcurl4
             # ubuntu 14, 16 and other linux use libcurl3
-            apt install -y libcurl3 || apt install -y libcurl4
+            if [ $(lsb_release -rs) = "18.04" ]
+            then 
+                apt install -y libcurl4
+            else
+                apt install -y libcurl3
+            fi
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -104,7 +109,12 @@ then
                 
                 # ubuntu 18 uses libcurl4
                 # ubuntu 14, 16 and other linux use libcurl3
-                apt-get install -y libcurl3 || apt-get install -y libcurl4
+                if [ $(lsb_release -rs) = "18.04" ]
+                then 
+                    apt-install install -y libcurl4
+                else
+                    apt-install install -y libcurl3
+                fi
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
on our systems, `libcurl3` is still available on Ubuntu 18.04 servers, so the script installs `libcurl3`, which forces `curl` and `libcurl4` to be removed.

This change checks to see which version of Ubuntu the script is running on and then installs the appropriate version of `libcurl`.  