### PR TITLE
Support AutoLogon + RunOnce

### DIFF
--- a/src/Agent.Listener/CommandLine/ConfigureAgent.cs
+++ b/src/Agent.Listener/CommandLine/ConfigureAgent.cs
@@ -102,6 +102,9 @@ namespace Agent.Listener.CommandLine
         [Option(Constants.Agent.CommandLine.Flags.RunAsService)]
         public bool RunAsService { get; set; }
 
+        [Option(Constants.Agent.CommandLine.Flags.Once)]
+        public bool RunOnce { get; set; }
+
         [Option(Constants.Agent.CommandLine.Args.SslCACert)]
         public string SslCACert { get; set; }
 

--- a/src/Agent.Listener/CommandSettings.cs
+++ b/src/Agent.Listener/CommandSettings.cs
@@ -479,7 +479,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
         public bool GetRunOnce()
         {
-            return TestFlag(Run?.RunOnce, Constants.Agent.CommandLine.Flags.Once);
+            return TestFlag(Configure?.RunOnce, Constants.Agent.CommandLine.Flags.Once) ||
+                   TestFlag(Run?.RunOnce, Constants.Agent.CommandLine.Flags.Once);
         }
 
         public bool GetDeploymentPool()

--- a/src/Agent.Listener/Configuration.Windows/AutoLogonRegistryManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/AutoLogonRegistryManager.cs
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
             //User specific
             string subKeyName = $"{securityId}\\{RegistryConstants.UserSettings.SubKeys.StartupProcess}";
-            _registryManager.SetValue(RegistryHive.Users, subKeyName, RegistryConstants.UserSettings.ValueNames.StartupProcess, GetStartupCommand(command.GetRunOnce()));
+            _registryManager.SetValue(RegistryHive.Users, subKeyName, RegistryConstants.UserSettings.ValueNames.StartupProcess, GetStartupCommand(runOnce: command.GetRunOnce()));
         }
 
         private void UpdateScreenSaverSettings(CommandSettings command, string securityId)

--- a/src/Agent.Listener/Configuration.Windows/AutoLogonRegistryManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/AutoLogonRegistryManager.cs
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
             //User specific
             string subKeyName = $"{securityId}\\{RegistryConstants.UserSettings.SubKeys.StartupProcess}";
-            _registryManager.SetValue(RegistryHive.Users, subKeyName, RegistryConstants.UserSettings.ValueNames.StartupProcess, GetStartupCommand());
+            _registryManager.SetValue(RegistryHive.Users, subKeyName, RegistryConstants.UserSettings.ValueNames.StartupProcess, GetStartupCommand(command.GetRunOnce()));
         }
 
         private void UpdateScreenSaverSettings(CommandSettings command, string securityId)
@@ -320,7 +320,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             _registryManager.SetValue(RegistryHive.Users, screenSaverSubKeyName, screenSaverValueName, "0");
         }
 
-        private string GetStartupCommand()
+        private string GetStartupCommand(bool runOnce)
         {
             //startup process
             string cmdExePath = Environment.GetEnvironmentVariable("comspec");
@@ -333,8 +333,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             //file to run in cmd.exe
             var filePath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Root), "run.cmd");
 
+            string once = runOnce ? "--once" : null;
+
             //extra " are to handle the spaces in the file path (if any)
-            var startupCommand = $@"{cmdExePath} /D /S /C start ""Agent with AutoLogon"" ""{filePath}"" --startuptype autostartup";
+            var startupCommand = $@"{cmdExePath} /D /S /C start ""Agent with AutoLogon"" ""{filePath}"" --startuptype autostartup {once}";
             Trace.Info($"Agent auto logon startup command: '{startupCommand}'");
 
             return startupCommand;
@@ -363,10 +365,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         private void DeleteStartupCommand(RegistryHive targetHive, string securityId)
         {
             var startupProcessSubKeyName = $"{securityId}\\{RegistryConstants.UserSettings.SubKeys.StartupProcess}";
-            var expectedStartupCmd = GetStartupCommand();
+            var expectedStartupCmd = GetStartupCommand(runOnce: false);
             var actualStartupCmd = _registryManager.GetValue(targetHive, startupProcessSubKeyName, RegistryConstants.UserSettings.ValueNames.StartupProcess);
 
-            if(string.Equals(actualStartupCmd, expectedStartupCmd, StringComparison.CurrentCultureIgnoreCase))
+            // Use StartWith() instead of Equals() because we don't know if the startupCmd should include the runOnce parameter
+            if(actualStartupCmd != null && 
+               actualStartupCmd.StartsWith(expectedStartupCmd, StringComparison.CurrentCultureIgnoreCase))
             {
                 _registryManager.DeleteValue(RegistryHive.Users, startupProcessSubKeyName, RegistryConstants.UserSettings.ValueNames.StartupProcess);
             }


### PR DESCRIPTION
Add Configure support for --once to work alongside --runAsAutoLogon so the auto logon registry setting would be 'run.cmd --once'.  This enables a BYOS scenario so we can support both running the agent as a local user and a single-use VM.

Added an L0 test for this.

