### PR TITLE
Throw an actionable error message for pipeline not found instead of object null reference

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
         private void CtrlCHandler(object sender, EventArgs e)
         {
-            _term.WriteLine("Exiting...");
+            _term.WriteLine(StringUtil.Loc("Exiting"));
             if (_inConfigStage)
             {
                 HostContext.Dispose();

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
@@ -284,15 +284,16 @@ namespace Agent.Plugins.PipelineArtifact
             BuildHttpClient buildHttpClient = connection.GetClient<BuildHttpClient>();
 
             var isDefinitionNum = Int32.TryParse(pipelineDefinition, out int definition);
-            if(!isDefinitionNum) 
+            if (!isDefinitionNum)
             {
-                try
-                {
-                    definition = (await buildHttpClient.GetDefinitionsAsync(new System.Guid(project), pipelineDefinition, cancellationToken: cancellationToken)).First().Id;
-                }
-                catch (Exception ex)
+                var definitionRef = (await buildHttpClient.GetDefinitionsAsync(new System.Guid(project), pipelineDefinition, cancellationToken: cancellationToken)).FirstOrDefault();
+                if (definitionRef == null)
                 {
                     throw new ArgumentException(StringUtil.Loc("PipelineDoesNotExist", pipelineDefinition));
+                }
+                else
+                {
+                    definition = definitionRef.Id;
                 }
             }
             var definitions = new List<int>() { definition };

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
@@ -286,7 +286,14 @@ namespace Agent.Plugins.PipelineArtifact
             var isDefinitionNum = Int32.TryParse(pipelineDefinition, out int definition);
             if(!isDefinitionNum) 
             {
-                definition = (await buildHttpClient.GetDefinitionsAsync(new System.Guid(project), pipelineDefinition, cancellationToken: cancellationToken)).FirstOrDefault().Id;
+                try
+                {
+                    definition = (await buildHttpClient.GetDefinitionsAsync(new System.Guid(project), pipelineDefinition, cancellationToken: cancellationToken)).FirstOrDefault().Id;
+                }
+                catch (Exception ex)
+                {
+                    throw new ArgumentException(StringUtil.Loc("PipelineDoesNotExist", pipelineDefinition));
+                }
             }
             var definitions = new List<int>() { definition };
 

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
@@ -288,7 +288,7 @@ namespace Agent.Plugins.PipelineArtifact
             {
                 try
                 {
-                    definition = (await buildHttpClient.GetDefinitionsAsync(new System.Guid(project), pipelineDefinition, cancellationToken: cancellationToken)).FirstOrDefault().Id;
+                    definition = (await buildHttpClient.GetDefinitionsAsync(new System.Guid(project), pipelineDefinition, cancellationToken: cancellationToken)).First().Id;
                 }
                 catch (Exception ex)
                 {

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -411,6 +411,7 @@
   "Password": "password",
   "PathDoesNotExist": "Path does not exist: {0}",
   "PersonalAccessToken": "personal access token",
+  "PipelineDoesNotExist": "The following pipeline does not exist: {0}. Please verify the name of the pipeline.",
   "PoolNotFound": "Agent pool not found: '{0}'",
   "PostJob": "Post-job: {0}",
   "PowerOptionsConfigError": "Error occurred while configuring power options. Please refer logs for more details.",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -273,6 +273,7 @@
   "EulasSectionHeader": "End User License Agreements",
   "EvaluateReleaseTrackingFile": "Evaluate ReleaseDirectory tracking file: {0}",
   "EvaluateTrackingFile": "Evaluate BuildDirectory tracking file: {0}",
+  "Exiting": "Exiting...",
   "ExpectedMappingCloak": "Expected mapping[{0}] cloak: '{1}'. Actual: '{2}'",
   "ExpectedMappingLocalPath": "Expected mapping[{0}] local path: '{1}'. Actual: '{2}'",
   "ExpectedMappingRecursive": "Expected mapping[{0}] recursive: '{1}'. Actual: '{2}'",


### PR DESCRIPTION
Throw an actionable error message for pipeline not found instead of object null reference