### PR TITLE
Add libicu66 to list of supported versions

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -82,8 +82,8 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-            apt install -y libicu52 || apt install -y libicu55 || apt install -y libicu57 || apt install -y libicu60 || apt install -y libicu63
+            # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63 -> libicu66
+            apt install -y libicu52 || apt install -y libicu55 || apt install -y libicu57 || apt install -y libicu60 || apt install -y libicu63 || apt install -y libicu66
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -123,8 +123,8 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-                apt-get install -y libicu52 || apt-get install -y libicu55 || apt-get install -y libicu57 || apt-get install -y libicu60 || apt-get install -y libicu63
+                # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63 -> libicu66
+                apt-get install -y libicu52 || apt-get install -y libicu55 || apt-get install -y libicu57 || apt-get install -y libicu60 || apt-get install -y libicu63 || apt-get install -y libicu66
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
In addition to all previous versions of the libicu package, also try to install libicu66, which is the only version available on Ubuntu 20.04 LTS.

Fixes #2954 