### PR TITLE
Fix null ref exceptions on artifact deletion jobs

### DIFF
--- a/src/Agent.Listener/JobDispatcher.cs
+++ b/src/Agent.Listener/JobDispatcher.cs
@@ -471,8 +471,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     // send notification to machine provisioner.
                     var systemConnection = message.Resources.Endpoints.SingleOrDefault(x => string.Equals(x.Name, WellKnownServiceEndpointNames.SystemVssConnection, StringComparison.OrdinalIgnoreCase));
                     var accessToken = systemConnection?.Authorization?.Parameters["AccessToken"];
-                    VariableValue identifier = new VariableValue("0");
-                    VariableValue definitionId = new VariableValue("0");
+                    VariableValue identifier = null;
+                    VariableValue definitionId = null;
 
                     if (message.Plan.PlanType == "Build")
                     {
@@ -485,7 +485,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                         message.Variables.TryGetValue("release.definitionId", out definitionId);
                     }
 
-                    await notification.JobStarted(message.JobId, accessToken, systemConnection.Url, message.Plan.PlanId, identifier.Value, definitionId.Value, message.Plan.PlanType);
+                    await notification.JobStarted(message.JobId, accessToken, systemConnection.Url, message.Plan.PlanId, (identifier?.Value ?? "0"), (definitionId?.Value ?? "0"), message.Plan.PlanType);
 
                     HostContext.WritePerfCounter($"SentJobToWorker_{requestId.ToString()}");
 


### PR DESCRIPTION
We have seen the following Listener error in prod while debugging
artifact deletion job issues. On reproducing locally it
turned out this where these jobs fail when *not* using workspace IDs.
```
Object reference not set to an instance of an object.
   at Microsoft.VisualStudio.Services.Agent.Listener.JobDispatcher.RunAsync(AgentJobRequestMessage message, WorkerDispatcher previousJobDispatch, CancellationToken jobRequestCancellationToken, CancellationToken workerCancelTimeoutKillToken)
   at Microsoft.VisualStudio.Services.Agent.Listener.JobDispatcher.EnsureDispatchFinished(WorkerDispatcher jobDispatch, Boolean cancelRunningJob)
```
Locally I traced the null ref to the identifier variable.
From the previous code it looks like the intention was to default
to "0", but those defaults were being nulled out by the TryGetValue
calls, so I fixed that default behavior.