### PR TITLE
Add signature verification mode and support for multiple fingerprints

### DIFF
--- a/src/Agent.Worker/SignatureService.cs
+++ b/src/Agent.Worker/SignatureService.cs
@@ -30,14 +30,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             var configurationStore = HostContext.GetService<IConfigurationStore>();
             AgentSettings settings = configurationStore.GetSettings();
-            String fingerprint = settings.Fingerprint;
+            SignatureVerificationSettings verificationSettings = settings.SignatureVerification;
             String taskZipPath = definition.ZipPath;
             String taskNugetPath = definition.ZipPath.Replace(".zip", ".nupkg");
 
             // Rename .zip to .nupkg
             File.Move(taskZipPath, taskNugetPath);
 
-            String arguments = $"verify -Signatures \"{taskNugetPath}\" -CertificateFingerprint {fingerprint} -Verbosity Detailed";
+            String arguments = $"verify -Signatures \"{taskNugetPath}\" -Verbosity Detailed";
+
+            if (verificationSettings?.Fingerprints != null && verificationSettings.Fingerprints.Count > 0)
+            {
+                String fingerprint = String.Join(";", verificationSettings.Fingerprints);
+                arguments += $" -CertificateFingerprint {fingerprint}";
+            }
 
             // Run nuget verify
             using (var processInvoker = HostContext.CreateService<IProcessInvoker>())

--- a/src/Agent.Worker/SignatureService.cs
+++ b/src/Agent.Worker/SignatureService.cs
@@ -42,12 +42,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             if (verificationSettings?.Fingerprints != null && verificationSettings.Fingerprints.Count > 0)
             {
                 String fingerprint = String.Join(";", verificationSettings.Fingerprints);
-                arguments += $" -CertificateFingerprint {fingerprint}";
+                arguments += $" -CertificateFingerprint \"{fingerprint}\"";
             }
+
+            Trace.Info($"nuget arguments: {arguments}");
 
             // Run nuget verify
             using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
             {
+                processInvoker.OutputDataReceived += (object sender, ProcessDataReceivedEventArgs args) =>
+                {
+                    if (!string.IsNullOrEmpty(args.Data))
+                    {
+                        Trace.Info(args.Data);
+                    }
+                };
                 int exitCode = await processInvoker.ExecuteAsync(workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Root),
                                                                  fileName: nugetPath,
                                                                  arguments: arguments,

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             var configurationStore = HostContext.GetService<IConfigurationStore>();
             AgentSettings settings = configurationStore.GetSettings();
-            Boolean signingEnabled = !String.IsNullOrEmpty(settings.Fingerprint);
+            Boolean signingEnabled = (settings.SignatureVerification != null && settings.SignatureVerification.Mode != SignatureVerificationMode.None);
 
             if (File.Exists(destDirectory + ".completed") && !signingEnabled)
             {

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -78,15 +78,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Verify task signatures if a fingerprint is configured for the Agent.
                 var configurationStore = HostContext.GetService<IConfigurationStore>();
                 AgentSettings settings = configurationStore.GetSettings();
+                SignatureVerificationMode verificationMode = SignatureVerificationMode.None;
+                if (settings.SignatureVerification != null)
+                {
+                    verificationMode = settings.SignatureVerification.Mode;
+                }
 
-                if (!String.IsNullOrEmpty(settings.Fingerprint))
+                if (verificationMode != SignatureVerificationMode.None)
                 {
                     ISignatureService signatureService = HostContext.CreateService<ISignatureService>();
                     Boolean verificationSuccessful =  await signatureService.VerifyAsync(definition, ExecutionContext.CancellationToken);
 
                     if (verificationSuccessful)
                     {
-                        ExecutionContext.Output("Task signature verification successful.");
+                        ExecutionContext.Output(StringUtil.Loc("TaskSignatureVerificationSucceeeded"));
 
                         // Only extract if it's not the checkout task.
                         if (!String.IsNullOrEmpty(definition.ZipPath))
@@ -96,7 +101,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                     else
                     {
-                        throw new InvalidOperationException("Task signature verification failed.");
+                        String message = StringUtil.Loc("TaskSignatureVerificationFailed");
+
+                        if (verificationMode == SignatureVerificationMode.Error)
+                        {
+                            throw new InvalidOperationException(message);
+                        }
+                        else
+                        {
+                            ExecutionContext.Warning(message);
+                        }
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
@@ -10,6 +10,22 @@ using System.Threading;
 
 namespace Microsoft.VisualStudio.Services.Agent
 {
+    public enum SignatureVerificationMode
+    {
+        Error,
+        Warning,
+        None
+    }
+
+    public sealed class SignatureVerificationSettings
+    {
+        [DataMember(EmitDefaultValue = false)]
+        public SignatureVerificationMode Mode { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public List<string> Fingerprints { get; set; }
+    }
+
     //
     // Settings are persisted in this structure
     //
@@ -29,7 +45,22 @@ namespace Microsoft.VisualStudio.Services.Agent
         public bool IsHosted => !string.IsNullOrEmpty(NotificationPipeName) || !string.IsNullOrEmpty(NotificationSocketAddress);
 
         [DataMember(EmitDefaultValue = false)]
-        public string Fingerprint { get; set; }
+        public string Fingerprint
+        {
+            // This setter is for backwards compatibility with the top level fingerprint setting
+            set
+            {
+                // prefer the new config format to the old
+                if (SignatureVerification == null && value != null)
+                {
+                    SignatureVerification = new SignatureVerificationSettings()
+                    {
+                        Mode = SignatureVerificationMode.Error,
+                        Fingerprints = new List<string>() { value }
+                    };
+                }
+            }
+        }
 
         [DataMember(EmitDefaultValue = false)]
         public string NotificationPipeName { get; set; }
@@ -42,6 +73,9 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         [DataMember(EmitDefaultValue = false)]
         public bool SkipSessionRecover { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public SignatureVerificationSettings SignatureVerification { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public int PoolId { get; set; }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -585,6 +585,8 @@
     "A copy of the Team Explorer Everywhere license agreement can be found at:",
     "  {0}"
   ],
+  "TaskSignatureVerificationFailed": "Task signature verification failed.",
+  "TaskSignatureVerificationSucceeeded": "Task signature verification successful.",
   "Telemetry": "Telemetry",
   "TelemetryCommandDataError": "Unable to parse telemetry data {0}. Error: {1}",
   "TelemetryCommandFailed": "Failed to publish telemetry data. Error {0}",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -579,14 +579,14 @@
   "SvnSyncingRepo": "Syncing repository: {0} (Svn)",
   "TaskDownloadFailed": "Failed to download task '{0}'. Error {1}",
   "TaskDownloadTimeout": "Task '{0}' didn't finish download within {1} seconds.",
+  "TaskSignatureVerificationFailed": "Task signature verification failed.",
+  "TaskSignatureVerificationSucceeeded": "Task signature verification successful.",
   "TeeEula": [
     "Building sources from a TFVC repository requires accepting the Team Explorer Everywhere End User License Agreement. This step is not required for building sources from Git repositories.",
     "",
     "A copy of the Team Explorer Everywhere license agreement can be found at:",
     "  {0}"
   ],
-  "TaskSignatureVerificationFailed": "Task signature verification failed.",
-  "TaskSignatureVerificationSucceeeded": "Task signature verification successful.",
   "Telemetry": "Telemetry",
   "TelemetryCommandDataError": "Unable to parse telemetry data {0}. Error: {1}",
   "TelemetryCommandFailed": "Failed to publish telemetry data. Error {0}",

--- a/src/Test/L1/Worker/WorkerL1Tests.cs
+++ b/src/Test/L1/Worker/WorkerL1Tests.cs
@@ -5,7 +5,7 @@ using Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -195,13 +195,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
         [Trait("Level", "L1")]
         [Trait("Category", "Worker")]
         // TODO: When NuGet works cross-platform, remove these traits. Also, package NuGet with the Agent.
         [Trait("SkipOn", "darwin")]
         [Trait("SkipOn", "linux")]
-        public async Task SignatureEnforcementMode_PassesWhenAllTasksAreSigned()
+        public async Task SignatureVerification_PassesWhenAllTasksAreSigned(bool useFingerprintList, bool useTopLevelFingerprint)
         {
             try
             {
@@ -209,7 +212,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
                 SetupL1();
                 FakeConfigurationStore fakeConfigurationStore = GetMockedService<FakeConfigurationStore>();
                 AgentSettings settings = fakeConfigurationStore.GetSettings();
-                settings.Fingerprint = _fingerprint;
+                settings.SignatureVerification = new SignatureVerificationSettings()
+                {
+                    Mode = SignatureVerificationMode.Error
+                };
+                if (useFingerprintList)
+                {
+                    settings.SignatureVerification.Fingerprints = new List<string>() { _fingerprint };
+                }
+                else if (useTopLevelFingerprint)
+                {
+                    settings.Fingerprint = _fingerprint;
+                }
                 fakeConfigurationStore.UpdateSettings(settings);
 
                 var message = LoadTemplateMessage();
@@ -221,8 +235,87 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
 
                 // Assert
                 FakeJobServer fakeJobServer = GetMockedService<FakeJobServer>();
-                Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(fakeJobServer.Timelines));
+                AssertJobCompleted();
+                Assert.Equal(TaskResult.Succeeded, results.Result);
+            }
+            finally
+            {
+                TearDown();
+            }
+        }
 
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [Trait("Level", "L1")]
+        [Trait("Category", "Worker")]
+        // TODO: When NuGet works cross-platform, remove these traits. Also, package NuGet with the Agent.
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
+        public async Task SignatureVerification_FailsWhenTasksArentSigned(bool useFingerprintList, bool useTopLevelFingerprint)
+        {
+            try
+            {
+                // Arrange
+                SetupL1();
+                FakeConfigurationStore fakeConfigurationStore = GetMockedService<FakeConfigurationStore>();
+                AgentSettings settings = fakeConfigurationStore.GetSettings();
+                settings.SignatureVerification = new SignatureVerificationSettings()
+                {
+                    Mode = SignatureVerificationMode.Error
+                };
+                if (useFingerprintList)
+                {
+                    settings.SignatureVerification.Fingerprints = new List<string>() { _fingerprint };
+                }
+                else if (useTopLevelFingerprint)
+                {
+                    settings.Fingerprint = _fingerprint;
+                }
+                fakeConfigurationStore.UpdateSettings(settings);
+                var message = LoadTemplateMessage();
+
+                // Act
+                var results = await RunWorker(message);
+
+                // Assert
+                AssertJobCompleted();
+                Assert.Equal(TaskResult.Failed, results.Result);
+            }
+            finally
+            {
+                TearDown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L1")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
+        public async Task SignatureVerification_MultipleFingerprints()
+        {
+            try
+            {
+                // Arrange
+                SetupL1();
+                FakeConfigurationStore fakeConfigurationStore = GetMockedService<FakeConfigurationStore>();
+                AgentSettings settings = fakeConfigurationStore.GetSettings();
+                settings.SignatureVerification = new SignatureVerificationSettings()
+                {
+                    Mode = SignatureVerificationMode.Error,
+                    Fingerprints = new List<string>() { "BAD", _fingerprint }
+                };
+                fakeConfigurationStore.UpdateSettings(settings);
+                var message = LoadTemplateMessage();
+                message.Steps.Clear();
+                message.Steps.Add(GetSignedTask());
+
+                // Act
+                var results = await RunWorker(message);
+
+                // Assert
                 AssertJobCompleted();
                 Assert.Equal(TaskResult.Succeeded, results.Result);
             }
@@ -235,10 +328,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
         [Fact]
         [Trait("Level", "L1")]
         [Trait("Category", "Worker")]
-        // TODO: When NuGet works cross-platform, remove these traits. Also, package NuGet with the Agent.
         [Trait("SkipOn", "darwin")]
         [Trait("SkipOn", "linux")]
-        public async Task SignatureEnforcementMode_FailsWhenTasksArentSigned()
+        public async Task SignatureVerification_Warning()
         {
             try
             {
@@ -246,16 +338,63 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
                 SetupL1();
                 FakeConfigurationStore fakeConfigurationStore = GetMockedService<FakeConfigurationStore>();
                 AgentSettings settings = fakeConfigurationStore.GetSettings();
-                settings.Fingerprint = _fingerprint;
+                settings.SignatureVerification = new SignatureVerificationSettings()
+                {
+                    Mode = SignatureVerificationMode.Warning,
+                    Fingerprints = new List<string>() { "BAD" }
+                };
                 fakeConfigurationStore.UpdateSettings(settings);
                 var message = LoadTemplateMessage();
+                message.Steps.Clear();
+                message.Steps.Add(GetSignedTask());
 
                 // Act
                 var results = await RunWorker(message);
 
                 // Assert
                 AssertJobCompleted();
-                Assert.Equal(TaskResult.Failed, results.Result);
+                Assert.Equal(TaskResult.Succeeded, results.Result);
+
+                var steps = GetSteps();
+                var log = GetTimelineLogLines(steps[1]);
+
+                Assert.Equal(1, log.Where(x => x.Contains("##[warning]Task signature verification failed.")).Count());
+            }
+            finally
+            {
+                TearDown();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L1")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
+        public async Task SignatureVerification_Disabled()
+        {
+            try
+            {
+                // Arrange
+                SetupL1();
+                FakeConfigurationStore fakeConfigurationStore = GetMockedService<FakeConfigurationStore>();
+                AgentSettings settings = fakeConfigurationStore.GetSettings();
+                settings.SignatureVerification = new SignatureVerificationSettings()
+                {
+                    Mode = SignatureVerificationMode.None,
+                    Fingerprints = new List<string>() { "BAD" }
+                };
+                fakeConfigurationStore.UpdateSettings(settings);
+                var message = LoadTemplateMessage();
+                message.Steps.Clear();
+                message.Steps.Add(GetSignedTask());
+
+                // Act
+                var results = await RunWorker(message);
+
+                // Assert
+                AssertJobCompleted();
+                Assert.Equal(TaskResult.Succeeded, results.Result);
             }
             finally
             {


### PR DESCRIPTION
Adds a new "signatureVerfication" section to the agent configuration:

```json
{
  "agentId": 41,
  "agentName": "MAROGHEL-DESK",
  "poolId": 1,
  "poolName": "Default",
  "serverUrl": "https://codedev.ms/Test/",
  "signatureVerification":
  {
    "fingerprints": [ "94E88F7D7E4534287EB11420C9CCD8D626CA54656C3D2DC53EEF825D4F90E66C" ],
    "mode": "error"
  },
  "workFolder": "_work"
}
```

Supported modes are "error", "warn", and "none".

The fingerprints array is optional. The pre-existing top level "fingerprint" option maps to this new structure automatically.