### PR TITLE
Update the list of 3rd party dlls to sign

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -146,7 +146,7 @@ jobs:
       condition: always()
 
   # Code coverage
-  - ${{ if parameters.codeCoverage }}:
+  - ${{ if and(parameters.codeCoverage, parameters.unitTests, parameters.functionalTests) }}:
     - script: dotnet tool install --global dotnet-reportgenerator-globaltool
       displayName: Install Report Generator
 

--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -142,10 +142,14 @@ steps:
       bin\NCrontab.Signed.dll
       bin\Newtonsoft.Json.dll
       bin\Newtonsoft.Json.Bson.dll
+      bin\RocksDbNative.dll
+      bin\RocksDbSharp.dll
       bin\RuntimeContracts.dll
       bin\System.Interactive.Async.dll
       bin\System.IO.Abstractions.dll
+      bin\System.Linq.Async.dll
       bin\YamlDotNet.dll
+      bin\native\amd64\rocksdb.dll
       externals\git\**\*.dll
       externals\git\**\*.exe
       externals\node\bin\node.exe

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -10,6 +10,12 @@ parameters:
   type: boolean
   default: false
   displayName: Skip Tests
+# buildStageOnly is useful for testing changes of the build stage which cannot be tested
+# in the ci project, like signing, without actually doing a release
+- name: buildStageOnly
+  type: boolean
+  default: false
+  displayName: Build Stage Only
 
 variables:
   releaseBranch: releases/${{ parameters.version }}
@@ -23,145 +29,147 @@ extends:
     sign: true
     publishArtifacts: true
 
-    preBuildStages:
-    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-      - stage: Create_Release_Branch
-        displayName: Create Release Branch
+    ${{ if not(parameters.buildStageOnly) }}:
+      preBuildStages:
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+        - stage: Create_Release_Branch
+          displayName: Create Release Branch
+          jobs:
+          ################################################################################
+          - job: Create_Release_Branch
+          ################################################################################
+            displayName: Create Release Branch
+            pool:
+              vmImage: ubuntu-18.04
+
+            steps:
+            - checkout: self
+
+            - script: |
+                cd release
+                npm install
+                node createReleaseBranch.js ${{ parameters.version }} --derivedFrom=${{ parameters.derivedFrom }}
+              env:
+                EDITOR: cat
+                PAT: $(GithubToken)
+              displayName: Push release branch to GitHub
+
+    ${{ if not(parameters.buildStageOnly) }}:
+      postBuildStages:
+      - stage: Release
         jobs:
         ################################################################################
-        - job: Create_Release_Branch
+        - job: publish_agent_packages
         ################################################################################
-          displayName: Create Release Branch
+          displayName: Publish Agents (Windows/Linux/OSX)
+          pool:
+            name: ProductionRMAgents
+          steps:
+
+          # Clean
+          - checkout: self
+            clean: true
+
+          # Switch to release branch
+          - template: switch-branch.yml
+            parameters:
+              branch: ${{ variables.releaseBranch }}
+          
+          # Download all agent packages from all previous phases
+          - task: DownloadBuildArtifacts@0
+            displayName: Download Agent Packages
+            inputs:
+              artifactName: agent
+
+          # Upload agent packages to Azure blob storage and refresh Azure CDN
+          - powershell: |
+              Write-Host "Preloading Azure modules." # This is for better performance, to avoid module-autoloading.
+              Import-Module AzureRM, AzureRM.profile, AzureRM.Storage, Azure.Storage, AzureRM.Cdn -ErrorAction Ignore -PassThru
+              Enable-AzureRmAlias -Scope CurrentUser
+              $uploadFiles = New-Object System.Collections.ArrayList
+              $certificateThumbprint = (Get-ItemProperty -Path "$(ServicePrincipalReg)").ServicePrincipalCertThumbprint
+              $clientId = (Get-ItemProperty -Path "$(ServicePrincipalReg)").ServicePrincipalClientId
+              Write-Host "##vso[task.setsecret]$certificateThumbprint"
+              Write-Host "##vso[task.setsecret]$clientId"
+              Login-AzureRmAccount -ServicePrincipal -CertificateThumbprint $certificateThumbprint -ApplicationId $clientId -TenantId $(TenantId)
+              Select-AzureRmSubscription -SubscriptionId $(SubscriptionId)
+              $storage = Get-AzureRmStorageAccount -ResourceGroupName vstsagentpackage -AccountName vstsagentpackage
+              Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
+                $executable = (Get-ChildItem "$(System.ArtifactsDirectory)/agent/$_")[0]
+                $versionDir = $executable.Name.Trim('.zip').Trim('.tar.gz')
+                $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
+                Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"
+                Write-Host "Uploading $executable to BlobStorage vstsagentpackage/agent/$versionDir"
+                Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$_/$executable" -Blob "$versionDir/$executable" -Force
+                $uploadFiles.Add("/agent/$versionDir/$executable")
+              }
+              Write-Host "Purge Azure CDN Cache"
+              Unpublish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -PurgeContent $uploadFiles
+              Write-Host "Force Refresh Azure CDN Cache"
+              Publish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -LoadContent $uploadFiles
+            displayName: Upload to Azure Blob
+
+          # Create agent release on Github
+          - powershell: |
+              Write-Host "Creating github release."
+              $releaseNotes = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\releaseNote.md").Replace("<AGENT_VERSION>","$(ReleaseAgentVersion)")
+              $releaseData = @{
+                tag_name = "v$(ReleaseAgentVersion)";
+                target_commitish = "$(Build.SourceVersion)";
+                name = "v$(ReleaseAgentVersion)";
+                body = $releaseNotes;
+                draft = $false;
+                prerelease = $true;
+              }
+              $releaseParams = @{
+                Uri = "https://api.github.com/repos/Microsoft/azure-pipelines-agent/releases";
+                Method = 'POST';
+                Headers = @{
+                  Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("vsts:$(GithubToken)"));
+                }
+                ContentType = 'application/json';
+                Body = (ConvertTo-Json $releaseData -Compress)
+              }
+              [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+              $releaseCreated = Invoke-RestMethod @releaseParams
+              Write-Host $releaseCreated
+              $releaseId = $releaseCreated.id
+              $assets = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\assets.json").Replace("<AGENT_VERSION>","$(ReleaseAgentVersion)")
+              $assetsParams = @{
+                Uri = "https://uploads.github.com/repos/Microsoft/azure-pipelines-agent/releases/$releaseId/assets?name=assets.json"
+                Method = 'POST';
+                Headers = @{
+                  Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("vsts:$(GithubToken)"));
+                }
+                ContentType = 'application/octet-stream';
+                Body = [system.Text.Encoding]::UTF8.GetBytes($assets)
+              }
+              Invoke-RestMethod @assetsParams
+            displayName: Create agent release on Github
+
+      - stage: CreatePR
+        jobs:
+        ################################################################################
+        - job: create_ado_pr
+        ################################################################################
+          displayName: Create PR in AzureDevOps
           pool:
             vmImage: ubuntu-18.04
 
           steps:
           - checkout: self
 
-          - script: |
+          - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+            - script: git checkout ${{ variables.releaseBranch }}
+              displayName: Checkout release branch
+
+          - bash: |
+              set -x
               cd release
               npm install
-              node createReleaseBranch.js ${{ parameters.version }} --derivedFrom=${{ parameters.derivedFrom }}
+              ls
+              node createAdoPr.js ${{ parameters.version }}
+            displayName: Create PR in AzureDevOps
             env:
-              EDITOR: cat
-              PAT: $(GithubToken)
-            displayName: Push release branch to GitHub
-
-    postBuildStages:
-    - stage: Release
-      jobs:
-      ################################################################################
-      - job: publish_agent_packages
-      ################################################################################
-        displayName: Publish Agents (Windows/Linux/OSX)
-        pool:
-          name: ProductionRMAgents
-        steps:
-
-        # Clean
-        - checkout: self
-          clean: true
-
-        # Switch to release branch
-        - template: switch-branch.yml
-          parameters:
-            branch: ${{ variables.releaseBranch }}
-        
-        # Download all agent packages from all previous phases
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Agent Packages
-          inputs:
-            artifactName: agent
-
-        # Upload agent packages to Azure blob storage and refresh Azure CDN
-        - powershell: |
-            Write-Host "Preloading Azure modules." # This is for better performance, to avoid module-autoloading.
-            Import-Module AzureRM, AzureRM.profile, AzureRM.Storage, Azure.Storage, AzureRM.Cdn -ErrorAction Ignore -PassThru
-            Enable-AzureRmAlias -Scope CurrentUser
-            $uploadFiles = New-Object System.Collections.ArrayList
-            $certificateThumbprint = (Get-ItemProperty -Path "$(ServicePrincipalReg)").ServicePrincipalCertThumbprint
-            $clientId = (Get-ItemProperty -Path "$(ServicePrincipalReg)").ServicePrincipalClientId
-            Write-Host "##vso[task.setsecret]$certificateThumbprint"
-            Write-Host "##vso[task.setsecret]$clientId"
-            Login-AzureRmAccount -ServicePrincipal -CertificateThumbprint $certificateThumbprint -ApplicationId $clientId -TenantId $(TenantId)
-            Select-AzureRmSubscription -SubscriptionId $(SubscriptionId)
-            $storage = Get-AzureRmStorageAccount -ResourceGroupName vstsagentpackage -AccountName vstsagentpackage
-            Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
-              $executable = (Get-ChildItem "$(System.ArtifactsDirectory)/agent/$_")[0]
-              $versionDir = $executable.Name.Trim('.zip').Trim('.tar.gz')
-              $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
-              Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"
-              Write-Host "Uploading $executable to BlobStorage vstsagentpackage/agent/$versionDir"
-              Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$_/$executable" -Blob "$versionDir/$executable" -Force
-              $uploadFiles.Add("/agent/$versionDir/$executable")
-            }
-            Write-Host "Purge Azure CDN Cache"
-            Unpublish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -PurgeContent $uploadFiles
-            Write-Host "Force Refresh Azure CDN Cache"
-            Publish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -LoadContent $uploadFiles
-          displayName: Upload to Azure Blob
-
-        # Create agent release on Github
-        - powershell: |
-            Write-Host "Creating github release."
-            $releaseNotes = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\releaseNote.md").Replace("<AGENT_VERSION>","$(ReleaseAgentVersion)")
-            $releaseData = @{
-              tag_name = "v$(ReleaseAgentVersion)";
-              target_commitish = "$(Build.SourceVersion)";
-              name = "v$(ReleaseAgentVersion)";
-              body = $releaseNotes;
-              draft = $false;
-              prerelease = $true;
-            }
-            $releaseParams = @{
-              Uri = "https://api.github.com/repos/Microsoft/azure-pipelines-agent/releases";
-              Method = 'POST';
-              Headers = @{
-                Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("vsts:$(GithubToken)"));
-              }
-              ContentType = 'application/json';
-              Body = (ConvertTo-Json $releaseData -Compress)
-            }
-            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-            $releaseCreated = Invoke-RestMethod @releaseParams
-            Write-Host $releaseCreated
-            $releaseId = $releaseCreated.id
-            $assets = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\assets.json").Replace("<AGENT_VERSION>","$(ReleaseAgentVersion)")
-            $assetsParams = @{
-              Uri = "https://uploads.github.com/repos/Microsoft/azure-pipelines-agent/releases/$releaseId/assets?name=assets.json"
-              Method = 'POST';
-              Headers = @{
-                Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("vsts:$(GithubToken)"));
-              }
-              ContentType = 'application/octet-stream';
-              Body = [system.Text.Encoding]::UTF8.GetBytes($assets)
-            }
-            Invoke-RestMethod @assetsParams
-          displayName: Create agent release on Github
-
-    - stage: CreatePR
-      jobs:
-      ################################################################################
-      - job: create_ado_pr
-      ################################################################################
-        displayName: Create PR in AzureDevOps
-        pool:
-          vmImage: ubuntu-18.04
-
-        steps:
-        - checkout: self
-
-        - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
-          - script: git checkout ${{ variables.releaseBranch }}
-            displayName: Checkout release branch
-
-        - bash: |
-            set -x
-            cd release
-            npm install
-            ls
-            node createAdoPr.js ${{ parameters.version }}
-          displayName: Create PR in AzureDevOps
-          env:
-            USER: $(User)
-            PAT: $(AdoPAT)
+              USER: $(User)
+              PAT: $(AdoPAT)


### PR DESCRIPTION
This fixes the release build following the latest
update of vss-api-netcore in #3061.

Also updates the release pipeline to support a
"buildStageOnly" flag that makes it easier
to test such changes in the future without having
to temporarily comment out parts of the build.

Most of the diff is just an indentation change.