### PR TITLE
Separate targets flags and add skipTests

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -37,6 +37,10 @@ parameters:
   - x64
   - x86
 
+- name: unitTests
+  type: boolean
+  default: true
+
 - name: functionalTests
   type: boolean
   default: true
@@ -106,9 +110,10 @@ jobs:
         ADO_ENABLE_LOGISSUE: true
 
   # Run l0 tests
-  - script: ${{ variables.devCommand }} testl0
-    workingDirectory: src
-    displayName: Unit tests
+  - ${{ if parameters.unitTests }}:
+    - script: ${{ variables.devCommand }} testl0
+      workingDirectory: src
+      displayName: Unit tests
 
   # Install nuget
   - ${{ if eq(parameters.os, 'win') }}:
@@ -121,23 +126,24 @@ jobs:
       workingDirectory: src
       displayName: Functional tests
 
-  # Publish test results
-  - task: PublishTestResults@2
-    displayName: Publish Test Results **/*.trx
-    inputs:
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-      testRunTitle: 'Agent Tests - ${{ parameters.os }}-${{ parameters.arch }}'
-    condition: always()
+  - ${{ if or(parameters.unitTests, parameters.functionalTests) }}:
+    # Publish test results
+    - task: PublishTestResults@2
+      displayName: Publish Test Results **/*.trx
+      inputs:
+        testRunner: VSTest
+        testResultsFiles: '**/*.trx'
+        testRunTitle: 'Agent Tests - ${{ parameters.os }}-${{ parameters.arch }}'
+      condition: always()
 
-  # Upload test log
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Test logs
-    inputs:
-      pathToPublish: src/Test/TestLogs
-      artifactName: ${{ parameters.os }}-${{ parameters.arch }}-$(System.JobId)
-      artifactType: container
-    condition: always()
+    # Upload test log
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Test logs
+      inputs:
+        pathToPublish: src/Test/TestLogs
+        artifactName: ${{ parameters.os }}-${{ parameters.arch }}-$(System.JobId)
+        artifactType: container
+      condition: always()
 
   # Code coverage
   - ${{ if parameters.codeCoverage }}:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -8,6 +8,9 @@ parameters:
 - name: componentDetection
   type: boolean
   default: false
+- name: test
+  type: boolean
+  default: true
 - name: sign
   type: boolean
   default: false
@@ -17,18 +20,29 @@ parameters:
 - name: branch
   type: string
   default: ''
-- name: target
-  type: string
-  default: All
-  values:
-  - All
-  - Windows (x64)
-  - Windows (x86)
-  - Linux (x64)
-  - Linux (ARM)
-  - Linux (ARM64)
-  - RHEL 6 (x64)
-  - macOS (x64)
+
+# Targets
+- name: win_x64
+  type: boolean
+  default: true
+- name: win_x86
+  type: boolean
+  default: true
+- name: linux_x64
+  type: boolean
+  default: true
+- name: linux_arm
+  type: boolean
+  default: true
+- name: linux_arm64
+  type: boolean
+  default: true
+- name: rhel6_x64
+  type: boolean
+  default: true
+- name: macOS_x64
+  type: boolean
+  default: true
 
 resources:
   containers:
@@ -46,7 +60,7 @@ stages:
   jobs:
 
   # Windows x64
-  - ${{ if or(eq(parameters.target, 'Windows (x64)'), eq(parameters.target, 'All')) }}:
+  - ${{ if parameters.win_x64 }}:
     - template: build-job.yml
       parameters:
         jobName: build_windows_x64_agent
@@ -58,12 +72,14 @@ stages:
         branch: ${{ parameters.branch }}
         codeCoverage: true
         componentDetection: ${{ parameters.componentDetection }}
+        unitTests: ${{ parameters.test }}
+        functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
         verifySigning: ${{ parameters.sign }}
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Windows (x86)
-  - ${{ if or(eq(parameters.target, 'Windows (x86)'), eq(parameters.target, 'All')) }}:
+  - ${{ if parameters.win_x86 }}:
     - template: build-job.yml
       parameters:
         jobName: build_windows_x86_agent
@@ -75,11 +91,13 @@ stages:
         arch: x86
         branch: ${{ parameters.branch }}
         componentDetection: false
+        unitTests: ${{ parameters.test }}
+        functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (x64)
-  - ${{ if or(eq(parameters.target, 'Linux (x64)'), eq(parameters.target, 'All')) }}:
+  - ${{ if parameters.linux_x64 }}:
     - template: build-job.yml
       parameters:
         jobName: build_linux_x64_agent
@@ -90,11 +108,13 @@ stages:
         arch: x64
         branch: ${{ parameters.branch }}
         componentDetection: ${{ parameters.componentDetection }}
+        unitTests: ${{ parameters.test }}
+        functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM)
-  - ${{ if or(eq(parameters.target, 'Linux (ARM)'), eq(parameters.target, 'All')) }}:
+  - ${{ if parameters.linux_arm }}:
     - template: build-job.yml
       parameters:
         jobName: build_linux_arm_agent
@@ -108,12 +128,13 @@ stages:
         arch: arm
         branch: ${{ parameters.branch }}
         componentDetection: false
+        unitTests: ${{ parameters.test }}
+        functionalTests: false
         sign: false
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # Linux (ARM64)
-  #- ${{ if or(eq(parameters.target, 'Linux (ARM64)'), eq(parameters.target, 'All')) }}:
-  - ${{ if eq(parameters.target, 'Linux (ARM64)') }}:
+  - ${{ if parameters.linux_arm64 }}:
     - template: build-job.yml
       parameters:
         jobName: build_linux_arm64_agent
@@ -126,11 +147,13 @@ stages:
         arch: arm64
         branch: ${{ parameters.branch }}
         componentDetection: false
+        unitTests: ${{ parameters.test }}
+        functionalTests: ${{ parameters.test }}
         sign: false
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # RHEL6 Agent (x64)
-  - ${{ if or(eq(parameters.target, 'RHEL 6 (x64)'), eq(parameters.target, 'All')) }}:
+  - ${{ if parameters.rhel6_x64 }}:
     - template: build-job.yml
       parameters:
         jobName: build_rhel6_x64_agent
@@ -142,11 +165,13 @@ stages:
         arch: x64
         branch: ${{ parameters.branch }}
         componentDetection: false
+        unitTests: ${{ parameters.test }}
+        functionalTests: ${{ parameters.test }}
         sign: false
         publishArtifact: ${{ parameters.publishArtifacts }}
 
   # macOS x64
-  - ${{ if or(eq(parameters.target, 'macOS (x64)'), eq(parameters.target, 'All')) }}:
+  - ${{ if parameters.macOS_x64 }}:
     - template: build-job.yml
       parameters:
         jobName: build_osx_agent
@@ -157,6 +182,8 @@ stages:
         arch: x64
         branch: ${{ parameters.branch }}
         componentDetection: ${{ parameters.componentDetection }}
+        unitTests: ${{ parameters.test }}
+        functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
         publishArtifact: ${{ parameters.publishArtifacts }}
 

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -1,17 +1,32 @@
 parameters:
-- name: target
-  displayName: Target
-  type: string
-  default: All
-  values:
-  - All
-  - Windows (x64)
-  - Windows (x86)
-  - Linux (x64)
-  - Linux (ARM)
-  - Linux (ARM64)
-  - RHEL 6 (x64)
-  - macOS (x64)
+- name: win_x64
+  type: boolean
+  displayName: Windows (x64)
+  default: true
+- name: win_x86
+  type: boolean
+  displayName: Windows (x86)
+  default: true
+- name: linux_x64
+  type: boolean
+  displayName: Linux (x64)
+  default: true
+- name: linux_arm
+  type: boolean
+  displayName: Linux (ARM)
+  default: true
+- name: linux_arm64
+  type: boolean
+  displayName: Linux (ARM64)
+  default: false
+- name: rhel6_x64
+  type: boolean
+  displayName: RHEL 6 (x64)
+  default: true
+- name: macOS_x64
+  type: boolean
+  displayName: macOS (x64)
+  default: true
 
 pr:
   branches:
@@ -26,4 +41,10 @@ extends:
   parameters:
     componentDetection: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
     publishArtifacts: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
-    target: ${{ parameters.target }}
+    win_x64: ${{ parameters.win_x64 }}
+    win_x86: ${{ parameters.win_x86 }}
+    linux_x64: ${{ parameters.linux_x64 }}
+    linux_arm: ${{ parameters.linux_arm }}
+    linux_arm64: ${{ parameters.linux_arm64 }}
+    rhel6_x64: ${{ parameters.rhel6_x64 }}
+    macOS_x64: ${{ parameters.macOS_x64 }}

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -6,6 +6,10 @@ parameters:
   type: string
   displayName: Derived From Version
   default: latest
+- name: skipTests
+  type: boolean
+  default: false
+  displayName: Skip Tests
 
 variables:
   releaseBranch: releases/${{ parameters.version }}
@@ -15,6 +19,7 @@ extends:
   parameters:
     branch:  ${{ variables.releaseBranch }}
     componentDetection: false
+    test: ${{ not(parameters.skipTests) }}
     sign: true
     publishArtifacts: true
 


### PR DESCRIPTION
For the CI build, allow the user to pick each target to build and test. This is primarily to make it easier to exclude the Linux ARM64 from CI while we continue working on finding a permanent home for the build machines where they are more reliably available. Also add an option to the release build to skip tests, which was a repair item from the other week when slow ARM tests were delaying a hotfix.