### PR TITLE
Default System.PreferGitFromPath to false

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -48,7 +48,7 @@ namespace Agent.Sdk.Knob
             "Determines which Git we will use on Windows. By default, we prefer the built-in portable git in the agent's externals folder, setting this to true makes the agent find git.exe from %PATH% if possible.",
             new RuntimeKnobSource("system.prefergitfrompath"),
             new EnvironmentKnobSource("system.prefergitfrompath"),
-            new BuiltInDefaultKnobSource("true"));
+            new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob DisableGitPrompt = new Knob(
             nameof(DisableGitPrompt),


### PR DESCRIPTION
Prior to the port to AgentKnobs, we used git
from the path always on Linux and Mac, but on
Windows we preferred the MinGit shipped with the
agent, unless the System.PreferGitFromPath variable
was present and true. The fact that this config
defaulted to false wasn't obvious because it
relied on Boolean.TryParse setting the output
variable to false on a failure parsing a non-existent
environment variable. The default has changed by
mistake in the port to knobs, causing checkouts to
fail on Windows systems with no git in the path.