### PR TITLE
Add setup_info support from Actions Runner

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.VisualStudio.Services.Agent.Util;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
@@ -99,6 +100,16 @@ namespace Microsoft.VisualStudio.Services.Agent
         public bool GitUseSecureChannel { get; set; }
     }
 
+    [DataContract]
+    public class SetupInfo
+    {
+        [DataMember]
+        public string Group { get; set; }
+
+        [DataMember]
+        public string Detail { get; set; }
+    }
+
     [ServiceLocator(Default = typeof(ConfigurationStore))]
     public interface IConfigurationStore : IAgentService
     {
@@ -117,6 +128,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         void SaveAutoLogonSettings(AutoLogonSettings settings);
         AutoLogonSettings GetAutoLogonSettings();
         AgentRuntimeOptions GetAgentRuntimeOptions();
+        IEnumerable<SetupInfo> GetSetupInfo();
         void SaveAgentRuntimeOptions(AgentRuntimeOptions options);
         void DeleteAgentRuntimeOptions();
     }
@@ -129,11 +141,13 @@ namespace Microsoft.VisualStudio.Services.Agent
         private string _serviceConfigFilePath;
         private string _autoLogonSettingsFilePath;
         private string _runtimeOptionsFilePath;
+        private string _setupInfoFilePath;
 
         private CredentialData _creds;
         private AgentSettings _settings;
         private AutoLogonSettings _autoLogonSettings;
         private AgentRuntimeOptions _runtimeOptions;
+        private IEnumerable<SetupInfo> _setupInfo;
 
         public override void Initialize(IHostContext hostContext)
         {
@@ -162,6 +176,9 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             _runtimeOptionsFilePath = hostContext.GetConfigFile(WellKnownConfigFile.Options);
             Trace.Info("RuntimeOptionsFilePath: {0}", _runtimeOptionsFilePath);
+
+            _setupInfoFilePath = hostContext.GetConfigFile(WellKnownConfigFile.SetupInfo);
+            Trace.Info("SetupInfoFilePath: {0}", _setupInfoFilePath);
         }
 
         public string RootFolder { get; private set; }
@@ -235,6 +252,24 @@ namespace Microsoft.VisualStudio.Services.Agent
             }
 
             return _autoLogonSettings;
+        }
+
+        public IEnumerable<SetupInfo> GetSetupInfo()
+        {
+            if (_setupInfo == null)
+            {
+                if (File.Exists(_setupInfoFilePath))
+                {
+                    Trace.Info($"Load machine setup info from {_setupInfoFilePath}");
+                    _setupInfo = IOUtil.LoadObject<List<SetupInfo>>(_setupInfoFilePath);
+                }
+                else
+                {
+                    _setupInfo = new List<SetupInfo>();
+                }
+            }
+
+            return _setupInfo;
         }
 
         public void SaveCredential(CredentialData credential)

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         ProxyBypass,
         Autologon,
         Options,
+        SetupInfo
     }
 
     public static class Constants

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -342,6 +342,13 @@ namespace Microsoft.VisualStudio.Services.Agent
                         GetDirectory(WellKnownDirectory.Root),
                         ".options");
                     break;
+
+                case WellKnownConfigFile.SetupInfo:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Root),
+                        ".setup_info");
+                    break;
+
                 default:
                     throw new NotSupportedException($"Unexpected well known config file: '{configFile}'");
             }

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -342,6 +342,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                         GetDirectory(WellKnownDirectory.Root),
                         ".options");
                     break;
+
+                case WellKnownConfigFile.SetupInfo:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Root),
+                        ".setup_info");
+                    break;
+
                 default:
                     throw new NotSupportedException($"Unexpected well known config file: '{configFile}'");
             }

--- a/src/Test/L1/Mock/FakeConfigurationStore.cs
+++ b/src/Test/L1/Mock/FakeConfigurationStore.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
@@ -8,6 +9,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
         public string WorkingDirectoryName { get; set; }
 
         public string RootFolder => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "/TestRuns/" + WorkingDirectoryName;
+
+        public List<SetupInfo> SetupInfo => new List<SetupInfo>();
 
         private AgentSettings _agentSettings;
 
@@ -34,6 +37,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
         public CredentialData GetCredentials()
         {
             return null;
+        }
+
+        public IEnumerable<SetupInfo> GetSetupInfo()
+        {
+            return SetupInfo;
         }
 
         public AgentSettings GetSettings()


### PR DESCRIPTION
The is a port of a change from the Actions runner to display additional machine setup information in the job initialization logs in a structured way. For hosted pools, MMS is already putting this file in place. It contains useful information about the machine image, including a link to detailed release notes that indicate the exact versions of the included tools.

Original spec: https://github.com/actions/runner/blob/master/docs/adrs/0354-runner-machine-info.md

Runner implementation: https://github.com/actions/runner/pull/364/
