### PR TITLE
Fail if you can't connect to LocationService the first time

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/LocationServer.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/LocationServer.cs
@@ -28,21 +28,16 @@ namespace Microsoft.VisualStudio.Services.Agent
         {
             ArgUtil.NotNull(jobConnection, nameof(jobConnection));
             _connection = jobConnection;
-            int attemptCount = 5;
-            while (!_connection.HasAuthenticated && attemptCount-- > 0)
-            {
-                try
-                {
-                    await _connection.ConnectAsync();
-                    break;
-                }
-                catch (Exception ex) when (attemptCount > 0)
-                {
-                    Trace.Info($"Catch exception during connect. {attemptCount} attempt left.");
-                    Trace.Error(ex);
-                }
 
-                await Task.Delay(100);
+            try
+            {
+                await _connection.ConnectAsync();
+            }
+            catch (Exception ex)
+            {
+                Trace.Info($"Unable to connect to {_connection.Uri}.");
+                Trace.Error(ex);
+                throw;
             }
 
             _locationClient = _connection.GetClient<LocationHttpClient>();


### PR DESCRIPTION
The retry performs differently and might succeed even though you don't have a valid connection.

I have an offline thread I added you to regarding @mjroghelia , but this change creates a nicer user flow.

Previously you'd continue if you don't have a good connection.  
Now you only get 1 opportunity to connect, but fail gracefully.

Since this is part of config setup, you shouldn't need multiple tries here.