### PR TITLE
Handle Workspace ID errors and update feature flag name

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -478,7 +478,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     // This allows similar jobs in the same definition to reuse that workspace and other jobs to have their own.
                     JobSettings[WellKnownJobSettings.WorkspaceIdentifier] = GetWorkspaceIdentifier(message);
                 }
-                catch (ArgumentException ex)
+                catch (Exception ex)
                 {
                     Trace.Warning($"Unable to generate workspace ID: {ex.Message}");
                 }

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -470,11 +470,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             Variables = new Variables(HostContext, message.Variables, out warnings);
             Variables.StringTranslator = TranslatePathForStepTarget;
 
-            if (Variables.GetBoolean("agent.useWorkspaceIds") == true)
+            if (Variables.GetBoolean("agent.useWorkspaceId") == true)
             {
-                // We need an identifier that represents which repos make up the workspace.
-                // This allows similar jobs in the same definition to reuse that workspace and other jobs to have their own.
-                JobSettings[WellKnownJobSettings.WorkspaceIdentifier] = GetWorkspaceIdentifier(message);
+                try
+                {
+                    // We need an identifier that represents which repos make up the workspace.
+                    // This allows similar jobs in the same definition to reuse that workspace and other jobs to have their own.
+                    JobSettings[WellKnownJobSettings.WorkspaceIdentifier] = GetWorkspaceIdentifier(message);
+                }
+                catch (ArgumentException ex)
+                {
+                    Trace.Warning($"Unable to generate workspace ID: {ex.Message}");
+                }
             }
 
             // Prepend Path

--- a/src/Test/L1/Worker/ConfigL1Tests.cs
+++ b/src/Test/L1/Worker/ConfigL1Tests.cs
@@ -98,15 +98,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
                 SetupL1();
                 FakeConfigurationStore fakeConfigurationStore = GetMockedService<FakeConfigurationStore>();
                 var message1 = LoadTemplateMessage(additionalRepos: 2);
-                message1.Variables.Add("agent.useWorkspaceIds", new VariableValue(Boolean.TrueString, false, true));
+                message1.Variables.Add("agent.useWorkspaceId", new VariableValue(Boolean.TrueString, false, true));
 
                 // second message is the same definition but a different job with a different order of the repos being checked out in a different order
                 var message2 = LoadTemplateMessage(jobId: "642e8db6-0794-4b7b-8fd9-33ee9202a795", jobName: "__default2", jobDisplayName: "Job2", checkoutRepoAlias: "Repo2", additionalRepos: 1);
-                message2.Variables.Add("agent.useWorkspaceIds", new VariableValue(Boolean.TrueString, false, true));
+                message2.Variables.Add("agent.useWorkspaceId", new VariableValue(Boolean.TrueString, false, true));
 
                 // third message uses the same repos as the first
                 var message3 = LoadTemplateMessage(additionalRepos: 2);
-                message3.Variables.Add("agent.useWorkspaceIds", new VariableValue(Boolean.TrueString, false, true));
+                message3.Variables.Add("agent.useWorkspaceId", new VariableValue(Boolean.TrueString, false, true));
 
                 // Act
                 var results1 = await RunWorker(message1);

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             message.Variables.TryGetValue("system.definitionId", out VariableValue definitionIdVar);
 
             string filename;
-            if (message.Variables.TryGetValue("agent.useWorkspaceIds", out _))
+            if (message.Variables.TryGetValue("agent.useWorkspaceId", out _))
             {
                 var repoTrackingInfos = message.Resources.Repositories.Select(repo => new RepositoryTrackingInfo(repo, "/")).ToList();
                 var workspaceIdentifier = TrackingConfigHashAlgorithm.ComputeHash(collectionIdVar?.Value, definitionIdVar?.Value, repoTrackingInfos);


### PR DESCRIPTION
Any failure to compute a workspace ID due to missing inputs from the job message (as we have seen in artifact deletion jobs and maintenance jobs) will result in fallback to workspaceID-less behavior which is fine.

The name of the variable controlling the feature has been changed so it can be enabled on only the new agent, without exercising the broken behavior on previous releases.