### PR TITLE
Allow Checkout to continue if "git lfs fetch" fails

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -255,7 +255,7 @@ namespace Agent.Plugins.Repository
                     if (++retryCount < 3)
                     {
                         var backOff = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
-                        context.Warning($"Git lfs fetch failed with exit code {fetchExitCode}, back off {backOff.TotalSeconds} seconds before retry.");
+                        context.Output($"Git lfs fetch failed with exit code {fetchExitCode}, back off {backOff.TotalSeconds} seconds before retry.");
                         await Task.Delay(backOff);
                     }
                 }

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -879,7 +879,8 @@ namespace Agent.Plugins.Repository
 
                     // git lfs fetch failed, get lfs log, the log is critical for debug.
                     int exitCode_lfsLogs = await gitCommandManager.GitLFSLogs(executionContext, targetPath);
-                    throw new InvalidOperationException($"Git lfs fetch failed with exit code: {exitCode_lfsFetch}. Git lfs logs returned with exit code: {exitCode_lfsLogs}.");
+                    executionContext.Output($"Git lfs fetch failed with exit code: {exitCode_lfsFetch}. Git lfs logs returned with exit code: {exitCode_lfsLogs}.");
+                    executionContext.Output($"Checkout will continue.  \"git checkout\" will fetch lfs files, however this could cause poor performance on old versions of git.");
                 }
             }
 


### PR DESCRIPTION
`git lfs fetch` is not required for an lfs checkout

According to the comments it was added because:
_"fetch lfs object upfront, this will avoid fetch lfs object during checkout which cause checkout taking forever.  since checkout will fetch lfs object 1 at a time, while git lfs fetch will fetch lfs object in parallel."_
In modern versions of git, checkout happens in parallel and a `git lfs fetch` does not help performance.

Additionally, `git lfs fetch` will fail if your remote is different than the lfs url as described here: https://github.com/git-lfs/git-lfs/issues/4198.  This is causing failures for a few customers.  This change will allow the checkout to be successful for them.

Changed the warnings to outputs, since the failure is expected in some cases and the checkout will perform the same task.