### PR TITLE
Node.js 10.x Vulnerabilities update to v10.22.1

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -8,7 +8,6 @@ CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
 NODE10_VERSION="10.23.0"
-NODE14_VERSION="14.11.0"
 MINGIT_VERSION="2.28.0"
 
 get_abs_path() {

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -7,7 +7,7 @@ L1_MODE=$4
 CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
-NODE10_VERSION="10.22.1"
+NODE10_VERSION="10.23.0"
 NODE14_VERSION="14.11.0"
 MINGIT_VERSION="2.28.0"
 

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -7,7 +7,7 @@ L1_MODE=$4
 CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
-NODE10_VERSION="10.21.0"
+NODE10_VERSION="10.22.1"
 NODE14_VERSION="14.11.0"
 MINGIT_VERSION="2.28.0"
 


### PR DESCRIPTION
Node.js 10.x Multiple Vulnerabilities
CVE references
CVE-2020-8252 | CVE-2020-8201 |
Solution
Update to version 10.22.1.