### PR TITLE
Remove all warnings from build output

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -162,6 +162,7 @@ namespace Agent.Plugins.Repository
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1505: Avoid unmaintainable code")]
     public abstract class GitSourceProvider : ISourceProvider
     {
         // refs prefix

--- a/src/Agent.Plugins/PipelineArtifact/IArtifactProvider.cs
+++ b/src/Agent.Plugins/PipelineArtifact/IArtifactProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 
 namespace Agent.Plugins.PipelineArtifact
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1068: CancellationToken parameters must come last")]
     internal interface IArtifactProvider
     {
         Task DownloadSingleArtifactAsync(PipelineArtifactDownloadParameters downloadParameters, BuildArtifact buildArtifact, CancellationToken cancellationToken, AgentTaskPluginExecutionContext context);

--- a/src/Agent.Plugins/PipelineArtifact/Telemetry/FileShareActionRecord.cs
+++ b/src/Agent.Plugins/PipelineArtifact/Telemetry/FileShareActionRecord.cs
@@ -11,6 +11,7 @@ namespace Agent.Plugins.PipelineArtifact.Telemetry
     /// <summary>
     /// Generic telemetry record for use with FileShare Artifact events.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501: Avoid excessive inheritance")]
     public class FileShareActionRecord : PipelineArtifactActionRecord
     {
         public int TotalFile { get; private set; }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
@@ -22,6 +22,7 @@ namespace Agent.Plugins.PipelineCache
 {
     public class PipelineCacheServer
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1068: CancellationToken parameters must come last")]
         internal async Task UploadAsync(
             AgentTaskPluginExecutionContext context,
             Fingerprint fingerprint,

--- a/src/Agent.Sdk/CommandPlugin.cs
+++ b/src/Agent.Sdk/CommandPlugin.cs
@@ -18,6 +18,7 @@ using Agent.Sdk.Knob;
 
 namespace Agent.Sdk
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716: Identifiers should not match keywords")]
     public interface IAgentCommandPlugin
     {
         String Area { get; }

--- a/src/Agent.Sdk/ExecutionTargetInfo.cs
+++ b/src/Agent.Sdk/ExecutionTargetInfo.cs
@@ -3,6 +3,7 @@
 
 namespace Agent.Sdk
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1715: Identifiers should have correct prefix")]
     public interface ExecutionTargetInfo
     {
         PlatformUtil.OS ExecutionOS { get; }

--- a/src/Agent.Sdk/LogPlugin.cs
+++ b/src/Agent.Sdk/LogPlugin.cs
@@ -19,6 +19,7 @@ using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 
 namespace Agent.Sdk
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716: Identifiers should not match keywords")]
     public interface IAgentLogPlugin
     {
         // Short meaningful name for the plugin.

--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                 : StringComparison.OrdinalIgnoreCase;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720: Identifiers should not contain type")]
         public static void SaveObject(object obj, string path)
         {
             File.WriteAllText(path, StringUtil.ConvertToJson(obj), Encoding.UTF8);

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -15,6 +15,7 @@ namespace Agent.Sdk
         
         // System.Runtime.InteropServices.OSPlatform is a struct, so it is
         // not suitable for switch statements.
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1717: Only FlagsAttribute enums should have plural names")]
         public enum OS
         {
             Linux,
@@ -24,6 +25,7 @@ namespace Agent.Sdk
 
         public static OS HostOS
         {
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1065: Do not raise exceptions in unexpected")]
             get
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -74,6 +74,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720: Identifiers should not contain type")]
         public static string ConvertToJson(object obj, Formatting formatting = Formatting.Indented)
         {
             return JsonConvert.SerializeObject(obj, formatting, s_serializerSettings.Value);

--- a/src/Agent.Worker/AsyncCommandContext.cs
+++ b/src/Agent.Worker/AsyncCommandContext.cs
@@ -51,6 +51,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             Name = name;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721: Property names should not match get methods")]
         public IHostContext GetHostContext()
         {
             return _executionContext.GetHostContext();

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -191,6 +191,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1505: Avoid unmaintainable code")]
     public abstract class GitSourceProvider : SourceProvider, ISourceProvider
     {
         // refs prefix

--- a/src/Agent.Worker/Build/TrackingConfigHashAlgorithm.cs
+++ b/src/Agent.Worker/Build/TrackingConfigHashAlgorithm.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Cryptography", "CA5350: Do Not Use Weak Cryptographic Algorithms")]
     public class TrackingConfigHashAlgorithm
     {
         /// <summary>

--- a/src/Agent.Worker/CodeCoverage/CodeCoverageServer.cs
+++ b/src/Agent.Worker/CodeCoverage/CodeCoverageServer.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage
         Task PublishCoverageSummaryAsync(IAsyncCommandContext context, VssConnection connection, string project, int buildId, IEnumerable<CodeCoverageStatistics> coverageData, CancellationToken cancellationToken);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812: Avoid uninstantiated internal classes")]
     internal sealed class CodeCoverageServer : AgentService, ICodeCoverageServer
     {
         public async Task PublishCoverageSummaryAsync(IAsyncCommandContext context, VssConnection connection, string project, int buildId, IEnumerable<CodeCoverageStatistics> coverageData, CancellationToken cancellationToken)

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -183,6 +183,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             });
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721: Property names should not match get methods")]
         public IHostContext GetHostContext()
         {
             return HostContext;

--- a/src/Agent.Worker/ExpressionManager.cs
+++ b/src/Agent.Worker/ExpressionManager.cs
@@ -205,6 +205,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public bool Value { get; set; }
         public string Trace { get; set; }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2225: Operator overloads have named")]
         public static implicit operator ConditionResult(bool value)
         {
             return new ConditionResult(value);

--- a/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
@@ -15,6 +15,7 @@ using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 namespace Microsoft.VisualStudio.Services.Agent
 {
     [ServiceLocator(Default = typeof(JobServerQueue))]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711: Identifiers should not have incorrect suffix")]
     public interface IJobServerQueue : IAgentService, IThrottlingReporter
     {
         event EventHandler<ThrottlingEventArgs> JobServerQueueThrottling;
@@ -25,6 +26,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         void QueueTimelineRecordUpdate(Guid timelineId, TimelineRecord timelineRecord);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711: Identifiers should not have incorrect suffix")]
     public sealed class JobServerQueue : AgentService, IJobServerQueue
     {
         // Default delay for Dequeue process

--- a/src/Microsoft.VisualStudio.Services.Agent/Logging.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Logging.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         void Write(string message);
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716: Identifiers should not match keywords")]
         void End();
     }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/ProcessChannel.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ProcessChannel.cs
@@ -10,8 +10,10 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 
 namespace Microsoft.VisualStudio.Services.Agent
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711: Identifiers should not have incorrect suffix")]
     public delegate void StartProcessDelegate(string pipeHandleOut, string pipeHandleIn);
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1008: Enums should have zero value")]
     public enum MessageType
     {
         NotInitialized = -1,

--- a/src/rules.ruleset
+++ b/src/rules.ruleset
@@ -12,119 +12,119 @@
       <Rule Id="CA1000" Action="Error" />            <!-- Do not declare static members on generic types -->
       <Rule Id="CA1001" Action="Error" />            <!-- Types that own disposable fields should be disposable -->
       <Rule Id="CA1003" Action="Error" />            <!-- Use generic event handler instances -->
-      <Rule Id="CA1008" Action="Warning" />          <!-- Enums should have zero value -->
+      <Rule Id="CA1008" Action="Error" />            <!-- Enums should have zero value -->
       <Rule Id="CA1010" Action="Error" />            <!-- Collections should implement generic interface -->
-      <Rule Id="CA1012" Action="Warning" />          <!-- Abstract types should not have constructors -->
-      <Rule Id="CA1014" Action="Warning" />          <!-- Mark assemblies with CLSCompliant -->
+      <Rule Id="CA1012" Action="Hidden" />           <!-- Abstract types should not have constructors -->
+      <Rule Id="CA1014" Action="Hidden" />           <!-- Mark assemblies with CLSCompliant -->
       <Rule Id="CA1016" Action="Error" />            <!-- Mark assemblies with assembly version -->
       <Rule Id="CA1017" Action="Error" />            <!-- Mark assemblies with ComVisible -->
       <Rule Id="CA1018" Action="Error" />            <!-- Mark attributes with AttributeUsageAttribute -->
       <Rule Id="CA1019" Action="Error" />            <!-- Define accessors for attribute arguments -->
-      <Rule Id="CA1024" Action="Warning" />          <!-- Use properties where appropriate -->
+      <Rule Id="CA1024" Action="Hidden" />           <!-- Use properties where appropriate -->
       <Rule Id="CA1027" Action="Error" />            <!-- Mark enums with FlagsAttribute -->
       <Rule Id="CA1028" Action="Error" />            <!-- Enum Storage should be Int32 -->
-      <Rule Id="CA1030" Action="Warning" />          <!-- Use events where appropriate -->
+      <Rule Id="CA1030" Action="Hidden" />           <!-- Use events where appropriate -->
       <Rule Id="CA1031" Action="Hidden" />           <!-- Do not catch general exception types -->
-      <Rule Id="CA1032" Action="Warning" />          <!-- Implement standard exception constructors -->
-      <Rule Id="CA1033" Action="Warning" />          <!-- Interface methods should be callable by child types -->
-      <Rule Id="CA1034" Action="Warning" />          <!-- Nested types should not be visible -->
+      <Rule Id="CA1032" Action="Info" />             <!-- Implement standard exception constructors -->
+      <Rule Id="CA1033" Action="Hidden" />           <!-- Interface methods should be callable by child types -->
+      <Rule Id="CA1034" Action="Hidden" />           <!-- Nested types should not be visible -->
       <Rule Id="CA1036" Action="Error" />            <!-- Override methods on comparable types -->
       <Rule Id="CA1040" Action="Error" />            <!-- Avoid empty interfaces -->
       <Rule Id="CA1041" Action="Error" />            <!-- Provide ObsoleteAttribute message -->
       <Rule Id="CA1043" Action="Error" />            <!-- Use Integral Or String Argument For Indexers -->
-      <Rule Id="CA1044" Action="Warning" />          <!-- Properties should not be write only -->
+      <Rule Id="CA1044" Action="Info" />             <!-- Properties should not be write only -->
       <Rule Id="CA1050" Action="Error" />            <!-- Declare types in namespaces -->
-      <Rule Id="CA1051" Action="Warning" />          <!-- Do not declare visible instance fields -->
-      <Rule Id="CA1052" Action="Warning" />          <!-- Static holder types should be Static or NotInheritable -->
+      <Rule Id="CA1051" Action="Hidden" />           <!-- Do not declare visible instance fields -->
+      <Rule Id="CA1052" Action="Info" />             <!-- Static holder types should be Static or NotInheritable -->
       <Rule Id="CA1054" Action="Hidden" />           <!-- Uri parameters should not be strings -->
       <Rule Id="CA1055" Action="Hidden" />           <!-- Uri return values should not be strings -->
       <Rule Id="CA1056" Action="Hidden" />           <!-- Uri properties should not be strings -->
       <Rule Id="CA1058" Action="Error" />            <!-- Types should not extend certain base types -->
-      <Rule Id="CA1060" Action="Warning" />          <!-- Move pinvokes to native methods class -->
+      <Rule Id="CA1060" Action="Hidden" />           <!-- Move pinvokes to native methods class -->
       <Rule Id="CA1061" Action="Error" />            <!-- Do not hide base class methods -->
-      <Rule Id="CA1062" Action="Warning" />          <!-- Validate arguments of public methods --> <!-- PARTIALLY COMPLETE -->
+      <Rule Id="CA1062" Action="Info" />             <!-- Validate arguments of public methods --> <!-- PARTIALLY COMPLETE -->
       <Rule Id="CA1063" Action="Error" />            <!-- Implement IDisposable Correctly -->
       <Rule Id="CA1064" Action="Error" />            <!-- Exceptions should be public -->
-      <Rule Id="CA1065" Action="Warning" />          <!-- Do not raise exceptions in unexpected locations -->
+      <Rule Id="CA1065" Action="Error" />            <!-- Do not raise exceptions in unexpected locations -->
       <Rule Id="CA1066" Action="Error" />            <!-- Type {0} should implement IEquatable<T> because it overrides Equals -->
       <Rule Id="CA1067" Action="Error" />            <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
-      <Rule Id="CA1068" Action="Warning" />          <!-- CancellationToken parameters must come last -->
+      <Rule Id="CA1068" Action="Error" />            <!-- CancellationToken parameters must come last -->
       <Rule Id="CA1200" Action="Error" />            <!-- Avoid using cref tags with a prefix -->
       <Rule Id="CA1303" Action="Hidden" />           <!-- Do not pass literals as localized parameters -->
       <Rule Id="CA1304" Action="Hidden" />           <!-- Specify CultureInfo -->
       <Rule Id="CA1305" Action="Hidden" />           <!-- Specify IFormatProvider -->
-      <Rule Id="CA1307" Action="Warning" />          <!-- Specify StringComparison -->
-      <Rule Id="CA1308" Action="Warning" />          <!-- Normalize strings to uppercase -->
-      <Rule Id="CA1309" Action="Warning" />          <!-- Use ordinal stringcomparison -->
-      <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
-      <Rule Id="CA1501" Action="Warning" />          <!-- Avoid excessive inheritance -->
-      <Rule Id="CA1502" Action="Warning" />          <!-- Avoid excessive complexity -->
-      <Rule Id="CA1505" Action="Warning" />          <!-- Avoid unmaintainable code -->
-      <Rule Id="CA1506" Action="Warning" />          <!-- Avoid excessive class coupling -->
+      <Rule Id="CA1307" Action="Info" />             <!-- Specify StringComparison -->
+      <Rule Id="CA1308" Action="Info" />             <!-- Normalize strings to uppercase -->
+      <Rule Id="CA1309" Action="Info" />             <!-- Use ordinal stringcomparison -->
+      <Rule Id="CA1401" Action="Info" />             <!-- P/Invokes should not be visible -->
+      <Rule Id="CA1501" Action="Error" />            <!-- Avoid excessive inheritance -->
+      <Rule Id="CA1502" Action="Hidden" />           <!-- Avoid excessive complexity -->
+      <Rule Id="CA1505" Action="Error" />            <!-- Avoid unmaintainable code -->
+      <Rule Id="CA1506" Action="Hidden" />           <!-- Avoid excessive class coupling -->
       <Rule Id="CA1507" Action="Error" />            <!-- Use nameof to express symbol names -->
       <Rule Id="CA1508" Action="Hidden" />           <!-- Avoid dead conditional code --> <!-- TOO MANY FALSE POSITIVES -->
       <Rule Id="CA1509" Action="Error" />            <!-- Invalid entry in code metrics rule specification file -->
       <Rule Id="CA1707" Action="Hidden" />           <!-- Identifiers should not contain underscores --> <!-- Too much work to change now -->
-      <Rule Id="CA1708" Action="Warning" />          <!-- Identifiers should differ by more than case -->
+      <Rule Id="CA1708" Action="Info" />             <!-- Identifiers should differ by more than case -->
       <Rule Id="CA1710" Action="Error" />            <!-- Identifiers should have correct suffix -->
-      <Rule Id="CA1711" Action="Warning" />          <!-- Identifiers should not have incorrect suffix -->
+      <Rule Id="CA1711" Action="Error" />            <!-- Identifiers should not have incorrect suffix -->
       <Rule Id="CA1712" Action="Error" />            <!-- Do not prefix enum values with type name -->
       <Rule Id="CA1714" Action="Error" />            <!-- Flags enums should have plural names -->
-      <Rule Id="CA1715" Action="Warning" />          <!-- Identifiers should have correct prefix -->
-      <Rule Id="CA1716" Action="Warning" />          <!-- Identifiers should not match keywords -->
-      <Rule Id="CA1717" Action="Warning" />          <!-- Only FlagsAttribute enums should have plural names -->
-      <Rule Id="CA1720" Action="Warning" />          <!-- Identifier contains type name -->
-      <Rule Id="CA1721" Action="Warning" />          <!-- Property names should not match get methods -->
-      <Rule Id="CA1724" Action="Warning" />          <!-- Type names should not match namespaces -->
-      <Rule Id="CA1725" Action="Warning" />          <!-- Parameter names should match base declaration -->
-      <Rule Id="CA1801" Action="Warning" />          <!-- Review unused parameters -->
+      <Rule Id="CA1715" Action="Error" />            <!-- Identifiers should have correct prefix -->
+      <Rule Id="CA1716" Action="Error" />            <!-- Identifiers should not match keywords -->
+      <Rule Id="CA1717" Action="Error" />            <!-- Only FlagsAttribute enums should have plural names -->
+      <Rule Id="CA1720" Action="Error" />            <!-- Identifier contains type name -->
+      <Rule Id="CA1721" Action="Error" />            <!-- Property names should not match get methods -->
+      <Rule Id="CA1724" Action="Hidden" />           <!-- Type names should not match namespaces -->
+      <Rule Id="CA1725" Action="Hidden" />           <!-- Parameter names should match base declaration -->
+      <Rule Id="CA1801" Action="Info" />             <!-- Review unused parameters -->
       <Rule Id="CA1802" Action="Hidden" />           <!-- Use literals where appropriate --> <!-- this flags 'static readonly' as should be 'const' -->
-      <Rule Id="CA1806" Action="Warning" />          <!-- Do not ignore method results -->
-      <Rule Id="CA1810" Action="Warning" />          <!-- Initialize reference type static fields inline -->
-      <Rule Id="CA1812" Action="Warning" />          <!-- Avoid uninstantiated internal classes -->
+      <Rule Id="CA1806" Action="Info" />             <!-- Do not ignore method results -->
+      <Rule Id="CA1810" Action="Error" />            <!-- Initialize reference type static fields inline -->
+      <Rule Id="CA1812" Action="Error" />            <!-- Avoid uninstantiated internal classes -->
       <Rule Id="CA1813" Action="Error" />            <!-- Avoid unsealed attributes -->
-      <Rule Id="CA1814" Action="Warning" />          <!-- Prefer jagged arrays over multidimensional -->
-      <Rule Id="CA1815" Action="Warning" />          <!-- Override equals and operator equals on value types -->
-      <Rule Id="CA1816" Action="Warning" />          <!-- Dispose methods should call SuppressFinalize -->
-      <Rule Id="CA1819" Action="Warning" />          <!-- Properties should not return arrays -->
-      <Rule Id="CA1820" Action="Warning" />          <!-- Test for empty strings using string length -->
+      <Rule Id="CA1814" Action="Error" />            <!-- Prefer jagged arrays over multidimensional -->
+      <Rule Id="CA1815" Action="Info" />             <!-- Override equals and operator equals on value types -->
+      <Rule Id="CA1816" Action="Info" />             <!-- Dispose methods should call SuppressFinalize -->
+      <Rule Id="CA1819" Action="Hidden" />           <!-- Properties should not return arrays -->
+      <Rule Id="CA1820" Action="Info" />             <!-- Test for empty strings using string length -->
       <Rule Id="CA1821" Action="Error" />            <!-- Remove empty Finalizers -->
-      <Rule Id="CA1822" Action="Warning" />          <!-- Mark members as static -->
+      <Rule Id="CA1822" Action="Hidden" />           <!-- Mark members as static -->
       <Rule Id="CA1823" Action="Error" />            <!-- Avoid unused private fields -->
       <Rule Id="CA1824" Action="Error" />            <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
-      <Rule Id="CA1825" Action="Warning" />          <!-- Avoid zero-length array allocations. -->
-      <Rule Id="CA1826" Action="Warning" />          <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
-      <Rule Id="CA1827" Action="Warning" />          <!-- Do not use Count() or LongCount() when Any() can be used -->
+      <Rule Id="CA1825" Action="Info" />             <!-- Avoid zero-length array allocations. -->
+      <Rule Id="CA1826" Action="Info" />             <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+      <Rule Id="CA1827" Action="Info" />             <!-- Do not use Count() or LongCount() when Any() can be used -->
       <Rule Id="CA1828" Action="Error" />            <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
-      <Rule Id="CA1829" Action="Warning" />          <!-- Use Length/Count property instead of Count() when available -->
+      <Rule Id="CA1829" Action="Info" />             <!-- Use Length/Count property instead of Count() when available -->
       <Rule Id="CA2000" Action="Error" />            <!-- Dispose objects before losing scope -->
       <Rule Id="CA2002" Action="Error" />            <!-- Do not lock on objects with weak identity -->
       <Rule Id="CA2007" Action="Hidden" />           <!-- Consider calling ConfigureAwait on the awaited task -->
-      <Rule Id="CA2008" Action="Warning" />          <!-- Do not create tasks without passing a TaskScheduler -->
+      <Rule Id="CA2008" Action="Info" />             <!-- Do not create tasks without passing a TaskScheduler -->
       <Rule Id="CA2009" Action="Error" />            <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
       <Rule Id="CA2010" Action="Error" />            <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
       <Rule Id="CA2100" Action="Error" />            <!-- Review SQL queries for security vulnerabilities -->
-      <Rule Id="CA2101" Action="Warning" />          <!-- Specify marshaling for P/Invoke string arguments -->
+      <Rule Id="CA2101" Action="Hidden" />           <!-- Specify marshaling for P/Invoke string arguments -->
       <Rule Id="CA2119" Action="Error" />            <!-- Seal methods that satisfy private interfaces -->
       <Rule Id="CA2153" Action="Error" />            <!-- Do Not Catch Corrupted State Exceptions -->
       <Rule Id="CA2200" Action="Error" />            <!-- Rethrow to preserve stack details. -->
-      <Rule Id="CA2201" Action="Warning" />          <!-- Do not raise reserved exception types -->
+      <Rule Id="CA2201" Action="Info" />             <!-- Do not raise reserved exception types -->
       <Rule Id="CA2207" Action="Error" />            <!-- Initialize value type static fields inline -->
-      <Rule Id="CA2208" Action="Warning" />          <!-- Instantiate argument exceptions correctly -->
-      <Rule Id="CA2211" Action="Warning" />          <!-- Non-constant fields should not be visible -->
+      <Rule Id="CA2208" Action="Info" />             <!-- Instantiate argument exceptions correctly -->
+      <Rule Id="CA2211" Action="Info" />             <!-- Non-constant fields should not be visible -->
       <Rule Id="CA2213" Action="Error" />            <!-- Disposable fields should be disposed -->
       <Rule Id="CA2214" Action="Error" />            <!-- Do not call overridable methods in constructors -->
       <Rule Id="CA2216" Action="Error" />            <!-- Disposable types should declare finalizer -->
-      <Rule Id="CA2217" Action="Warning" />          <!-- Do not mark enums with FlagsAttribute -->
+      <Rule Id="CA2217" Action="Info" />             <!-- Do not mark enums with FlagsAttribute -->
       <Rule Id="CA2218" Action="Error" />            <!-- Override GetHashCode on overriding Equals -->
       <Rule Id="CA2219" Action="Error" />            <!-- Do not raise exceptions in finally clauses -->
       <Rule Id="CA2224" Action="Error" />            <!-- Override Equals on overloading operator equals -->
-      <Rule Id="CA2225" Action="Warning" />          <!-- Operator overloads have named alternates -->
+      <Rule Id="CA2225" Action="Error" />            <!-- Operator overloads have named alternates -->
       <Rule Id="CA2226" Action="Error" />            <!-- Operators should have symmetrical overloads -->
-      <Rule Id="CA2227" Action="Warning" />          <!-- Collection properties should be read only -->
+      <Rule Id="CA2227" Action="Info" />             <!-- Collection properties should be read only -->
       <Rule Id="CA2229" Action="Error" />            <!-- Implement serialization constructors -->
       <Rule Id="CA2231" Action="Error" />            <!-- Overload operator equals on overriding value type Equals -->
-      <Rule Id="CA2234" Action="Warning" />          <!-- Pass system uri objects instead of strings -->
+      <Rule Id="CA2234" Action="Info" />             <!-- Pass system uri objects instead of strings -->
       <Rule Id="CA2235" Action="Error" />            <!-- Mark all non-serializable fields -->
       <Rule Id="CA2237" Action="Error" />            <!-- Mark ISerializable types with serializable -->
       <Rule Id="CA2241" Action="Error" />            <!-- Provide correct arguments to formatting methods -->
@@ -165,8 +165,8 @@
       <Rule Id="CA3076" Action="Error" />            <!-- Insecure XSLT script processing. -->
       <Rule Id="CA3077" Action="Error" />            <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
       <Rule Id="CA3147" Action="Error" />            <!-- Mark Verb Handlers With Validate Antiforgery Token -->
-      <Rule Id="CA5350" Action="Warning" />          <!-- Do Not Use Weak Cryptographic Algorithms -->
-      <Rule Id="CA5351" Action="Warning" />          <!-- Do Not Use Broken Cryptographic Algorithms -->
+      <Rule Id="CA5350" Action="Error" />            <!-- Do Not Use Weak Cryptographic Algorithms -->
+      <Rule Id="CA5351" Action="Error" />            <!-- Do Not Use Broken Cryptographic Algorithms -->
       <Rule Id="CA5358" Action="Error" />            <!-- Do Not Use Unsafe Cipher Modes -->
       <Rule Id="CA5359" Action="Error" />            <!-- Do Not Disable Certificate Validation -->
       <Rule Id="CA5360" Action="Error" />            <!-- Do Not Call Dangerous Methods In Deserialization -->
@@ -178,7 +178,7 @@
       <Rule Id="CA5366" Action="Error" />            <!-- Use XmlReader For DataSet Read Xml -->
       <Rule Id="CA5367" Action="Error" />            <!-- Do Not Serialize Types With Pointer Fields -->
       <Rule Id="CA5368" Action="Error" />            <!-- Set ViewStateUserKey For Classes Derived From Page -->
-      <Rule Id="CA5369" Action="Warning" />          <!-- Use XmlReader For Deserialize -->
+      <Rule Id="CA5369" Action="Info" />             <!-- Use XmlReader For Deserialize -->
       <Rule Id="CA5370" Action="Error" />            <!-- Use XmlReader For Validating Reader -->
       <Rule Id="CA5371" Action="Error" />            <!-- Use XmlReader For Schema Read -->
       <Rule Id="CA5372" Action="Error" />            <!-- Use XmlReader For XPathDocument -->
@@ -201,16 +201,16 @@
       <Rule Id="CA5389" Action="Error" />            <!-- Do Not Add Archive Item's Path To The Target File System Path -->
       <Rule Id="CA5390" Action="Error" />            <!-- Do not hard-code encryption key -->
       <Rule Id="CA5391" Action="Error" />            <!-- Use antiforgery tokens in ASP.NET Core MVC controllers -->
-      <Rule Id="CA5392" Action="Warning" />          <!-- Use DefaultDllImportSearchPaths attribute for P/Invokes -->
+      <Rule Id="CA5392" Action="Hidden" />           <!-- Use DefaultDllImportSearchPaths attribute for P/Invokes -->
       <Rule Id="CA5393" Action="Error" />            <!-- Do not use unsafe DllImportSearchPath value -->
-      <Rule Id="CA5394" Action="Warning" />          <!-- Do not use insecure randomness -->
+      <Rule Id="CA5394" Action="Error" />            <!-- Do not use insecure randomness -->
       <Rule Id="CA5395" Action="Error" />            <!-- Miss HttpVerb attribute for action methods -->
       <Rule Id="CA5396" Action="Error" />            <!-- Set HttpOnly to true for HttpCookie -->
       <Rule Id="CA5397" Action="Error" />            <!-- Do not use deprecated SslProtocols values -->
       <Rule Id="CA5398" Action="Error" />            <!-- Avoid hardcoded SslProtocols values -->
       <Rule Id="CA5399" Action="Error" />            <!-- HttpClients should enable certificate revocation list checks -->
       <Rule Id="CA5400" Action="Error" />            <!-- Ensure HttpClient certificate revocation list check is not disabled -->
-      <Rule Id="CA5401" Action="Warning" />          <!-- Do not use CreateEncryptor with non-default IV -->
+      <Rule Id="CA5401" Action="Info" />             <!-- Do not use CreateEncryptor with non-default IV -->
       <Rule Id="CA5402" Action="Error" />            <!-- Use CreateEncryptor with the default IV  -->
       <Rule Id="CA5403" Action="Error" />            <!-- Do not hard-code certificate -->
       <Rule Id="CA9999" Action="Error" />            <!-- Analyzer version mismatch -->


### PR DESCRIPTION
I evaluated each warning and converted it info, error, or hidden.
I did not make any functional code changes to address the rules.
In cases where the rule looked useful and there were only a few
violations, I annotated the relevant code and switched to
error. Where the pattern was so pervasive or harmless that we
were unlikely to ever address it, I switched to hidden.
Otherwise I used info so we could address them individually
later.