### PR TITLE
set default DOCKER_CONFIG in agent path

### DIFF
--- a/src/Misc/layoutbin/vsts.agent.service.template
+++ b/src/Misc/layoutbin/vsts.agent.service.template
@@ -9,6 +9,7 @@ WorkingDirectory={{AgentRoot}}
 KillMode=process
 KillSignal=SIGTERM
 TimeoutStopSec=5min
+Environment=DOCKER_CONFIG={{AgentRoot}}/docker
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When using several agents on the same Host and user Docker pull fails to authenticate randomly because all agents use the the same DOCKER_CONFIG environment variable.

Fixes #3133 