### PR TITLE
Set ProvisioningState when creating an agent.

### DIFF
--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -694,6 +694,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     PublicKey = new TaskAgentPublicKey(publicKey.Exponent, publicKey.Modulus),
                 },
                 MaxParallelism = 1,
+                ProvisioningState = TaskAgentProvisioningStateConstants.Provisioned,
                 Version = BuildConstants.AgentPackage.Version,
                 OSDescription = RuntimeInformation.OSDescription,
             };


### PR DESCRIPTION
Previously the TaskAgent class itself set this
in the constructor, but that was removed with the
most recent client lib update.