### PR TITLE
Revert "made RunPorcelainCommandAsync and RunPorcelainCommandAsync wi…

### DIFF
--- a/src/Agent.Plugins/TFCliManager.cs
+++ b/src/Agent.Plugins/TFCliManager.cs
@@ -303,7 +303,7 @@ namespace Agent.Plugins.Repository
             args.Add("/format:xml");
 
             // Run the command.
-            string xml = await RunPorcelainCommandAsync(3, args.ToArray()) ?? string.Empty;
+            string xml = await RunPorcelainCommandAsync(args.ToArray()) ?? string.Empty;
 
             // Deserialize the XML.
             var serializer = new XmlSerializer(typeof(TFWorkspaces));

--- a/src/Agent.Plugins/TeeCliManager.cs
+++ b/src/Agent.Plugins/TeeCliManager.cs
@@ -278,7 +278,7 @@ namespace Agent.Plugins.Repository
             args.Add("-format:xml");
 
             // Run the command.
-            TfsVCPorcelainCommandResult result = await TryRunPorcelainCommandAsync(FormatFlags.None, 3, args.ToArray());
+            TfsVCPorcelainCommandResult result = await TryRunPorcelainCommandAsync(FormatFlags.None, args.ToArray());
             ArgUtil.NotNull(result, nameof(result));
             if (result.Exception != null)
             {

--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -152,23 +152,13 @@ namespace Agent.Plugins.Repository
 
         protected Task<string> RunPorcelainCommandAsync(params string[] args)
         {
-            return RunPorcelainCommandAsync(FormatFlags.None, 0, args);
+            return RunPorcelainCommandAsync(FormatFlags.None, args);
         }
 
-        protected Task<string> RunPorcelainCommandAsync(int retriesOnFailure, params string[] args)
-        {
-            return RunPorcelainCommandAsync(FormatFlags.None, retriesOnFailure, args);
-        }
-
-        protected Task<string> RunPorcelainCommandAsync(FormatFlags formatFlags, params string[] args)
-        {
-            return RunPorcelainCommandAsync(formatFlags, 0, args);
-        }
-
-        protected async Task<string> RunPorcelainCommandAsync(FormatFlags formatFlags, int retriesOnFailure, params string[] args)
+        protected async Task<string> RunPorcelainCommandAsync(FormatFlags formatFlags, params string[] args)
         {
             // Run the command.
-            TfsVCPorcelainCommandResult result = await TryRunPorcelainCommandAsync(formatFlags, retriesOnFailure, args);
+            TfsVCPorcelainCommandResult result = await TryRunPorcelainCommandAsync(formatFlags, args);
             ArgUtil.NotNull(result, nameof(result));
             if (result.Exception != null)
             {
@@ -183,12 +173,6 @@ namespace Agent.Plugins.Repository
         }
 
         protected async Task<TfsVCPorcelainCommandResult> TryRunPorcelainCommandAsync(FormatFlags formatFlags, params string[] args)
-        {
-            var result = await TryRunPorcelainCommandAsync(formatFlags, 0, args);
-            return result;
-        }
-
-        protected async Task<TfsVCPorcelainCommandResult> TryRunPorcelainCommandAsync(FormatFlags formatFlags, int retriesOnFailure, params string[] args)
         {
             // Validation.
             ArgUtil.NotNull(args, nameof(args));
@@ -220,32 +204,6 @@ namespace Agent.Plugins.Repository
                 // TODO: Test whether the output encoding needs to be specified on a non-Latin OS.
                 try
                 {
-                    for (int attempt = 0; attempt < retriesOnFailure; attempt++)
-                    {
-                        int exitCode = await processInvoker.ExecuteAsync(
-                            workingDirectory: SourcesDirectory,
-                            fileName: "tf",
-                            arguments: arguments,
-                            environment: AdditionalEnvironmentVariables,
-                            requireExitCodeZero: false,
-                            outputEncoding: OutputEncoding,
-                            cancellationToken: CancellationToken);
-
-                        if (exitCode == 0)
-                        {
-                            return result;
-                        }
-
-                        int sleep = Math.Min(200 * (int)Math.Pow(5, attempt), 30000);
-                        ExecutionContext.Output($"Sleeping for {sleep} ms");
-                        Thread.Sleep(sleep);
-
-                        // Use attempt+2 since we're using 0 based indexing and we're displaying this for the next attempt.
-                        ExecutionContext.Output($@"Retrying. Attempt ${attempt + 2}/${retriesOnFailure}");
-
-                    }
-
-                    // Perform one last try and fail on non-zero exit code
                     await processInvoker.ExecuteAsync(
                         workingDirectory: SourcesDirectory,
                         fileName: "tf",


### PR DESCRIPTION
Exercising this retry logic produces an error about `_proc` not being null. The ProcessInvoker is apparently not designed to be reused in this way. This reverts the change for now. A fix can be done in a separate PR.

…t retry logic and used them in WorkspacesAsync command (#3019)"

This reverts commit fb4a788825cacf3e7c8bee12b8bf77c853dac92b.