### PR TITLE
branch in createReleaseBranch.js was undefined

### DIFF
--- a/release/createReleaseBranch.js
+++ b/release/createReleaseBranch.js
@@ -17,6 +17,7 @@ process.env.EDITOR = process.env.EDITOR === undefined ? 'code --wait' : process.
 var opt = require('node-getopt').create([
     ['',  'dryrun',               'Dry run only, do not actually commit new release'],
     ['',  'derivedFrom=version',  'Used to get PRs merged since this release was created', 'latest'],
+    ['',  'branch=branch',        'Branch to select PRs merged into', 'master'],
     ['h', 'help',                 'Display this help'],
   ])
   .setHelp(


### PR DESCRIPTION
The branch option was dropped in the migration from
the previous version of the script and the undefined
opt.options.branch resulted in no PRs being found in the
call to the GitHub API.