### PR TITLE
Disable masking with the new regexes from CredScan

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -160,9 +160,9 @@ namespace Agent.Sdk.Knob
         
         public static readonly Knob MaskUsingCredScanRegexes = new Knob(
             nameof(MaskUsingCredScanRegexes),
-            "Use the CredScan regexes for masking secrets. CredScan is an internal tool developed at Microsoft to keep passwords and authentication keys from being checked in. This defaults to enabled, but can be turned off if it masks too much.",
+            "Use the CredScan regexes for masking secrets. CredScan is an internal tool developed at Microsoft to keep passwords and authentication keys from being checked in. This defaults to disabled, as there are performance problems with some task outputs.",
             new EnvironmentKnobSource("AZP_USE_CREDSCAN_REGEXES"),
-            new BuiltInDefaultKnobSource("true"));
+            new BuiltInDefaultKnobSource("false"));
 
         // Misc
         public static readonly Knob DisableAgentDowngrade = new Knob(

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -98,13 +99,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         public void OtherSecretsAreMasked(string input, string expected)
         {
             // Arrange.
-            using (var _hc = Setup())
+            try
             {
-                // Act.
-                var result = _hc.SecretMasker.MaskSecrets(input);
+                Environment.SetEnvironmentVariable("AZP_USE_CREDSCAN_REGEXES", "true");
 
-                // Assert.
-                Assert.Equal(expected, result);
+                using (var _hc = Setup())
+                {
+                    // Act.
+                    var result = _hc.SecretMasker.MaskSecrets(input);
+
+                    // Assert.
+                    Assert.Equal(expected, result);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AZP_USE_CREDSCAN_REGEXES", null);
             }
         }
 


### PR DESCRIPTION
They add significant overhead to the timeline output, resulting in job timeouts.