### PR TITLE
Correct Move behavior for Multi-Repo Checkout

### DIFF
--- a/src/Agent.Worker/Build/BuildDirectoryManager.cs
+++ b/src/Agent.Worker/Build/BuildDirectoryManager.cs
@@ -111,16 +111,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 description: "binaries directory",
                 path: Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newConfig.BuildDirectory, Constants.Build.Path.BinariesDirectory),
                 deleteExisting: cleanOption == BuildCleanOption.Binary);
+
+            var defaultSourceDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newConfig.SourcesDirectory);
             CreateDirectory(
                 executionContext,
                 description: "source directory",
-                path: Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newConfig.SourcesDirectory),
+                path: defaultSourceDirectory,
                 deleteExisting: cleanOption == BuildCleanOption.Source);
 
             // Set the default clone path for each repository (the Checkout task may override this later)
             foreach (var repository in repositories)
             {
                 var repoPath = GetDefaultRepositoryPath(executionContext, repository, newConfig.SourcesDirectory);
+
+                if (!string.Equals(repoPath, defaultSourceDirectory, StringComparison.Ordinal))
+                {
+                    CreateDirectory(
+                        executionContext,
+                        description: "repository source directory",
+                        path: repoPath,
+                        deleteExisting: cleanOption == BuildCleanOption.Source);
+                }
+
                 Trace.Info($"Set repository path for repository {repository.Alias} to '{repoPath}'");
                 repository.Properties.Set<string>(RepositoryPropertyNames.Path, repoPath);
             }


### PR DESCRIPTION
There is an optimization to reuse existing repository clones.

This doesn't work for multi-repo.  An easy example is:
```
resources:
  repositories:
  - repository: test
    type: git
    name: jessica/test
  - repository: test2
    type: git
    name: jessica/test2

steps:
- checkout: test
  path: test
- checkout: test2
  path: test2
  
```

The move fails because path1 hasn't been created yet, which is assumed [here](https://github.com/microsoft/azure-pipelines-agent/blob/6f30db3f80a0cecab1b3f6439971fee034c51bf5/src/Agent.Sdk/Util/IOUtil.cs#L208). 

The correct fix is to create the directory up front like we do for the other build directories.