### PR TITLE
Switch to new HTTP handler by default

### DIFF
--- a/src/Agent.Listener/Program.cs
+++ b/src/Agent.Listener/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Agent.Sdk;
+using Agent.Sdk.Knob;
 using CommandLine;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
@@ -66,6 +67,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     terminal.WriteError(StringUtil.Loc("ErrorOccurred", e.Message));
                     trace.Error(e);
                     return Constants.Agent.ReturnCode.TerminatedError;
+                }
+
+                if (PlatformUtil.UseLegacyHttpHandler)
+                {
+                    trace.Warning($"You are using the legacy HTTP handler because you set ${AgentKnobs.LegacyHttpVariableName}.");
+                    trace.Warning($"This feature will go away with .NET 5.0, and we recommend you don't use it.");
+                    trace.Warning($"If you continue using it, you must ensure libcurl is installed on your system.");
                 }
 
                 if (PlatformUtil.RunningOnWindows)

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -114,6 +114,12 @@ namespace Agent.Sdk.Knob
             new BuiltInDefaultKnobSource("1200")); // 20*60
 
         // HTTP
+        public static readonly Knob UseLegacyHttpHandler = new DeprecatedKnob(
+            nameof(UseLegacyHttpHandler),
+            "Use the libcurl-based HTTP handler rather than .NET's native HTTP handler, as we did on .NET Core 2.1",
+            new EnvironmentKnobSource("AZP_AGENT_USE_LEGACY_HTTP"),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob HttpRetryCount = new Knob(
             nameof(HttpRetryCount),
             "Number of times to retry Http requests",

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -114,10 +114,11 @@ namespace Agent.Sdk.Knob
             new BuiltInDefaultKnobSource("1200")); // 20*60
 
         // HTTP
+        public const string LegacyHttpVariableName = "AZP_AGENT_USE_LEGACY_HTTP";
         public static readonly Knob UseLegacyHttpHandler = new DeprecatedKnob(
             nameof(UseLegacyHttpHandler),
             "Use the libcurl-based HTTP handler rather than .NET's native HTTP handler, as we did on .NET Core 2.1",
-            new EnvironmentKnobSource("AZP_AGENT_USE_LEGACY_HTTP"),
+            new EnvironmentKnobSource(LegacyHttpVariableName),
             new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob HttpRetryCount = new Knob(

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -135,11 +135,13 @@ namespace Agent.Sdk
             // On Linux, negotiate auth didn't work if the TFS URL was HTTPS
             // On Windows, proxy was not working
             // But on ARM/ARM64 Linux, the legacy curl dependency is problematic
-            // (see https://github.com/dotnet/runtime/issues/28891)
+            // (see https://github.com/dotnet/runtime/issues/28891), so we slowly
+            // started to use the new handler.
             //
             // The legacy handler is going away in .NET 5.0, so we'll go ahead
             // and remove its usage now. In case this breaks anyone, adding
             // a temporary knob so they can re-enable it.
+            // https://github.com/dotnet/runtime/issues/35365#issuecomment-667467706
             get => AgentKnobs.UseLegacyHttpHandler.GetValue(_knobContext).AsBoolean();
         }
     }

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -4,11 +4,15 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Agent.Sdk.Knob;
+using Microsoft.VisualStudio.Services.Agent.Util;
 
 namespace Agent.Sdk
 {
     public static class PlatformUtil
     {
+        private static UtilKnobValueContext _knobContext = UtilKnobValueContext.Instance();
+        
         // System.Runtime.InteropServices.OSPlatform is a struct, so it is
         // not suitable for switch statements.
         public enum OS
@@ -125,8 +129,6 @@ namespace Agent.Sdk
             get => PlatformUtil.HostArchitecture == Architecture.Arm64;
         }
 
-        // remove this after addressing
-        // https://github.com/microsoft/azure-pipelines-agent/issues/2875
         public static bool UseLegacyHttpHandler
         {
             // In .NET Core 2.1, we couldn't use the new SocketsHttpHandler for Windows or Linux
@@ -134,7 +136,11 @@ namespace Agent.Sdk
             // On Windows, proxy was not working
             // But on ARM/ARM64 Linux, the legacy curl dependency is problematic
             // (see https://github.com/dotnet/runtime/issues/28891)
-            get => !(PlatformUtil.RunningOnLinux && (PlatformUtil.IsArm || PlatformUtil.IsArm64));
+            //
+            // The legacy handler is going away in .NET 5.0, so we'll go ahead
+            // and remove its usage now. In case this breaks anyone, adding
+            // a temporary knob so they can re-enable it.
+            get => AgentKnobs.UseLegacyHttpHandler.GetValue(_knobContext).AsBoolean();
         }
     }
 }

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -61,16 +61,6 @@ then
                 exit 1
             fi
             
-            # ubuntu 18 uses libcurl4
-            # ubuntu 14, 16 and other linux use libcurl3
-            apt install -y libcurl4 || apt install -y libcurl3
-            if [ $? -ne 0 ]
-            then
-                echo "'apt' failed with exit code '$?'"
-                print_errormessage
-                exit 1
-            fi
-
 	        # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
             # other debian linux use libssl1.0.0
@@ -102,16 +92,6 @@ then
                     exit 1
                 fi
                 
-                # ubuntu 18 uses libcurl4
-                # ubuntu 14, 16 and other linux use libcurl3
-                apt-get install -y libcurl4 || apt-get install -y libcurl3
-                if [ $? -ne 0 ]
-                then
-                    echo "'apt-get' failed with exit code '$?'"
-                    print_errormessage
-                    exit 1
-                fi
-
                 # debian 10 uses libssl1.1
                 # debian 9 uses libssl1.0.2
                 # other debian linux use libssl1.0.0
@@ -190,7 +170,7 @@ then
                     fi
                 fi       
 
-                dnf install -y lttng-ust libcurl krb5-libs zlib libicu
+                dnf install -y lttng-ust krb5-libs zlib libicu
                 if [ $? -ne 0 ]
                 then
                     echo "'dnf' failed with exit code '$?'"
@@ -206,7 +186,7 @@ then
             command -v yum
             if [ $? -eq 0 ]
             then
-                yum install -y openssl-libs libcurl krb5-libs zlib libicu
+                yum install -y openssl-libs krb5-libs zlib libicu
                 if [ $? -ne 0 ]
                 then                    
                     echo "'yum' failed with exit code '$?'"
@@ -238,7 +218,7 @@ then
             command -v zypper
             if [ $? -eq 0 ]
             then
-                zypper -n install lttng-ust libopenssl1_0_0 libcurl4 krb5 zlib libicu52_1
+                zypper -n install lttng-ust libopenssl1_0_0 krb5 zlib libicu52_1
                 if [ $? -ne 0 ]
                 then
                     echo "'zypper' failed with exit code '$?'"


### PR DESCRIPTION
fixes #2875

This change has the potential to break people if the new handler still isn't a complete replacement. But, I have no reason to believe that's the case. And if it is, we need to know it now before we take a .NET 5 upgrade. I put in a knob (env var `AZP_AGENT_USE_LEGACY_HTTP`) for anyone whom it does break.

The change will need to be release-noted (which I can take care of), and ideally it would be tested with some down-level TFS instances before we ship it broadly.