### PR TITLE
Add pipelines-agent-* packages without Node 6

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -11,15 +11,12 @@ parameters:
 
 - name: container
   type: string
-  default: ''
 
 - name: timeoutInMinutes
   type: number
-  default: 60
 
 - name: branch
   type: string
-  default: ''
 
 - name: os
   type: string
@@ -39,15 +36,12 @@ parameters:
 
 - name: unitTests
   type: boolean
-  default: true
 
 - name: functionalTests
   type: boolean
-  default: true
 
 - name: codeCoverage
   type: boolean
-  default: false
 
 - name: componentDetection
   type: boolean
@@ -57,7 +51,6 @@ parameters:
 
 - name: verifySigning
   type: boolean
-  default: false
 
 - name: publishArtifact
   type: boolean
@@ -66,6 +59,12 @@ parameters:
   type: boolean
   default: false
 
+- name: packageType
+  type: string
+  default: agent
+  values:
+  - agent
+  - pipelines-agent
 
 jobs:
 
@@ -78,6 +77,7 @@ jobs:
     container: ${{ parameters.container }}
 
   variables:
+    PACKAGE_TYPE: ${{ parameters.packageType }}
     ${{ if eq(parameters.os, 'win') }}:
       devCommand: dev.cmd
     ${{ if ne(parameters.os, 'win') }}:
@@ -87,7 +87,7 @@ jobs:
   steps:
 
   # Component detection
-  - ${{ if eq(parameters.componentDetection, true) }}:
+  - ${{ if parameters.componentDetection }}:
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
       displayName: 'Component Detection'
 
@@ -105,7 +105,7 @@ jobs:
   - script: ${{ variables.devCommand }} layout Release
     workingDirectory: src
     displayName: Build & Layout Release
-    ${{ if eq(parameters.enableADOLogIssue, true) }}:
+    ${{ if parameters.enableADOLogIssue }}:
       env:
         ADO_ENABLE_LOGISSUE: true
 

--- a/.azure-pipelines/build-jobs.yml
+++ b/.azure-pipelines/build-jobs.yml
@@ -1,0 +1,101 @@
+parameters:
+
+- name: jobName
+  type: string
+
+- name: displayName
+  type: string
+
+- name: pool
+  type: object
+
+- name: container
+  type: string
+  default: ''
+
+- name: timeoutInMinutes
+  type: number
+  default: 60
+
+- name: branch
+  type: string
+  default: ''
+
+- name: os
+  type: string
+
+- name: arch
+  type: string
+
+- name: unitTests
+  type: boolean
+  default: true
+
+- name: functionalTests
+  type: boolean
+  default: true
+
+- name: codeCoverage
+  type: boolean
+  default: false
+
+- name: componentDetection
+  type: boolean
+
+- name: sign
+  type: boolean
+
+- name: verifySigning
+  type: boolean
+  default: false
+
+- name: publishArtifacts
+  type: boolean
+
+- name: enableADOLogIssue
+  type: boolean
+  default: false
+
+- name: buildAlternatePackage
+  type: boolean
+  default: false
+
+jobs:
+  - template: build-job.yml
+    parameters:
+      jobName: ${{ parameters.jobName }}
+      displayName: ${{ parameters.displayName }}
+      pool: ${{ parameters.pool }}
+      container: ${{ parameters.container }}
+      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      os: ${{ parameters.os }}
+      arch: ${{ parameters.arch }}
+      branch: ${{ parameters.branch }}
+      codeCoverage: ${{ parameters.codeCoverage }}
+      componentDetection: ${{ parameters.componentDetection }}
+      unitTests: ${{ parameters.unitTests }}
+      functionalTests: ${{ parameters.functionalTests }}
+      sign: ${{ parameters.sign }}
+      verifySigning: ${{ parameters.sign }}
+      publishArtifact: ${{ parameters.publishArtifacts }}
+      packageType: agent
+
+  - ${{ if parameters.buildAlternatePackage }}:
+    - template: build-job.yml
+      parameters:
+        jobName: ${{ parameters.jobName }}_alternate
+        displayName: ${{ parameters.displayName }} (without Node 6)
+        pool: ${{ parameters.pool }}
+        container: ${{ parameters.container }}
+        timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+        os: ${{ parameters.os }}
+        arch: ${{ parameters.arch }}
+        branch: ${{ parameters.branch }}
+        codeCoverage: false
+        componentDetection: ${{ parameters.componentDetection }}
+        unitTests: false
+        functionalTests: false
+        sign: ${{ parameters.sign }}
+        verifySigning: ${{ parameters.sign }}
+        publishArtifact: ${{ parameters.publishArtifacts }}
+        packageType: pipelines-agent

--- a/.azure-pipelines/build-jobs.yml
+++ b/.azure-pipelines/build-jobs.yml
@@ -76,7 +76,7 @@ jobs:
       unitTests: ${{ parameters.unitTests }}
       functionalTests: ${{ parameters.functionalTests }}
       sign: ${{ parameters.sign }}
-      verifySigning: ${{ parameters.sign }}
+      verifySigning: ${{ parameters.verifySigning }}
       publishArtifact: ${{ parameters.publishArtifacts }}
       packageType: agent
 
@@ -96,6 +96,6 @@ jobs:
         unitTests: false
         functionalTests: false
         sign: ${{ parameters.sign }}
-        verifySigning: ${{ parameters.sign }}
+        verifySigning: ${{ parameters.verifySigning }}
         publishArtifact: ${{ parameters.publishArtifacts }}
         packageType: pipelines-agent

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -17,6 +17,9 @@ parameters:
 - name: publishArtifacts
   type: boolean
   default: false
+- name: buildAlternatePackage
+  type: boolean
+  default: true
 - name: branch
   type: string
   default: ''
@@ -59,12 +62,12 @@ stages:
   displayName: Build
   jobs:
 
-  # Windows x64
+  # Windows (x64)
   - ${{ if parameters.win_x64 }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_windows_x64_agent
-        displayName: Windows Agent (x64)
+        jobName: build_windows_x64
+        displayName: Windows (x64)
         pool:
           vmImage: vs2017-win2016
         os: win
@@ -76,14 +79,34 @@ stages:
         functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
         verifySigning: ${{ parameters.sign }}
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
+
+    - ${{ if parameters.buildAlternatePackage }}:
+      - template: build-job.yml
+        parameters:
+          jobName: build_windows_x64_alternate
+          displayName: Windows Agent (x64) (without Node 6)
+          pool:
+            vmImage: vs2017-win2016
+          os: win
+          arch: x64
+          branch: ${{ parameters.branch }}
+          codeCoverage: true
+          componentDetection: ${{ parameters.componentDetection }}
+          unitTests: false
+          functionalTests: false
+          sign: ${{ parameters.sign }}
+          verifySigning: ${{ parameters.sign }}
+          publishArtifact: ${{ parameters.publishArtifacts }}
+          packageType: pipelines-agent
 
   # Windows (x86)
   - ${{ if parameters.win_x86 }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_windows_x86_agent
-        displayName: Windows Agent (x86)
+        jobName: build_windows_x86
+        displayName: Windows (x86)
         pool:
           name: buildDevs
           demands: 'Agent.OSArchitecture -equals X86'
@@ -94,14 +117,15 @@ stages:
         unitTests: ${{ parameters.test }}
         functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
   # Linux (x64)
   - ${{ if parameters.linux_x64 }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_linux_x64_agent
-        displayName: Linux Agent (x64)
+        jobName: build_linux_x64
+        displayName: Linux (x64)
         pool:
           vmImage: ubuntu-16.04
         os: linux
@@ -111,14 +135,15 @@ stages:
         unitTests: ${{ parameters.test }}
         functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
   # Linux (ARM)
   - ${{ if parameters.linux_arm }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_linux_arm_agent
-        displayName: Linux Agent (ARM)
+        jobName: build_linux_arm
+        displayName: Linux (ARM)
         pool:
           name: buildDevs
           demands: 'Agent.OSArchitecture -equals ARM'
@@ -131,14 +156,15 @@ stages:
         unitTests: ${{ parameters.test }}
         functionalTests: false
         sign: false
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
   # Linux (ARM64)
   - ${{ if parameters.linux_arm64 }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_linux_arm64_agent
-        displayName: Linux Agent (ARM64)
+        jobName: build_linux_arm64
+        displayName: Linux (ARM64)
         pool:
           name: buildDevs
           demands: 'Agent.OSArchitecture -equals ARM64'
@@ -150,14 +176,15 @@ stages:
         unitTests: ${{ parameters.test }}
         functionalTests: ${{ parameters.test }}
         sign: false
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
-  # RHEL6 Agent (x64)
+  # RHEL6 (x64)
   - ${{ if parameters.rhel6_x64 }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_rhel6_x64_agent
-        displayName: RHEL6 Agent (x64)
+        jobName: build_rhel6_x64
+        displayName: RHEL6 (x64)
         pool:
           vmImage: ubuntu-16.04
         container: dotnetcore_centos6
@@ -168,14 +195,15 @@ stages:
         unitTests: ${{ parameters.test }}
         functionalTests: ${{ parameters.test }}
         sign: false
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
   # macOS x64
   - ${{ if parameters.macOS_x64 }}:
-    - template: build-job.yml
+    - template: build-jobs.yml
       parameters:
-        jobName: build_osx_agent
-        displayName: macOS Agent (x64)
+        jobName: build_osx
+        displayName: macOS (x64)
         pool:
           vmImage: macOS-10.14
         os: osx
@@ -185,6 +213,7 @@ stages:
         unitTests: ${{ parameters.test }}
         functionalTests: ${{ parameters.test }}
         sign: ${{ parameters.sign }}
-        publishArtifact: ${{ parameters.publishArtifacts }}
+        publishArtifacts: ${{ parameters.publishArtifacts }}
+        buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
 - ${{ parameters.postBuildStages }}

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -82,25 +82,6 @@ stages:
         publishArtifacts: ${{ parameters.publishArtifacts }}
         buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
-    - ${{ if parameters.buildAlternatePackage }}:
-      - template: build-job.yml
-        parameters:
-          jobName: build_windows_x64_alternate
-          displayName: Windows Agent (x64) (without Node 6)
-          pool:
-            vmImage: vs2017-win2016
-          os: win
-          arch: x64
-          branch: ${{ parameters.branch }}
-          codeCoverage: true
-          componentDetection: ${{ parameters.componentDetection }}
-          unitTests: false
-          functionalTests: false
-          sign: ${{ parameters.sign }}
-          verifySigning: ${{ parameters.sign }}
-          publishArtifact: ${{ parameters.publishArtifacts }}
-          packageType: pipelines-agent
-
   # Windows (x86)
   - ${{ if parameters.win_x86 }}:
     - template: build-jobs.yml

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -41,6 +41,7 @@ extends:
   parameters:
     componentDetection: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
     publishArtifacts: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
+    buildAlternatePackage: false
     win_x64: ${{ parameters.win_x64 }}
     win_x86: ${{ parameters.win_x86 }}
     linux_x64: ${{ parameters.linux_x64 }}

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -94,14 +94,15 @@ extends:
               Login-AzureRmAccount -ServicePrincipal -CertificateThumbprint $certificateThumbprint -ApplicationId $clientId -TenantId $(TenantId)
               Select-AzureRmSubscription -SubscriptionId $(SubscriptionId)
               $storage = Get-AzureRmStorageAccount -ResourceGroupName vstsagentpackage -AccountName vstsagentpackage
+              $versionDir = "${{ parameters.version }}"
               Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
-                $executable = (Get-ChildItem "$(System.ArtifactsDirectory)/agent/$_")[0]
-                $versionDir = $executable.Name.Trim('.zip').Trim('.tar.gz')
-                $versionDir = $versionDir.SubString($versionDir.LastIndexOf('-') + 1)
-                Write-Host "##vso[task.setvariable variable=ReleaseAgentVersion;]$versionDir"
-                Write-Host "Uploading $executable to BlobStorage vstsagentpackage/agent/$versionDir"
-                Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$_/$executable" -Blob "$versionDir/$executable" -Force
-                $uploadFiles.Add("/agent/$versionDir/$executable")
+                $target=$_
+                Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent/$target" -Include "*.zip","*.tar.gz" | ForEach-Object {
+                  $executable = $_
+                  Write-Host "Uploading $executable to BlobStorage vstsagentpackage/agent/$versionDir"
+                  Set-AzureStorageBlobContent -Context $storage.Context -Container agent -File "$(System.ArtifactsDirectory)/agent/$target/$executable" -Blob "$versionDir/$executable" -Force
+                  $uploadFiles.Add("/agent/$versionDir/$executable")
+                }
               }
               Write-Host "Purge Azure CDN Cache"
               Unpublish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -PurgeContent $uploadFiles
@@ -112,11 +113,11 @@ extends:
           # Create agent release on Github
           - powershell: |
               Write-Host "Creating github release."
-              $releaseNotes = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\releaseNote.md").Replace("<AGENT_VERSION>","$(ReleaseAgentVersion)")
+              $releaseNotes = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\releaseNote.md").Replace("<AGENT_VERSION>","${{ parameters.version }}")
               $releaseData = @{
-                tag_name = "v$(ReleaseAgentVersion)";
+                tag_name = "v${{ parameters.version }}";
                 target_commitish = "$(Build.SourceVersion)";
-                name = "v$(ReleaseAgentVersion)";
+                name = "v${{ parameters.version }}";
                 body = $releaseNotes;
                 draft = $false;
                 prerelease = $true;
@@ -134,7 +135,7 @@ extends:
               $releaseCreated = Invoke-RestMethod @releaseParams
               Write-Host $releaseCreated
               $releaseId = $releaseCreated.id
-              $assets = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\assets.json").Replace("<AGENT_VERSION>","$(ReleaseAgentVersion)")
+              $assets = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\assets.json").Replace("<AGENT_VERSION>","${{ parameters.version }}")
               $assetsParams = @{
                 Uri = "https://uploads.github.com/repos/Microsoft/azure-pipelines-agent/releases/$releaseId/assets?name=assets.json"
                 Method = 'POST';

--- a/assets.json
+++ b/assets.json
@@ -6,10 +6,22 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip"
     },
     {
+        "name": "pipelines-agent-win-x64-<AGENT_VERSION>.zip",
+        "platform": "win-x64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip"
+    },
+    {
         "name": "vsts-agent-win-x86-<AGENT_VERSION>.zip",
         "platform": "win-x86",
         "version": "<AGENT_VERSION>",
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip"
+    },
+    {
+        "name": "pipelines-agent-win-x86-<AGENT_VERSION>.zip",
+        "platform": "win-x86",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip"
     },
     {
         "name": "vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz",
@@ -18,10 +30,22 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz"
     },
     {
+        "name": "pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz",
+        "platform": "osx-x64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz"
+    },
+    {
         "name": "vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-x64",
         "version": "<AGENT_VERSION>",
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz"
+    },
+    {
+        "name": "pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz",
+        "platform": "linux-x64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz",
@@ -30,15 +54,33 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz"
     },
     {
+        "name": "pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz",
+        "platform": "linux-arm",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz"
+    },
+    {
         "name": "vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-arm64",
         "version": "<AGENT_VERSION>",
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
     },
     {
+        "name": "pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz",
+        "platform": "linux-arm64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
+    },
+    {
         "name": "vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz",
         "platform": "rhel.6-x64",
         "version": "<AGENT_VERSION>",
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz"
+    },
+    {
+        "name": "pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz",
+        "platform": "rhel.6-x64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz"
     }
 ]

--- a/docs/node6.md
+++ b/docs/node6.md
@@ -1,0 +1,9 @@
+# Node 6 and Agent Packages
+
+Agent tasks can be implemented in PowerShell or Node. The agent currently ships with two versions of Node that tasks can target: 6 & 10.
+
+Node 6 has long since passed out of the upstream maintenance window, however many Pipelines tasks depend on it. Azure DevOps is currently in the process of migrating all offically supported tasks to Node 10. Third party tasks will need to be updated by their maintainers to migrate to Node 10.
+
+For these reasons, packages of the agent (named vsts-agent-*) that include Node 6 will continue to be made available for the forseeable future. Node 6 dependent tasks will continue be supported in hosted pools.
+
+However, because Node 6 is no longer maintained, many customers do not want it installed on their systems. For customers who know for sure they are not using Node 6 dependent tasks, we provide alternate packages (pipelines-agent-*) that only include Node 10. In the future, once all officially supported tasks have been updated for Node 10, these packages will because the primarily recommended ones.

--- a/docs/node6.md
+++ b/docs/node6.md
@@ -6,4 +6,4 @@ Node 6 has long since passed out of the upstream maintenance window, however man
 
 For these reasons, packages of the agent (named vsts-agent-*) that include Node 6 will continue to be made available for the forseeable future. Node 6 dependent tasks will continue be supported in hosted pools.
 
-However, because Node 6 is no longer maintained, many customers do not want it installed on their systems. For customers who know for sure they are not using Node 6 dependent tasks, we provide alternate packages (pipelines-agent-*) that only include Node 10. In the future, once all officially supported tasks have been updated for Node 10, these packages will because the primarily recommended ones.
+However, because Node 6 is no longer maintained, many customers do not want it installed on their systems. For customers who know for sure they are not using Node 6 dependent tasks, we provide alternate packages (pipelines-agent-*) that only include Node 10. In the future, once all officially supported tasks have been updated for Node 10, these packages will become the primarily recommended ones.

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -1,15 +1,15 @@
 
 ## Agent Downloads
 
-|         | Package | Alternate Package ([without Node 6](docs/node6.md))
-| ------- | --------| ------- |
-| Windows x64 | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) |
-| Windows x86 | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) |
-| macOS   | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) |
-| Linux x64  | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
-| Linux ARM  | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
-| Linux ARM64  | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |[pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
-| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |
+|             | Package |
+| ----------- | ------- |
+| Windows x64 | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) |
+| Windows x86 | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) |
+| macOS       | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) |
+| Linux x64   | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
+| Linux ARM   | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
+| Linux ARM64 | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
+| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |
 
 After Download:
 
@@ -61,3 +61,18 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 ~/$ mkdir myagent && cd myagent
 ~/myagent$ tar xzf ~/Downloads/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
 ```
+
+## Alternate Agent Downloads
+
+This following alternate packages do not include Node 6 and are only suitable for users who do not use Node 6 dependent tasks. 
+See [notes](docs/node6.md) on Node version support for more details.
+
+|             | Package |
+| ----------- | ------- |
+| Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) |
+| Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) |
+| macOS       | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) |
+| Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
+| Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
+| Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
+| RHEL 6 x64  | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -1,15 +1,15 @@
 
 ## Agent Downloads
 
-|         | Package                                                                                                       |
-| ------- | ----------------------------------------------------------------------------------------------------------- |
-| Windows x64 | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip)      |
-| Windows x86 | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip)      |
-| macOS   | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz)   |
-| Linux x64  | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
-| Linux ARM  | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
-| Linux ARM64  | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
-| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |
+|         | Package | Alternate Package ([without Node 6](docs/node6.md))
+| ------- | --------| ------- |
+| Windows x64 | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) |
+| Windows x86 | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) |
+| macOS   | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) |
+| Linux x64  | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
+| Linux ARM  | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
+| Linux ARM64  | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |[pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
+| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |
 
 After Download:
 

--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
     public class SelfUpdater : AgentService, ISelfUpdater
     {
-        private static string _packageType = "agent";
+        private static string _packageType = BuildConstants.AgentPackage.PackageType;
         private static string _platform = BuildConstants.AgentPackage.PackageName;
         private static UpdaterKnobValueContext _knobContext = new UpdaterKnobValueContext();
 

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -9,9 +9,19 @@
         <AddTaskPackageData packageType="agent" platform="osx-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add OSX alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="osx-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
     <ServicingStep name="Add x64 Linux agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="agent" platform="linux-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add x64 Linux alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM Linux agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
@@ -19,9 +29,19 @@
         <AddTaskPackageData packageType="agent" platform="linux-arm" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add ARM Linux alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
     <ServicingStep name="Add ARM64 Linux agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="agent" platform="linux-arm64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add ARM64 Linux alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
@@ -29,14 +49,29 @@
         <AddTaskPackageData packageType="agent" platform="win-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x64-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add x64 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x64-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
     <ServicingStep name="Add x86 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="agent" platform="win-x86" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add x86 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
     <ServicingStep name="Add x64 Redhat 6 agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="agent" platform="rhel.6-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add x64 Redhat 6 alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.6-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
   </Steps>

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -4,6 +4,8 @@ PRECACHE=$2
 LAYOUT_DIR=$3
 L1_MODE=$4
 
+INCLUDE_NODE6=${INCLUDE_NODE6:-true}
+
 CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
@@ -147,8 +149,10 @@ if [[ "$PACKAGERUNTIME" == "win-x64" ]]; then
     acquireExternalTool "$CONTAINER_URL/vstsom/m122_887c6659/vstsom.zip" vstsom
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_d91bed0b/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.exe" node/bin
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.lib" node/bin
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.exe" node/bin
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.lib" node/bin
+    fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x64/node.exe" node10/bin
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x64/node.lib" node10/bin
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" nuget
@@ -160,8 +164,10 @@ if [[ "$PACKAGERUNTIME" == "win-x86" ]]; then
     acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_d91bed0b/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x86/node.exe" node/bin
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x86/node.lib" node/bin
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x86/node.exe" node/bin
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x86/node.lib" node/bin
+    fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x86/node.exe" node10/bin
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x86/node.lib" node10/bin
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" nuget
@@ -169,7 +175,9 @@ fi
 
 # Download the external tools only for OSX.
 if [[ "$PACKAGERUNTIME" == "osx-x64" ]]; then
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-x64.tar.gz" node fix_nested_dir
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-x64.tar.gz" node fix_nested_dir
+    fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-darwin-x64.tar.gz" node10 fix_nested_dir
 fi
 
@@ -181,17 +189,23 @@ fi
 
 # Download the external tools common across Linux PACKAGERUNTIMEs (excluding OSX).
 if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "rhel.6-x64" ]]; then
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" node fix_nested_dir
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" node fix_nested_dir
+    fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-x64.tar.gz" node10 fix_nested_dir
 fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-armv7l.tar.gz" node fix_nested_dir
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-armv7l.tar.gz" node fix_nested_dir
+    fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-armv7l.tar.gz" node10 fix_nested_dir
 fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
-    acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.gz" node fix_nested_dir
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.gz" node fix_nested_dir
+    fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-arm64.tar.gz" node10 fix_nested_dir
 fi
 

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -45,6 +45,7 @@
         <BuildConstants Include="%20%20%20%20%20%20%20%20}%0A"/>
         <BuildConstants Include="%20%20%20%20%20%20%20%20public static class AgentPackage"/>
         <BuildConstants Include="%20%20%20%20%20%20%20%20{"/>
+        <BuildConstants Include="%20%20%20%20%20%20%20%20%20%20%20%20public static readonly string PackageType = %22$(PackageType)%22%3B"/>
         <BuildConstants Include="%20%20%20%20%20%20%20%20%20%20%20%20public static readonly string PackageName = %22$(PackageRuntime)%22%3B"/>
         <BuildConstants Include="%20%20%20%20%20%20%20%20%20%20%20%20public static readonly string Version = %22$(AgentVersion)%22%3B"/>
         <BuildConstants Include="%20%20%20%20%20%20%20%20}"/>


### PR DESCRIPTION
Builds alternate packages of the agent that do not include Node 6. These packages are named with the prefix "pipelines-agent" rather than something that conveys their Node6-lessness specifically on the assumption that they will eventually become the default and the vsts-* ones will become legacy. I wanted to avoid introducing temporary naming conventions.

The build has been updated to add a different PackageType constant to BuildConstants ("agent" or "pipelines-agent") based on which package you are building. The default continues to be "agent". This will allow us to add the separate, Node6-less "pipelines-agent" packages to ADO and agent self-update will pull the correct packages.

Example build: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=13648142&view=results