### PR TITLE
Revert "Multiple directories and path glob pattern support for pipeline caching (#2834)"

### DIFF
--- a/src/Agent.Plugins/PipelineCache/FingerprintCreator.cs
+++ b/src/Agent.Plugins/PipelineCache/FingerprintCreator.cs
@@ -18,12 +18,6 @@ using System.Text;
 
 namespace Agent.Plugins.PipelineCache
 {
-    public enum FingerprintType
-    {
-        Key,
-        Path
-    }
-
     public static class FingerprintCreator
     {
         private static readonly bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -38,7 +32,7 @@ namespace Agent.Plugins.PipelineCache
             AllowWindowsPaths = isWindows,
         };
 
-        private static readonly char[] GlobChars = new[] { '*', '?', '[', ']' };
+        private static readonly char[] GlobChars = new [] { '*', '?', '[', ']' };
 
         private const char ForceStringLiteral = '"';
 
@@ -51,22 +45,21 @@ namespace Agent.Plugins.PipelineCache
             return !Path.GetInvalidFileNameChars().Contains(c);
         }
 
-        internal static bool IsPathySegment(string segment)
+        internal static bool IsPathyKeySegment(string keySegment)
         {
-            if (segment.First() == ForceStringLiteral && segment.Last() == ForceStringLiteral) return false;
-            if (segment.Any(c => !IsPathyChar(c))) return false;
-            if (!segment.Contains(".") &&
-                !segment.Contains(Path.DirectorySeparatorChar) &&
-                !segment.Contains(Path.AltDirectorySeparatorChar)) return false;
-            if (segment.Last() == '.') return false;
+            if (keySegment.First() == ForceStringLiteral && keySegment.Last() == ForceStringLiteral) return false;
+            if (keySegment.Any(c => !IsPathyChar(c))) return false;
+            if (!keySegment.Contains(".") && 
+                !keySegment.Contains(Path.DirectorySeparatorChar) &&
+                !keySegment.Contains(Path.AltDirectorySeparatorChar)) return false;
+            if (keySegment.Last() == '.') return false;
             return true;
         }
 
         internal static Func<string, bool> CreateMinimatchFilter(AgentTaskPluginExecutionContext context, string rule, bool invert)
         {
-            Func<string, bool> filter = Minimatcher.CreateFilter(rule, minimatchOptions);
-            Func<string, bool> tracedFilter = (path) =>
-            {
+            Func<string,bool> filter = Minimatcher.CreateFilter(rule, minimatchOptions);
+            Func<string,bool> tracedFilter = (path) => {
                 bool filterResult = filter(path);
                 context.Verbose($"Path `{path}` is {(filterResult ? "" : "not ")}{(invert ? "excluded" : "included")} because of pattern `{(invert ? "!" : "")}{rule}`.");
                 return invert ^ filterResult;
@@ -88,16 +81,16 @@ namespace Agent.Plugins.PipelineCache
             }
         }
 
-        internal static Func<string, bool> CreateFilter(
+        internal static Func<string,bool> CreateFilter(
             AgentTaskPluginExecutionContext context,
             IEnumerable<string> includeRules,
             IEnumerable<string> excludeRules)
         {
-            Func<string, bool>[] includeFilters = includeRules.Select(includeRule =>
-                 CreateMinimatchFilter(context, includeRule, invert: false)).ToArray();
-            Func<string, bool>[] excludeFilters = excludeRules.Select(excludeRule =>
-                 CreateMinimatchFilter(context, excludeRule, invert: true)).ToArray();
-            Func<string, bool> filter = (path) => includeFilters.Any(f => f(path)) && excludeFilters.All(f => f(path));
+            Func<string,bool>[] includeFilters = includeRules.Select(includeRule =>
+                CreateMinimatchFilter(context, includeRule, invert: false)).ToArray();
+            Func<string,bool>[] excludeFilters = excludeRules.Select(excludeRule => 
+                CreateMinimatchFilter(context, excludeRule, invert: true)).ToArray();
+            Func<string,bool> filter = (path) => includeFilters.Any(f => f(path)) && excludeFilters.All(f => f(path));
             return filter;
         }
 
@@ -116,10 +109,10 @@ namespace Agent.Plugins.PipelineCache
             {
                 this.DisplayPath = displayPath;
                 this.FileLength = fileLength;
-                this.Hash = hash;
+                this.Hash = hash;    
             }
 
-            public MatchedFile(string displayPath, FileStream fs) :
+            public MatchedFile(string displayPath, FileStream fs): 
                 this(displayPath, fs.Length, s_sha256.ComputeHash(fs).ToHex())
             {
             }
@@ -128,13 +121,11 @@ namespace Agent.Plugins.PipelineCache
             public long FileLength;
             public string Hash;
 
-            public string GetHash()
-            {
-                return MatchedFile.GenerateHash(new[] { this });
+            public string GetHash() {
+                return MatchedFile.GenerateHash(new [] { this });
             }
 
-            public static string GenerateHash(IEnumerable<MatchedFile> matches)
-            {
+            public static string GenerateHash(IEnumerable<MatchedFile> matches) {                
                 string s = matches.Aggregate(new StringBuilder(),
                         (sb, file) => sb.Append($"\nSHA256({file.DisplayPath})=[{file.FileLength}]{file.Hash}"),
                         sb => sb.ToString());
@@ -147,9 +138,7 @@ namespace Agent.Plugins.PipelineCache
         {
             String = 0,
             FilePath = 1,
-            FilePattern = 2,
-            Directory = 3,
-            DirectoryPattern = 4
+            FilePattern = 2
         }
 
         // Given a globby path, figure out where to start enumerating.
@@ -170,8 +159,7 @@ namespace Agent.Plugins.PipelineCache
             // no globbing
             if (firstGlob < 0)
             {
-                return new Enumeration()
-                {
+                return new Enumeration() {
                     RootPath = Path.GetDirectoryName(includeGlobPathAbsolute),
                     Pattern = Path.GetFileName(includeGlobPathAbsolute),
                     Depth = SearchOption.TopDirectoryOnly
@@ -179,130 +167,105 @@ namespace Agent.Plugins.PipelineCache
             }
             else
             {
-                int rootDirLength = includeGlobPathAbsolute.Substring(0, firstGlob).LastIndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
-                return new Enumeration()
-                {
-                    RootPath = includeGlobPathAbsolute.Substring(0, rootDirLength),
+                int rootDirLength = includeGlobPathAbsolute.Substring(0,firstGlob).LastIndexOfAny( new [] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar});
+                return new Enumeration() {
+                    RootPath = includeGlobPathAbsolute.Substring(0,rootDirLength),
                     Pattern = "*",
                     Depth = hasRecursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly
                 };
             }
         }
 
-        internal static void CheckSegment(string segment, string segmentType)
+        internal static void CheckKeySegment(string keySegment)
         {
-            if (segment.Equals("*", StringComparison.Ordinal))
+            if (keySegment.Equals("*", StringComparison.Ordinal))
             {
-                throw new ArgumentException($"`*` is a reserved {segmentType} segment. For path glob, use `./*`.");
+                throw new ArgumentException("`*` is a reserved key segment. For path glob, use `./*`.");
             }
-            else if (segment.Equals(Fingerprint.Wildcard, StringComparison.Ordinal))
+            else if (keySegment.Equals(Fingerprint.Wildcard, StringComparison.Ordinal))
             {
-                throw new ArgumentException($"`**` is a reserved {segmentType} segment. For path glob, use `./**`.");
+                throw new ArgumentException("`**` is a reserved key segment. For path glob, use `./**`.");
             }
-            else if (segment.First() == '\'')
+            else if (keySegment.First() == '\'')
             {
-                throw new ArgumentException($"A {segmentType} segment cannot start with a single-quote character`.");
+                throw new ArgumentException("A key segment cannot start with a single-quote character`.");
             }
-            else if (segment.First() == '`')
+            else if (keySegment.First() == '`')
             {
-                throw new ArgumentException($"A {segmentType} segment cannot start with a backtick character`.");
+                throw new ArgumentException("A key segment cannot start with a backtick character`.");
             }
         }
 
-        private static void LogSegment(
-            AgentTaskPluginExecutionContext context,
-            IEnumerable<string> segments,
-            string segment,
-            KeySegmentType type,
-            Object details)
-        {
-            string FormatForDisplay(string value, int displayLength)
-            {
-                if (value.Length > displayLength)
-                {
-                    value = value.Substring(0, displayLength - 3) + "...";
-                }
-
-                return value.PadRight(displayLength);
-            };
-
-            string formattedSegment = FormatForDisplay(segment, Math.Min(segments.Select(s => s.Length).Max(), 50));
-            
-            void LogPatternSegment<T>(object value, string title, Func<T, string> getText, Func<T,string> getSuffix = null)
-            {
-                var matches = (value as T[]) ?? Array.Empty<T>();
-                context.Output($" - {formattedSegment} [{title} pattern; matches: {matches.Length}]");
-                if (matches.Any())
-                {
-                    int displayLength = Math.Min(matches.Select(d => getText(d).Length).Max(), 70);
-                    foreach (var match in matches)
-                    {
-                        context.Output($"   - {FormatForDisplay(getText(match), displayLength)}{(getSuffix != null ? getSuffix(match) : "")}");
-                    }
-                }
-            };
-
-            switch (type)
-            {
-                case KeySegmentType.String:
-                    context.Output($" - {formattedSegment} [string]");
-                    break;
-                case KeySegmentType.Directory:
-                    context.Output($" - {formattedSegment} [directory]");
-                    break;
-                case KeySegmentType.DirectoryPattern:
-                    LogPatternSegment<string>(
-                        details, 
-                        "directory", 
-                        s => s
-                    );
-                    break;
-                case KeySegmentType.FilePath:
-                    var files = (details as MatchedFile[]) ?? new MatchedFile[0];
-                    string fileHash = files.Length > 0 ? files[0].Hash : null;
-                    context.Output($" - {formattedSegment} [file] {(!string.IsNullOrWhiteSpace(fileHash) ? $"--> {fileHash}" : "(not found)")}");
-                    break;
-                case KeySegmentType.FilePattern:
-                    LogPatternSegment<MatchedFile>(
-                        details, 
-                        "file", 
-                        match => match.DisplayPath, 
-                        match => $" --> {match.Hash}"
-                    );
-                    break;
-            }
-        }
-
-        public static Fingerprint EvaluateToFingerprint(
+        public static Fingerprint EvaluateKeyToFingerprint(
             AgentTaskPluginExecutionContext context,
             string filePathRoot,
-            IEnumerable<string> segments,
-            FingerprintType fingerprintType)
+            IEnumerable<string> keySegments)
         {
             // Quickly validate all segments
-            foreach (string segment in segments)
+            foreach (string keySegment in keySegments)
             {
-                CheckSegment(segment, fingerprintType.ToString());
+                CheckKeySegment(keySegment);
             }
 
             string defaultWorkingDirectory = context.Variables.GetValueOrDefault(
                 "system.defaultworkingdirectory" // Constants.Variables.System.DefaultWorkingDirectory
-            )?.Value ?? filePathRoot;
+                )?.Value;
 
             var resolvedSegments = new List<string>();
             var exceptions = new List<Exception>();
-            var hasPatternSegments = false;
 
-            foreach (string segment in segments)
+            Action<string, KeySegmentType, Object> LogKeySegment = (segment, type, details) =>
             {
-                if (!IsPathySegment(segment))
+                Func<string,int,string> FormatForDisplay = (value, displayLength) =>
                 {
-                    LogSegment(context, segments, segment, KeySegmentType.String, null);
-                    resolvedSegments.Add(segment);
+                    if (value.Length > displayLength)
+                    {
+                        value = value.Substring(0, displayLength - 3) + "...";
+                    }
+
+                    return value.PadRight(displayLength);
+                };
+
+                string formattedSegment = FormatForDisplay(segment, Math.Min(keySegments.Select(s => s.Length).Max(), 50));
+
+                if (type == KeySegmentType.String)
+                {
+                    context.Output($" - {formattedSegment} [string]");
                 }
                 else
                 {
-                    string[] pathRules = segment.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+                    var matches = (details as MatchedFile[]) ?? new MatchedFile[0];
+                    
+                    if (type == KeySegmentType.FilePath)
+                    {
+                        string fileHash = matches.Length > 0 ? matches[0].Hash : null;
+                        context.Output($" - {formattedSegment} [file] {(!string.IsNullOrWhiteSpace(fileHash) ? $"--> {fileHash}" : "(not found)")}");
+                    }
+                    else if (type == KeySegmentType.FilePattern)
+                    {
+                        context.Output($" - {formattedSegment} [file pattern; matches: {matches.Length}]");
+                        if (matches.Any())
+                        {
+                            int filePathDisplayLength = Math.Min(matches.Select(mf => mf.DisplayPath.Length).Max(), 70);
+                            foreach (var match in matches)
+                            {
+                                context.Output($"   - {FormatForDisplay(match.DisplayPath, filePathDisplayLength)} --> {match.Hash}");
+                            }
+                        }
+                    }   
+                }
+            };    
+
+            foreach (string keySegment in keySegments)
+            {
+                if (!IsPathyKeySegment(keySegment))
+                {
+                    LogKeySegment(keySegment, KeySegmentType.String, null);
+                    resolvedSegments.Add(keySegment);
+                }
+                else
+                {
+                    string[] pathRules = keySegment.Split(new []{','}, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
                     string[] includeRules = pathRules.Where(p => !p.StartsWith('!')).ToArray();
 
                     if (!includeRules.Any())
@@ -310,119 +273,75 @@ namespace Agent.Plugins.PipelineCache
                         throw new ArgumentException("No include rules specified.");
                     }
 
-                    var enumerations = new Dictionary<Enumeration, List<string>>();
-                    foreach (string includeRule in includeRules)
+                    var enumerations = new Dictionary<Enumeration,List<string>>();
+                    foreach(string includeRule in includeRules)
                     {
                         string absoluteRootRule = MakePathCanonical(defaultWorkingDirectory, includeRule);
                         context.Verbose($"Expanded include rule is `{absoluteRootRule}`.");
                         Enumeration enumeration = DetermineFileEnumerationFromGlob(absoluteRootRule);
                         List<string> globs;
-                        if (!enumerations.TryGetValue(enumeration, out globs))
+                        if(!enumerations.TryGetValue(enumeration, out globs))
                         {
-                            enumerations[enumeration] = globs = new List<string>();
+                            enumerations[enumeration] = globs = new List<string>(); 
                         }
                         globs.Add(absoluteRootRule);
                     }
 
                     string[] excludeRules = pathRules.Where(p => p.StartsWith('!')).ToArray();
-                    string[] absoluteExcludeRules = excludeRules.Select(excludeRule =>
-                    {
+                    string[] absoluteExcludeRules = excludeRules.Select(excludeRule => {
                         excludeRule = excludeRule.Substring(1);
                         return MakePathCanonical(defaultWorkingDirectory, excludeRule);
                     }).ToArray();
 
                     var matchedFiles = new SortedDictionary<string, MatchedFile>(StringComparer.Ordinal);
-                    var matchedDirectories = new SortedDictionary<string, string>(StringComparer.Ordinal);
 
-                    foreach (var kvp in enumerations)
+                    foreach(var kvp in enumerations)
                     {
                         Enumeration enumerate = kvp.Key;
                         List<string> absoluteIncludeGlobs = kvp.Value;
                         context.Verbose($"Enumerating starting at root `{enumerate.RootPath}` with pattern `{enumerate.Pattern}` and depth `{enumerate.Depth}`.");
-                        IEnumerable<string> files = fingerprintType == FingerprintType.Key
-                            ? Directory.EnumerateFiles(enumerate.RootPath, enumerate.Pattern, enumerate.Depth)
-                            : Directory.EnumerateDirectories(enumerate.RootPath, enumerate.Pattern, enumerate.Depth);
-
-                        Func<string, bool> filter = CreateFilter(context, absoluteIncludeGlobs, absoluteExcludeRules);
+                        IEnumerable<string> files = Directory.EnumerateFiles(enumerate.RootPath, enumerate.Pattern, enumerate.Depth);
+                        Func<string,bool> filter = CreateFilter(context, absoluteIncludeGlobs, absoluteExcludeRules);
                         files = files.Where(f => filter(f)).Distinct();
 
-                        foreach (string path in files)
+                        foreach(string path in files)
                         {
-                            // Path.GetRelativePath returns 'The relative path, or path if the paths don't share the same root.'
-                            string displayPath = filePathRoot == null ? path : Path.GetRelativePath(filePathRoot, path);
-
-                            if (fingerprintType == FingerprintType.Key)
+                            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
                             {
-                                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-                                {
-                                    matchedFiles.Add(path, new MatchedFile(displayPath, fs));
-                                }
-                            }
-                            else
-                            {
-                                matchedDirectories.Add(path, displayPath);
+                                // Path.GetRelativePath returns 'The relative path, or path if the paths don't share the same root.'
+                                string displayPath = filePathRoot == null ? path : Path.GetRelativePath(filePathRoot, path);
+                                matchedFiles.Add(path, new MatchedFile(displayPath, fs));
                             }
                         }
                     }
 
-                    var patternSegment = segment.IndexOfAny(GlobChars) >= 0 || matchedFiles.Count > 1;
-                    hasPatternSegments |= patternSegment;
+                    var patternSegment = keySegment.IndexOfAny(GlobChars) >= 0 || matchedFiles.Count() > 1;
 
-                    var displaySegment = segment;
+                    var displayKeySegment = keySegment;
 
                     if (context.Container != null)
                     {
-                        displaySegment = context.Container.TranslateToContainerPath(displaySegment);
+                        displayKeySegment = context.Container.TranslateToContainerPath(displayKeySegment);
                     }
 
-                    KeySegmentType segmentType;
-                    object details;
-                    if (fingerprintType == FingerprintType.Key)
-                    {
-                        segmentType = patternSegment ? KeySegmentType.FilePattern : KeySegmentType.FilePath;
-                        details = matchedFiles.Values.ToArray();
-                        resolvedSegments.Add(MatchedFile.GenerateHash(matchedFiles.Values));
+                    LogKeySegment(displayKeySegment, 
+                        patternSegment ? KeySegmentType.FilePattern : KeySegmentType.FilePath,
+                        matchedFiles.Values.ToArray());
 
-                        if (!matchedFiles.Any())
+                    if (!matchedFiles.Any())
+                    {
+                        if (patternSegment)
                         {
-                            var message = patternSegment ? $"No matching files found for pattern: {displaySegment}" : $"File not found: {displaySegment}";
-                            exceptions.Add(new FileNotFoundException(message));
+                            exceptions.Add(new FileNotFoundException($"No matching files found for pattern: {displayKeySegment}"));
+                        }
+                        else
+                        {
+                            exceptions.Add(new FileNotFoundException($"File not found: {displayKeySegment}"));
                         }
                     }
-                    else
-                    {
-                        segmentType = patternSegment ? KeySegmentType.DirectoryPattern : KeySegmentType.Directory;
-                        details = matchedDirectories.Values.ToArray();
-                        resolvedSegments.AddRange(matchedDirectories.Values);
-
-                        if (!matchedDirectories.Any())
-                        {
-                            var message = patternSegment ? $"No matching directories found for pattern: {displaySegment}" : $"Directory not found: {displaySegment}";
-                            exceptions.Add(new DirectoryNotFoundException(message));
-                        }
-                    }
-
-                    LogSegment(
-                        context,
-                        segments,
-                        displaySegment,
-                        segmentType,
-                        details
-                    );
-                }
-            }
-
-            if (fingerprintType == FingerprintType.Path)
-            {
-                // If there are segments or contains a glob pattern, all resolved segments must be rooted within filePathRoot (e.g. Pipeline.Workspace)
-                // This limitation is mainly due to 7z not extracting backtraced paths
-                if (resolvedSegments.Count() > 1 || hasPatternSegments)
-                {
-                    foreach (var backtracedPath in resolvedSegments.Where(x => x.StartsWith("..")))
-                    {
-                        exceptions.Add(new ArgumentException($"Resolved path is not within `Pipeline.Workspace`: {backtracedPath}"));
-                    }
-                }
+                
+                    resolvedSegments.Add(MatchedFile.GenerateHash(matchedFiles.Values));
+                }                 
             }
 
             if (exceptions.Any())

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheServer.cs
@@ -32,9 +32,8 @@ namespace Agent.Plugins.PipelineCache
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1068: CancellationToken parameters must come last")]
         internal async Task UploadAsync(
             AgentTaskPluginExecutionContext context,
-            Fingerprint keyFingerprint,
-            string[] pathSegments,
-            string workspaceRoot,
+            Fingerprint fingerprint,
+            string path,
             CancellationToken cancellationToken,
             ContentFormat contentFormat)
         {
@@ -48,7 +47,7 @@ namespace Agent.Plugins.PipelineCache
                 // Check if the key exists.
                 PipelineCacheActionRecord cacheRecordGet = clientTelemetry.CreateRecord<PipelineCacheActionRecord>((level, uri, type) =>
                         new PipelineCacheActionRecord(level, uri, type, PipelineArtifactConstants.RestoreCache, context));
-                PipelineCacheArtifact getResult = await pipelineCacheClient.GetPipelineCacheArtifactAsync(new[] { keyFingerprint }, cancellationToken, cacheRecordGet);
+                PipelineCacheArtifact getResult = await pipelineCacheClient.GetPipelineCacheArtifactAsync(new [] {fingerprint}, cancellationToken, cacheRecordGet);
                 // Send results to CustomerIntelligence
                 context.PublishTelemetry(area: PipelineArtifactConstants.AzurePipelinesAgent, feature: PipelineArtifactConstants.PipelineCache, record: cacheRecordGet);
                 //If cache exists, return.
@@ -58,12 +57,7 @@ namespace Agent.Plugins.PipelineCache
                     return;
                 }
 
-                context.Output("Resolving path:");
-                Fingerprint pathFp = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, pathSegments, FingerprintType.Path);
-                context.Output($"Resolved to: {pathFp}");
-
-                string uploadPath = await this.GetUploadPathAsync(contentFormat, context, pathFp, pathSegments, workspaceRoot, cancellationToken);
-
+                string uploadPath = await this.GetUploadPathAsync(contentFormat, context, path, cancellationToken);
                 //Upload the pipeline artifact.
                 PipelineCacheActionRecord uploadRecord = clientTelemetry.CreateRecord<PipelineCacheActionRecord>((level, uri, type) =>
                     new PipelineCacheActionRecord(level, uri, type, nameof(dedupManifestClient.PublishAsync), context));
@@ -85,7 +79,7 @@ namespace Agent.Plugins.PipelineCache
 
                 CreatePipelineCacheArtifactContract options = new CreatePipelineCacheArtifactContract
                 {
-                    Fingerprint = keyFingerprint,
+                    Fingerprint = fingerprint,
                     RootId = result.RootId,
                     ManifestId = result.ManifestId,
                     ProofNodes = result.ProofNodes.ToArray(),
@@ -104,7 +98,7 @@ namespace Agent.Plugins.PipelineCache
                     }
                     catch { }
                 }
-
+                
                 // Cache the artifact
                 PipelineCacheActionRecord cacheRecord = clientTelemetry.CreateRecord<PipelineCacheActionRecord>((level, uri, type) =>
                     new PipelineCacheActionRecord(level, uri, type, PipelineArtifactConstants.SaveCache, context));
@@ -120,9 +114,8 @@ namespace Agent.Plugins.PipelineCache
         internal async Task DownloadAsync(
             AgentTaskPluginExecutionContext context,
             Fingerprint[] fingerprints,
-            string[] pathSegments,
+            string path,
             string cacheHitVariable,
-            string workspaceRoot,
             CancellationToken cancellationToken)
         {
             VssConnection connection = context.VssConnection;
@@ -149,12 +142,12 @@ namespace Agent.Plugins.PipelineCache
                         record: downloadRecord,
                         actionAsync: async () =>
                         {
-                            await this.DownloadPipelineCacheAsync(context, dedupManifestClient, result.ManifestId, pathSegments, workspaceRoot, Enum.Parse<ContentFormat>(result.ContentFormat), cancellationToken);
+                            await this.DownloadPipelineCacheAsync(context, dedupManifestClient, result.ManifestId, path, Enum.Parse<ContentFormat>(result.ContentFormat), cancellationToken);
                         });
 
                     // Send results to CustomerIntelligence
                     context.PublishTelemetry(area: PipelineArtifactConstants.AzurePipelinesAgent, feature: PipelineArtifactConstants.PipelineCache, record: downloadRecord);
-
+                    
                     context.Output("Cache restored.");
                 }
 
@@ -169,11 +162,11 @@ namespace Agent.Plugins.PipelineCache
                         context.Verbose($"Exact fingerprint: `{result.Fingerprint.ToString()}`");
 
                         bool foundExact = false;
-                        foreach (var fingerprint in fingerprints)
+                        foreach(var fingerprint in fingerprints)
                         {
                             context.Verbose($"This fingerprint: `{fingerprint.ToString()}`");
 
-                            if (fingerprint == result.Fingerprint
+                            if (fingerprint == result.Fingerprint 
                                 || result.Fingerprint.Segments.Length == 1 && result.Fingerprint.Segments.Single() == fingerprint.SummarizeForV1())
                             {
                                 foundExact = true;
@@ -200,30 +193,21 @@ namespace Agent.Plugins.PipelineCache
             return pipelineCacheClient;
         }
 
-        private Task<string> GetUploadPathAsync(ContentFormat contentFormat, AgentTaskPluginExecutionContext context, Fingerprint pathFingerprint, string[] pathSegments, string workspaceRoot, CancellationToken cancellationToken)
+        private async Task<string> GetUploadPathAsync(ContentFormat contentFormat, AgentTaskPluginExecutionContext context, string path, CancellationToken cancellationToken)
         {
-            if (contentFormat == ContentFormat.SingleTar)
+            string uploadPath = path;
+            if(contentFormat == ContentFormat.SingleTar)
             {
-                var (tarWorkingDirectory, isWorkspaceContained) = GetTarWorkingDirectory(pathSegments, workspaceRoot);
-
-                return TarUtils.ArchiveFilesToTarAsync(
-                    context, 
-                    pathFingerprint, 
-                    tarWorkingDirectory, 
-                    isWorkspaceContained, 
-                    cancellationToken
-                );
+                uploadPath = await TarUtils.ArchiveFilesToTarAsync(context, path, cancellationToken);
             }
-
-            return Task.FromResult(pathFingerprint.Segments[0]);
+            return uploadPath;
         }
 
         private async Task DownloadPipelineCacheAsync(
             AgentTaskPluginExecutionContext context,
             DedupManifestArtifactClient dedupManifestClient,
             DedupIdentifier manifestId,
-            string[] pathSegments,
-            string workspaceRoot,
+            string targetDirectory,
             ContentFormat contentFormat,
             CancellationToken cancellationToken)
         {
@@ -244,22 +228,21 @@ namespace Agent.Plugins.PipelineCache
                     continueOnCapturedContext: false);
 
                 Manifest manifest = JsonSerializer.Deserialize<Manifest>(File.ReadAllText(manifestPath));
-                var (tarWorkingDirectory, _) = GetTarWorkingDirectory(pathSegments, workspaceRoot);
-                await TarUtils.DownloadAndExtractTarAsync(context, manifest, dedupManifestClient, tarWorkingDirectory, cancellationToken);
+                await TarUtils.DownloadAndExtractTarAsync (context, manifest, dedupManifestClient, targetDirectory, cancellationToken);
                 try
                 {
-                    if (File.Exists(manifestPath))
+                    if(File.Exists(manifestPath))
                     {
                         File.Delete(manifestPath);
                     }
                 }
-                catch { }
+                catch {}
             }
             else
             {
                 DownloadDedupManifestArtifactOptions options = DownloadDedupManifestArtifactOptions.CreateWithManifestId(
                     manifestId,
-                    pathSegments[0],
+                    targetDirectory,
                     proxyUri: null,
                     minimatchPatterns: null);
 
@@ -275,22 +258,7 @@ namespace Agent.Plugins.PipelineCache
                     cancellationToken: cancellationToken,
                     continueOnCapturedContext: false);
             }
-        }
 
-        private (string workingDirectory, bool isWorkspaceContained) GetTarWorkingDirectory(string[] segments, string workspaceRoot)
-        {
-            // If path segment is single directory outside of Pipeline.Workspace extract tarball directly to this path
-            if (segments.Count() == 1) 
-            {
-                var workingDirectory = segments[0];
-                if (FingerprintCreator.IsPathySegment(workingDirectory) && !workingDirectory.StartsWith(workspaceRoot))
-                {
-                    return (workingDirectory, false);
-                }
-            }
-
-            // All other scenarios means that paths must within and relative to Pipeline.Workspace
-            return (workspaceRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), true);
         }
     }
 }

--- a/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
+++ b/src/Agent.Plugins/PipelineCache/PipelineCacheTaskPluginBase.cs
@@ -31,28 +31,26 @@ namespace Agent.Plugins.PipelineCache
         public abstract String Stage { get; }
         public const string ResolvedFingerPrintVariableName = "RESTORE_STEP_RESOLVED_FINGERPRINT";
 
-        internal static (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys, string[] pathSegments) ParseIntoSegments(string salt, string key, string restoreKeysBlock, string path)
+        internal static (bool isOldFormat, string[] keySegments,IEnumerable<string[]> restoreKeys) ParseIntoSegments(string salt, string key, string restoreKeysBlock)
         {
-            Func<string, string[]> splitAcrossPipes = (s) =>
-            {
-                var segments = s.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(segment => segment.Trim());
-                if (!string.IsNullOrWhiteSpace(salt))
+            Func<string,string[]> splitAcrossPipes = (s) => {
+                var segments = s.Split(new [] {'|'},StringSplitOptions.RemoveEmptyEntries).Select(segment => segment.Trim());
+                if(!string.IsNullOrWhiteSpace(salt))
                 {
-                    segments = (new[] { $"{SaltVariableName}={salt}" }).Concat(segments);
+                    segments = (new [] { $"{SaltVariableName}={salt}"}).Concat(segments);
                 }
                 return segments.ToArray();
             };
 
-            Func<string, string[]> splitAcrossNewlines = (s) =>
+            Func<string,string[]> splitAcrossNewlines = (s) => 
                 s.Replace("\r\n", "\n") //normalize newlines
-                 .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                 .Split(new [] {'\n'}, StringSplitOptions.RemoveEmptyEntries)
                  .Select(line => line.Trim())
                  .ToArray();
-
+            
             string[] keySegments;
-            string[] pathSegments;
             bool isOldFormat = key.Contains('\n');
-
+            
             IEnumerable<string[]> restoreKeys;
             bool hasRestoreKeys = !string.IsNullOrWhiteSpace(restoreKeysBlock);
 
@@ -60,7 +58,7 @@ namespace Agent.Plugins.PipelineCache
             {
                 throw new ArgumentException(OldKeyFormatMessage);
             }
-
+            
             if (isOldFormat)
             {
                 keySegments = splitAcrossNewlines(key);
@@ -69,9 +67,7 @@ namespace Agent.Plugins.PipelineCache
             {
                 keySegments = splitAcrossPipes(key);
             }
-
-            // Path can be a list of path segments to include in cache
-            pathSegments = splitAcrossPipes(path);
+            
 
             if (hasRestoreKeys)
             {
@@ -82,9 +78,9 @@ namespace Agent.Plugins.PipelineCache
                 restoreKeys = Enumerable.Empty<string[]>();
             }
 
-            return (isOldFormat, keySegments, restoreKeys, pathSegments);
+            return (isOldFormat, keySegments, restoreKeys);
         }
-
+        
         public async virtual Task RunAsync(AgentTaskPluginExecutionContext context, CancellationToken token)
         {
             ArgUtil.NotNull(context, nameof(context));
@@ -97,10 +93,8 @@ namespace Agent.Plugins.PipelineCache
 
             string key = context.GetInput(PipelineCacheTaskPluginConstants.Key, required: true);
             string restoreKeysBlock = context.GetInput(PipelineCacheTaskPluginConstants.RestoreKeys, required: false);
-            // TODO: Translate path from container to host (Ting)
-            string path = context.GetInput(PipelineCacheTaskPluginConstants.Path, required: true);
 
-            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys, string[] pathSegments) = ParseIntoSegments(salt, key, restoreKeysBlock, path);
+            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys) = ParseIntoSegments(salt, key, restoreKeysBlock);
 
             if (isOldFormat)
             {
@@ -108,26 +102,26 @@ namespace Agent.Plugins.PipelineCache
             }
 
             context.Output("Resolving key:");
-            Fingerprint keyFp = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, keySegments, FingerprintType.Key);
+            Fingerprint keyFp = FingerprintCreator.EvaluateKeyToFingerprint(context, workspaceRoot, keySegments);
             context.Output($"Resolved to: {keyFp}");
 
-            Func<Fingerprint[]> restoreKeysGenerator = () =>
-                restoreKeys.Select(restoreKey =>
-                {
+            Func<Fingerprint[]> restoreKeysGenerator = () => 
+                restoreKeys.Select(restoreKey => {
                     context.Output("Resolving restore key:");
-                    Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, restoreKey, FingerprintType.Key);
-                    f.Segments = f.Segments.Concat(new[] { Fingerprint.Wildcard }).ToArray();
+                    Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, workspaceRoot, restoreKey);
+                    f.Segments = f.Segments.Concat(new [] { Fingerprint.Wildcard} ).ToArray();
                     context.Output($"Resolved to: {f}");
                     return f;
                 }).ToArray();
 
+            // TODO: Translate path from container to host (Ting)
+            string path = context.GetInput(PipelineCacheTaskPluginConstants.Path, required: true);
 
             await ProcessCommandInternalAsync(
                 context,
                 keyFp,
                 restoreKeysGenerator,
-                pathSegments,
-                workspaceRoot,
+                path,
                 token);
         }
 
@@ -136,8 +130,7 @@ namespace Agent.Plugins.PipelineCache
             AgentTaskPluginExecutionContext context,
             Fingerprint fingerprint,
             Func<Fingerprint[]> restoreKeysGenerator,
-            string[] pathSegments,
-            string workspaceRoot,
+            string path,
             CancellationToken token);
 
         // Properties set by tasks

--- a/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/RestorePipelineCacheV0.cs
@@ -9,7 +9,7 @@ using Agent.Sdk;
 using Microsoft.VisualStudio.Services.PipelineCache.WebApi;
 
 namespace Agent.Plugins.PipelineCache
-{
+{    
     public class RestorePipelineCacheV0 : PipelineCacheTaskPluginBase
     {
         public override string Stage => "main";
@@ -18,8 +18,7 @@ namespace Agent.Plugins.PipelineCache
             AgentTaskPluginExecutionContext context,
             Fingerprint fingerprint,
             Func<Fingerprint[]> restoreKeysGenerator,
-            string[] pathSegments,
-            string workspaceRoot,
+            string path,
             CancellationToken token)
         {
             context.SetTaskVariable(RestoreStepRanVariableName, RestoreStepRanVariableValue);
@@ -28,11 +27,10 @@ namespace Agent.Plugins.PipelineCache
             var server = new PipelineCacheServer(context);
             Fingerprint[] restoreFingerprints = restoreKeysGenerator();
             await server.DownloadAsync(
-                context,
-                (new[] { fingerprint }).Concat(restoreFingerprints).ToArray(),
-                pathSegments,
+                context, 
+                (new [] { fingerprint}).Concat(restoreFingerprints).ToArray(),
+                path,
                 context.GetInput(PipelineCacheTaskPluginConstants.CacheHitVariable, required: false),
-                workspaceRoot,
                 token);
         }
     }

--- a/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
+++ b/src/Agent.Plugins/PipelineCache/SavePipelineCacheV0.cs
@@ -57,21 +57,20 @@ namespace Agent.Plugins.PipelineCache
 
         protected override async Task ProcessCommandInternalAsync(
             AgentTaskPluginExecutionContext context,
-            Fingerprint keyFingerprint,
+            Fingerprint fingerprint,
             Func<Fingerprint[]> restoreKeysGenerator,
-            string[] pathSegments,
-            string workspaceRoot,
+            string path,
             CancellationToken token)
         {
-            string contentFormatValue = context.Variables.GetValueOrDefault(ContentFormatVariableName)?.Value ?? string.Empty;
+            string contentFormatValue  = context.Variables.GetValueOrDefault(ContentFormatVariableName)?.Value ?? string.Empty;
             string calculatedFingerPrint = context.TaskVariables.GetValueOrDefault(ResolvedFingerPrintVariableName)?.Value ?? string.Empty;
 
-            if (!string.IsNullOrWhiteSpace(calculatedFingerPrint) && !keyFingerprint.ToString().Equals(calculatedFingerPrint, StringComparison.Ordinal))
+            if(!string.IsNullOrWhiteSpace(calculatedFingerPrint) && !fingerprint.ToString().Equals(calculatedFingerPrint, StringComparison.Ordinal))
             {
-                context.Warning($"The given cache key has changed in it's resolved value between restore and save steps;\n" +
-                                $"original key: {calculatedFingerPrint}\n" +
-                                $"modified key: {keyFingerprint}\n");
-            }
+                context.Warning($"The given cache key has changed in its resolved value between restore and save steps;\n"+
+                                $"original key: {calculatedFingerPrint}\n"+
+                                $"modified key: {fingerprint}\n");
+            } 
 
             ContentFormat contentFormat;
             if (string.IsNullOrWhiteSpace(contentFormatValue))
@@ -86,9 +85,8 @@ namespace Agent.Plugins.PipelineCache
             PipelineCacheServer server = new PipelineCacheServer(context);
             await server.UploadAsync(
                 context,
-                keyFingerprint,
-                pathSegments,
-                workspaceRoot,
+                fingerprint, 
+                path,
                 token,
                 contentFormat);
         }

--- a/src/Test/L0/Plugin/FingerprintCreatorTests.cs
+++ b/src/Test/L0/Plugin/FingerprintCreatorTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,16 +21,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
 
         private static readonly byte[] hash1;
         private static readonly byte[] hash2;
+
         private static readonly string directory;
         private static readonly string path1;
         private static readonly string path2;
-
-        private static readonly string workspaceRoot;
-        private static readonly string directory1;
-        private static readonly string directory2;
-
-        private static readonly string directory1Name;
-        private static readonly string directory2Name;
 
         static FingerprintCreatorTests()
         {
@@ -44,27 +38,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
             directory = Path.GetDirectoryName(path1);
             Assert.Equal(directory, Path.GetDirectoryName(path2));
 
-            var workspace = Guid.NewGuid().ToString();
-
-            var path3 = Path.Combine(directory, workspace, Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
-            var path4 = Path.Combine(directory, workspace, Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
-
-            directory1 = Path.GetDirectoryName(path3);
-            directory2 = Path.GetDirectoryName(path4);
-
-            workspaceRoot = Path.GetDirectoryName(directory1);
-
-            directory1Name = Path.GetFileName(directory1);
-            directory2Name = Path.GetFileName(directory2);
-
             File.WriteAllBytes(path1, content1);
             File.WriteAllBytes(path2, content2);
-
-            Directory.CreateDirectory(directory1);
-            Directory.CreateDirectory(directory2);
-
-            File.WriteAllBytes(path3, content1);
-            File.WriteAllBytes(path4, content2);
 
             using (var hasher = new SHA256Managed())
             {
@@ -78,20 +53,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Trait("Category", "Plugin")]
         public void Fingerprint_ReservedFails()
         {
-            using (var hostContext = new TestHostContext(this))
+            using(var hostContext = new TestHostContext(this))
             {
                 var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
                 Assert.Throws<ArgumentException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, directory, new[] { "*" }, FingerprintType.Key)
+                    () => FingerprintCreator.EvaluateKeyToFingerprint(context, directory, new [] {"*"})
                 );
                 Assert.Throws<ArgumentException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, directory, new[] { "**" }, FingerprintType.Key)
-                );
-                Assert.Throws<ArgumentException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, directory, new[] { "*" }, FingerprintType.Path)
-                );
-                Assert.Throws<ArgumentException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, directory, new[] { "**" }, FingerprintType.Path)
+                    () => FingerprintCreator.EvaluateKeyToFingerprint(context, directory, new [] {"**"})
                 );
             }
         }
@@ -99,9 +68,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]
-        public void Fingerprint_Key_ExcludeExactMatches()
+        public void Fingerprint_ExcludeExactMatches()
         {
-            using (var hostContext = new TestHostContext(this))
+            using(var hostContext = new TestHostContext(this))
             {
                 var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
                 var segments = new[]
@@ -109,7 +78,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                     $"{Path.GetDirectoryName(path1)},!{path1}",
                 };
                 Assert.Throws<AggregateException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, directory, segments, FingerprintType.Key)
+                    () => FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments)
                 );
             }
         }
@@ -117,206 +86,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_IncludeFullPathMatches()
+        public void Fingerprint_ExcludeExactMisses()
         {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var segments = new[]
-                {
-                    directory1,
-                    directory2
-                };
-
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path);
-                Assert.Equal(
-                    new[] { directory1Name, directory2Name }.OrderBy(x => x),
-                    f.Segments.OrderBy(x => x)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_IncludeRelativePathMatches()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var segments = new[]
-                {
-                    directory1Name,
-                    directory2Name
-                };
-
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path);
-                Assert.Equal(
-                    new[] { directory1Name, directory2Name }.OrderBy(x => x),
-                    f.Segments.OrderBy(x => x)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_IncludeGlobMatches()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var segments = new[]
-                {
-                    $"**/{directory1Name},**/{directory2Name}",
-                };
-
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path);
-                Assert.Equal(
-                    new[] { directory1Name, directory2Name }.OrderBy(x => x),
-                    f.Segments.OrderBy(x => x)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_ExcludeGlobMatches()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var segments = new[]
-                {
-                    $"**/{directory1Name},!**/{directory2Name}",
-                };
-
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path);
-                Assert.Equal(
-                    new[] { directory1Name },
-                    f.Segments
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_NoIncludePatterns()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var segments = new[]
-                {
-                    $"!**/{directory1Name},!**/{directory2Name}",
-                };
-
-                Assert.Throws<ArgumentException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_NoMatches()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var segments = new[]
-                {
-                    $"**/{Guid.NewGuid().ToString()},!**/{directory2Name}"
-                };
-
-                // TODO: Should this really be throwing an exception?
-                Assert.Throws<AggregateException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_SinglePathOutsidePipelineWorkspace()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var directoryInfo = new DirectoryInfo(workspaceRoot);
-                var segments = new[]
-                {
-                    directoryInfo.Parent.FullName,
-                };
-
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path);
-
-                Assert.Equal(1, f.Segments.Count());
-                Assert.Equal(
-                    new[] { Path.GetRelativePath(workspaceRoot, directoryInfo.Parent.FullName) },
-                    f.Segments
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_MultiplePathOutsidePipelineWorkspace()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var directoryInfo = new DirectoryInfo(workspaceRoot);
-                var segments = new[]
-                {
-                    directoryInfo.Parent.FullName,
-                    directory1Name,
-                };
-
-                Assert.Throws<AggregateException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Path_BacktracedGlobPattern()
-        {
-            using (var hostContext = new TestHostContext(this))
-            {
-                var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
-                var directoryInfo = new DirectoryInfo(workspaceRoot);
-                var segments = new[]
-                {
-                    $"{directoryInfo.Parent.FullName}/*",
-                };
-
-                Assert.Throws<AggregateException>(
-                    () => FingerprintCreator.EvaluateToFingerprint(context, workspaceRoot, segments, FingerprintType.Path)
-                );
-            }
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void Fingerprint_Key_ExcludeExactMisses()
-        {
-            using (var hostContext = new TestHostContext(this))
+            using(var hostContext = new TestHostContext(this))
             {
                 var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
                 var segments = new[]
                 {
                     $"{path1},!{path2}",
                 };
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, directory, segments, FingerprintType.Key);
+                Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
 
                 Assert.Equal(1, f.Segments.Length);
 
@@ -328,9 +107,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]
-        public void Fingerprint_Key_FileAbsolute()
+        public void Fingerprint_FileAbsolute()
         {
-            using (var hostContext = new TestHostContext(this))
+            using(var hostContext = new TestHostContext(this))
             {
                 var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
                 var segments = new[]
@@ -338,7 +117,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                     $"{path1}",
                     $"{path2}",
                 };
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, directory, segments, FingerprintType.Key);
+                Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
 
                 var file1 = new FingerprintCreator.MatchedFile(Path.GetFileName(path1), content1.Length, hash1.ToHex());
                 var file2 = new FingerprintCreator.MatchedFile(Path.GetFileName(path2), content2.Length, hash2.ToHex());
@@ -352,13 +131,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]
-        public void Fingerprint_Key_FileRelative()
+        public void Fingerprint_FileRelative()
         {
             string workingDir = Path.GetDirectoryName(path1);
             string relPath1 = Path.GetFileName(path1);
             string relPath2 = Path.GetFileName(path2);
 
-            using (var hostContext = new TestHostContext(this))
+            using(var hostContext = new TestHostContext(this))
             {
                 var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
                 context.SetVariable(
@@ -372,7 +151,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                     $"{relPath2}",
                 };
 
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, directory, segments, FingerprintType.Key);
+                Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
 
                 var file1 = new FingerprintCreator.MatchedFile(relPath1, content1.Length, hash1.ToHex());
                 var file2 = new FingerprintCreator.MatchedFile(relPath2, content2.Length, hash2.ToHex());
@@ -386,9 +165,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]
-        public void Fingerprint_Key_Str()
+        public void Fingerprint_Str()
         {
-            using (var hostContext = new TestHostContext(this))
+            using(var hostContext = new TestHostContext(this))
             {
                 var context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
                 var segments = new[]
@@ -396,7 +175,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
                     $"hello",
                 };
 
-                Fingerprint f = FingerprintCreator.EvaluateToFingerprint(context, directory, segments, FingerprintType.Key);
+                Fingerprint f = FingerprintCreator.EvaluateKeyToFingerprint(context, directory, segments);
 
                 Assert.Equal(1, f.Segments.Length);
                 Assert.Equal($"hello", f.Segments[0]);
@@ -408,13 +187,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Trait("Category", "Plugin")]
         public void ParseMultilineKeyAsOld()
         {
-            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys, string[] pathSegments) = PipelineCacheTaskPluginBase.ParseIntoSegments(
+            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys) = PipelineCacheTaskPluginBase.ParseIntoSegments(
                 string.Empty,
                 "gems\n$(Agent.OS)\n$(Build.SourcesDirectory)/my.gemspec",
-                string.Empty,
                 string.Empty);
             Assert.True(isOldFormat);
-            Assert.Equal(new[] { "gems", "$(Agent.OS)", "$(Build.SourcesDirectory)/my.gemspec" }, keySegments);
+            Assert.Equal(new [] {"gems", "$(Agent.OS)", "$(Build.SourcesDirectory)/my.gemspec"}, keySegments);
             Assert.Equal(0, restoreKeys.Count());
         }
 
@@ -423,13 +201,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Trait("Category", "Plugin")]
         public void ParseSingleLineAsNew()
         {
-            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys, string[] pathSegments) = PipelineCacheTaskPluginBase.ParseIntoSegments(
+            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys) = PipelineCacheTaskPluginBase.ParseIntoSegments(
                 string.Empty,
                 "$(Agent.OS)",
-                string.Empty,
                 string.Empty);
             Assert.False(isOldFormat);
-            Assert.Equal(new[] { "$(Agent.OS)" }, keySegments);
+            Assert.Equal(new [] {"$(Agent.OS)"}, keySegments);
             Assert.Equal(0, restoreKeys.Count());
         }
 
@@ -438,28 +215,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         [Trait("Category", "Plugin")]
         public void ParseMultilineWithRestoreKeys()
         {
-            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys, string[] pathSegments) = PipelineCacheTaskPluginBase.ParseIntoSegments(
+            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys) = PipelineCacheTaskPluginBase.ParseIntoSegments(
                 string.Empty,
                 "$(Agent.OS) | Gemfile.lock | **/*.gemspec,!./junk/**",
-                "$(Agent.OS) | Gemfile.lock\n$(Agent.OS)",
-                string.Empty);
+                "$(Agent.OS) | Gemfile.lock\n$(Agent.OS)");
             Assert.False(isOldFormat);
-            Assert.Equal(new[] { "$(Agent.OS)", "Gemfile.lock", "**/*.gemspec,!./junk/**" }, keySegments);
-            Assert.Equal(new[] { new[] { "$(Agent.OS)", "Gemfile.lock" }, new[] { "$(Agent.OS)" } }, restoreKeys);
-        }
-
-        [Fact]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void ParsePathSegments()
-        {
-            (bool isOldFormat, string[] keySegments, IEnumerable<string[]> restoreKeys, string[] pathSegments) = PipelineCacheTaskPluginBase.ParseIntoSegments(
-                string.Empty,
-                string.Empty,
-                string.Empty,
-                "node_modules | dist | **/globby.*,!**.exclude");
-            Assert.False(isOldFormat);
-            Assert.Equal(new[] { "node_modules", "dist", "**/globby.*,!**.exclude" }, pathSegments);
+            Assert.Equal(new [] {"$(Agent.OS)","Gemfile.lock","**/*.gemspec,!./junk/**"}, keySegments);
+            Assert.Equal(new [] {new []{ "$(Agent.OS)","Gemfile.lock"}, new[] {"$(Agent.OS)"}}, restoreKeys);
         }
     }
 }

--- a/src/Test/L0/Plugin/IsPathyTests.cs
+++ b/src/Test/L0/Plugin/IsPathyTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCache
         public void Fingerprint_IsPath()
         {
             Action<string,bool> assertPath = (path, isPath) =>
-                Assert.True(isPath == FingerprintCreator.IsPathySegment(path), $"IsPathy({path}) should have returned {isPath}.");
+                Assert.True(isPath == FingerprintCreator.IsPathyKeySegment(path), $"IsPathy({path}) should have returned {isPath}.");
             assertPath(@"''", false);
             assertPath(@"Windows_NT", false);
             assertPath(@"README.md", true);

--- a/src/Test/L0/Plugin/TarUtilsL0.cs
+++ b/src/Test/L0/Plugin/TarUtilsL0.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.PipelineCaching
 {
-    public class TarUtilsL0 {
+    public  class TarUtilsL0 {
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]


### PR DESCRIPTION
Revert #2834

We have gotten a couple of different bug reports related to this change.

See #3159 and https://developercommunity.visualstudio.com/content/problem/1248953/azure-pipelines-cache-task-now-fails-with-path-tha.html
