### PR TITLE
Add retries on PA downloads

### DIFF
--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactProvider.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.Services.BlobStore.Common.Telemetry;
 using Microsoft.VisualStudio.Services.BlobStore.WebApi;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
 using Microsoft.VisualStudio.Services.WebApi;
+using Microsoft.VisualStudio.Services.Content.Common;
 
 namespace Agent.Plugins.PipelineArtifact
 {
@@ -70,7 +71,17 @@ namespace Agent.Plugins.PipelineArtifact
                     record: downloadRecord,
                     actionAsync: async () =>
                     {
-                        await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                        await AsyncHttpRetryHelper.InvokeVoidAsync(
+                            async () =>
+                            {
+                                await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                            },
+                            maxRetries: 3,
+                            tracer: tracer,
+                            canRetryDelegate: e => true,
+                            context: nameof(DownloadSingleArtifactAsync),
+                            cancellationToken: cancellationToken,
+                            continueOnCapturedContext: false);
                     });
                 // Send results to CustomerIntelligence
                 this.context.PublishTelemetry(area: PipelineArtifactConstants.AzurePipelinesAgent, feature: PipelineArtifactConstants.PipelineArtifact, record: downloadRecord);
@@ -100,7 +111,17 @@ namespace Agent.Plugins.PipelineArtifact
                     record: downloadRecord,
                     actionAsync: async () =>
                     {
-                        await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                        await AsyncHttpRetryHelper.InvokeVoidAsync(
+                            async () =>
+                            {
+                                await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                            },
+                            maxRetries: 3,
+                            tracer: tracer,
+                            canRetryDelegate: e => true,
+                            context: nameof(DownloadMultipleArtifactsAsync),
+                            cancellationToken: cancellationToken,
+                            continueOnCapturedContext: false);
                     });
                 // Send results to CustomerIntelligence
                 this.context.PublishTelemetry(area: PipelineArtifactConstants.AzurePipelinesAgent, feature: PipelineArtifactConstants.PipelineArtifact, record: downloadRecord);

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactServer.cs
@@ -183,8 +183,19 @@ namespace Agent.Plugins.PipelineArtifact
                             record: downloadRecord,
                             actionAsync: async () =>
                             {
-                                await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                                await AsyncHttpRetryHelper.InvokeVoidAsync(
+                                    async () =>
+                                    {
+                                        await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                                    },
+                                    maxRetries: 3,
+                                    tracer: tracer,
+                                    canRetryDelegate: e => true,
+                                    context: nameof(DownloadAsync),
+                                    cancellationToken: cancellationToken,
+                                    continueOnCapturedContext: false);
                             });
+
                         // Send results to CustomerIntelligence
                         context.PublishTelemetry(area: PipelineArtifactConstants.AzurePipelinesAgent, feature: PipelineArtifactConstants.PipelineArtifact, record: downloadRecord);
                         }
@@ -226,8 +237,19 @@ namespace Agent.Plugins.PipelineArtifact
                         record: downloadRecord,
                         actionAsync: async () =>
                         {
-                            await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                            await AsyncHttpRetryHelper.InvokeVoidAsync(
+                                async () =>
+                                {
+                                    await dedupManifestClient.DownloadAsync(options, cancellationToken);
+                                },
+                                maxRetries: 3,
+                                tracer: tracer,
+                                canRetryDelegate: e => true,
+                                context: nameof(DownloadAsync),
+                                cancellationToken: cancellationToken,
+                                continueOnCapturedContext: false);
                         });
+
                     // Send results to CustomerIntelligence
                     context.PublishTelemetry(area: PipelineArtifactConstants.AzurePipelinesAgent, feature: PipelineArtifactConstants.PipelineArtifact, record: downloadRecord);
                 }

--- a/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
@@ -25,7 +25,7 @@ namespace Agent.Plugins.PipelineCache
             context.SetTaskVariable(RestoreStepRanVariableName, RestoreStepRanVariableValue);
             context.SetTaskVariable(ResolvedFingerPrintVariableName, fingerprint.ToString());
 
-            var server = new PipelineCacheServer();
+            var server = new PipelineCacheServer(context);
             Fingerprint[] restoreFingerprints = restoreKeysGenerator();
             await server.DownloadAsync(
                 context,

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -83,7 +83,7 @@ namespace Agent.Plugins.PipelineCache
                 contentFormat = Enum.Parse<ContentFormat>(contentFormatValue, ignoreCase: true);
             }
 
-            PipelineCacheServer server = new PipelineCacheServer();
+            PipelineCacheServer server = new PipelineCacheServer(context);
             await server.UploadAsync(
                 context,
                 keyFingerprint,


### PR DESCRIPTION
**Problem Statement:**
We have a customer support mail that their download on pipeline artifact has been failing intermittently on timeouts. Ex log: https://msazure.visualstudio.com/One/_releaseProgress?releaseId=3079708&_a=release-environment-logs&environmentId=9507108.

Some of the errors failed in a way that didn't retry but should have.
Attempt2: https://msazure.visualstudio.com/One/_releaseProgress?releaseId=3079708&_a=release-environment-logs&environmentId=9507124

**Fix:**
Add global retry for PA publish and download.

**Discussion in teams**
https://teams.microsoft.com/l/message/19:64eb0db4d2d8413b9e21966cf903ad6a@thread.tacv2/1602711074160?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=8a20ac16-024b-4cac-9f56-d50041298df4&parentMessageId=1602711074160&teamName=Azure Artifacts&channelName=Core&createdTime=1602711074160