### PR TITLE
Various release PR fixes

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -161,7 +161,7 @@ extends:
             npm install
             ls
             node createAdoPr.js ${{ parameters.version }}
-          displayName: Create PRs in AzureDevOps and AzureDevOps.ConfigChange
+          displayName: Create PR in AzureDevOps
           env:
             USER: $(User)
             PAT: $(AdoPAT)

--- a/release/createAdoPr.js
+++ b/release/createAdoPr.js
@@ -64,8 +64,9 @@ async function commitADOL2Changes(directory, release)
     
     if (!fs.existsSync(directory))
     {
-        sparseClone(directory, gitUrl);    
-        util.execInForeground(`${GIT} sparse-checkout set ${targetDirectory}`, directory, opt.dryrun);
+        // sparseClone(directory, gitUrl);
+        // util.execInForeground(`${GIT} sparse-checkout set ${targetDirectory}`, directory, opt.dryrun);
+        util.execInForeground(`${GIT} clone --depth 1 ${gitUrl} ${directory}`, null, opt.dryrun);
     }
 
     if (opt.options.dryrun)


### PR DESCRIPTION
* Fix displayName of task.

* Stop (for now) doing a sparse checkout. There is a regression in Git
  2.27 that breaks sparse checkouts with the --no-checkout clone option.