### PR TITLE
installdependencies script must prefer newer versions of packages

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -63,7 +63,7 @@ then
             
             # ubuntu 18 uses libcurl4
             # ubuntu 14, 16 and other linux use libcurl3
-            apt install -y libcurl3 || apt install -y libcurl4
+            apt install -y libcurl4 || apt install -y libcurl3
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -74,7 +74,7 @@ then
 	        # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
             # other debian linux use libssl1.0.0
-            apt install -y libssl1.0.0 || apt install -y libssl1.0.2 || apt install -y libssl1.1
+            apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -82,8 +82,8 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-            apt install -y libicu52 || apt install -y libicu55 || apt install -y libicu57 || apt install -y libicu60 || apt install -y libicu63
+            # libicu versions: libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+            apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -104,7 +104,7 @@ then
                 
                 # ubuntu 18 uses libcurl4
                 # ubuntu 14, 16 and other linux use libcurl3
-                apt-get install -y libcurl3 || apt-get install -y libcurl4
+                apt-get install -y libcurl4 || apt-get install -y libcurl3
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -115,7 +115,7 @@ then
                 # debian 10 uses libssl1.1
                 # debian 9 uses libssl1.0.2
                 # other debian linux use libssl1.0.0
-                apt-get install -y libssl1.0.0 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.1
+                apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -123,8 +123,8 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-                apt-get install -y libicu52 || apt-get install -y libicu55 || apt-get install -y libicu57 || apt-get install -y libicu60 || apt-get install -y libicu63
+                # libicu versions: libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+                apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
IMHO, I encountered an error in the script:
I use ubuntu 18.04 with pre-installed curl package. Using curl I download the current version of the agent.
When I run this script, curl package is deleted because in its current version, it depends on libcurl4 package, however, the script prefers to install libcurl3, which leads to the removal  of libcurl4 and curl packages as well. as a result, if I need use curl later,I will need to reinstall it, which in my opinion is incorrect.