### PR TITLE
Revert "Dont trim line break characters from inputs (#3025)"

### DIFF
--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     string key = input?.Name?.Trim() ?? string.Empty;
                     if (!string.IsNullOrEmpty(key))
                     {
-                        inputs[key] = input.DefaultValue?.Trim(' ') ?? string.Empty;
+                        inputs[key] = input.DefaultValue?.Trim() ?? string.Empty;
                     }
                 }
 
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     string key = input.Key?.Trim() ?? string.Empty;
                     if (!string.IsNullOrEmpty(key))
                     {
-                        inputs[key] = input.Value?.Trim(' ') ?? string.Empty;
+                        inputs[key] = input.Value?.Trim() ?? string.Empty;
                     }
                 }
 

--- a/src/Test/L1/Worker/WorkerL1Tests.cs
+++ b/src/Test/L1/Worker/WorkerL1Tests.cs
@@ -124,41 +124,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
         [Fact]
         [Trait("Level", "L1")]
         [Trait("Category", "Worker")]
-        public async Task Input_HandlesTrailingSpace()
-        {
-            try
-            {
-                // Arrange
-                SetupL1();
-                var message = LoadTemplateMessage();
-                // Remove all tasks
-                message.Steps.Clear();
-                // Add variable setting tasks
-                message.Steps.Add(CreateScriptTask("echo \\r\\n"));
-
-                // Act
-                var results = await RunWorker(message);
-
-                // Assert
-                AssertJobCompleted();
-                Assert.Equal(TaskResult.Succeeded, results.Result);
-
-                var steps = GetSteps();
-                Assert.Equal(3, steps.Count()); // Init, CmdLine, CmdLine, Finalize
-                var outputStep = steps[1];
-                var log = GetTimelineLogLines(outputStep);
-
-                Assert.True(log.Where(x => x.Contains("\\r\\n")).Count() > 0);
-            }
-            finally
-            {
-                TearDown();
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L1")]
-        [Trait("Category", "Worker")]
         public async Task Conditions_Failed()
         {
             try


### PR DESCRIPTION
Restoring the original trimming behavior. I think we should try again with a warning and a variable to make the behavior change opt-in. I think the underlying idea is good, but we shouldn't break existing pipelines.

This reverts commit 5e79b331809d8074ba6d7be4d3b9cad18a75c115.