### PR TITLE
[Security] Add a check of the agent's root directory access rules

### DIFF
--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -89,10 +89,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     IdentityReference bulitInUsersGroup = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null).Translate(typeof(NTAccount));
 
                     // Check if BUILTIN\Users group have modify/write rights for the agent root folder
-                    List<FileSystemAccessRule> potentiallyInsecureRules = (from rule in dirAccessRules.OfType<FileSystemAccessRule>().AsParallel()
-                                                                           where rule.IdentityReference == bulitInUsersGroup &&
-                                                                                 (rule.FileSystemRights.HasFlag(FileSystemRights.Write) || rule.FileSystemRights.HasFlag(FileSystemRights.Modify))
-                                                                           select rule).ToList<FileSystemAccessRule>();
+                    List<FileSystemAccessRule> potentiallyInsecureRules = dirAccessRules.OfType<FileSystemAccessRule>().AsParallel()
+                                                                          .Where(rule => rule.IdentityReference == bulitInUsersGroup && (rule.FileSystemRights.HasFlag(FileSystemRights.Write) || rule.FileSystemRights.HasFlag(FileSystemRights.Modify)))
+                                                                          .ToList<FileSystemAccessRule>();
 
                     // Notify user if there are some potentially insecure access rules for the agent root folder
                     if (potentiallyInsecureRules.Count != 0)

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -67,54 +67,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             return settings;
         }
 
-        private void checkAgentRootDirectorySecure()
-        {
-            Trace.Info(nameof(checkAgentRootDirectorySecure));
-
-            try
-            {
-                string rootDirPath = HostContext.GetDirectory(WellKnownDirectory.Root);
-
-                if (!String.IsNullOrEmpty(rootDirPath))
-                {
-                    // Get info about root folder
-                    DirectoryInfo dirInfo = new DirectoryInfo(rootDirPath);
-
-                    // Get directory access control list 
-                    DirectorySecurity directorySecurityInfo = dirInfo.GetAccessControl();
-                    AuthorizationRuleCollection dirAccessRules = directorySecurityInfo.GetAccessRules(true, true, typeof(NTAccount));
-
-
-                    // Get identity reference of the BUILTIN\Users group
-                    IdentityReference bulitInUsersGroup = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null).Translate(typeof(NTAccount));
-
-                    // Check if BUILTIN\Users group have modify/write rights for the agent root folder
-                    List<FileSystemAccessRule> potentiallyInsecureRules = dirAccessRules.OfType<FileSystemAccessRule>().AsParallel()
-                                                                          .Where(rule => rule.IdentityReference == bulitInUsersGroup && (rule.FileSystemRights.HasFlag(FileSystemRights.Write) || rule.FileSystemRights.HasFlag(FileSystemRights.Modify)))
-                                                                          .ToList<FileSystemAccessRule>();
-
-                    // Notify user if there are some potentially insecure access rules for the agent root folder
-                    if (potentiallyInsecureRules.Count != 0)
-                    {
-                        Trace.Warning("The {0} group have the following permissions to the agent root folder: ", bulitInUsersGroup.ToString());
-
-                        potentiallyInsecureRules.ForEach(accessRule => Trace.Warning("- {0}", accessRule.FileSystemRights.ToString()));
-
-                        _term.Write(StringUtil.Loc("agentRootFolderInsecure", bulitInUsersGroup.ToString()));
-                    }
-                }
-                else 
-                {
-                    Trace.Warning("Can't get path to the agent root folder, check was skipped.");
-                }
-            }
-            catch (Exception ex) {
-                Trace.Warning("Can't check permissions for agent root folder:");
-                Trace.Warning(ex.Message);
-                _term.Write(StringUtil.Loc("agentRootFolderCheckError"));
-            }
-        }
-
         public async Task ConfigureAsync(CommandSettings command)
         {
             ArgUtil.NotNull(command, nameof(command));

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             return settings;
         }
 
-        public void checkAgentRootDirectorySecure()
+        private void checkAgentRootDirectorySecure()
         {
             Trace.Info(nameof(checkAgentRootDirectorySecure));
 

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -106,19 +106,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     if (potentiallyInsecureRules.Count != 0)
                     {
                         Trace.Warning("The {0} group have the following right to the agent root folder: ", bulitInUsersGroup.ToString());
+
                         foreach (FileSystemAccessRule accessRule in potentiallyInsecureRules)
                         {
-                            Trace.Warning("- {0} ", accessRule.FileSystemRights.ToString());
+                            Trace.Warning("- {0}", accessRule.FileSystemRights.ToString());
                         }
 
-                        _term.WriteError(StringUtil.Loc("agentRootFolderInsecure", bulitInUsersGroup.ToString()));
+                        _term.Write(StringUtil.Loc("agentRootFolderInsecure", bulitInUsersGroup.ToString()));
                     }
                 }
             }
             catch (Exception ex) {
-                Trace.Error("Catch exception during checking access right of the agent root folder.");
-                Trace.Error(ex);
-                _term.WriteError(StringUtil.Loc("agentRootFolderCheckError"));
+                Trace.Warning("Catch exception during checking access right of the agent root folder.");
+                Trace.Warning(ex.Message);
+                _term.Write(StringUtil.Loc("agentRootFolderCheckError"));
             }
         }
 

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -67,61 +67,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             return settings;
         }
 
-        private void checkAgentRootDirectorySecure()
-        {
-            Trace.Info(nameof(checkAgentRootDirectorySecure));
-
-            try
-            {
-                string rootDirPath = HostContext.GetDirectory(WellKnownDirectory.Root);
-
-                if (!String.IsNullOrEmpty(rootDirPath))
-                {
-                    // Get info about root folder
-                    DirectoryInfo dirInfo = new DirectoryInfo(rootDirPath);
-
-                    // Get directory access control list 
-                    DirectorySecurity directorySecurityInfo = dirInfo.GetAccessControl();
-                    AuthorizationRuleCollection dirAccessRules = directorySecurityInfo.GetAccessRules(true, true, typeof(NTAccount));
-
-
-                    // Get identity reference of the BUILTIN\Users group
-                    IdentityReference bulitInUsersGroup = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null).Translate(typeof(NTAccount));
-
-                    // Check if BUILTIN\Users group have modify/write rights for the agent root folder
-                    List<FileSystemAccessRule> potentiallyInsecureRules = dirAccessRules.OfType<FileSystemAccessRule>().AsParallel()
-                                                                          .Where(rule => rule.IdentityReference == bulitInUsersGroup && (rule.FileSystemRights.HasFlag(FileSystemRights.Write) || rule.FileSystemRights.HasFlag(FileSystemRights.Modify)))
-                                                                          .ToList<FileSystemAccessRule>();
-
-                    // Notify user if there are some potentially insecure access rules for the agent root folder
-                    if (potentiallyInsecureRules.Count != 0)
-                    {
-                        Trace.Warning("The {0} group have the following permissions to the agent root folder: ", bulitInUsersGroup.ToString());
-
-                        potentiallyInsecureRules.ForEach(accessRule => Trace.Warning("- {0}", accessRule.FileSystemRights.ToString()));
-
-                        _term.Write(StringUtil.Loc("agentRootFolderInsecure", bulitInUsersGroup.ToString()));
-                    }
-                }
-                else 
-                {
-                    Trace.Warning("Can't get path to the agent root folder, check was skipped.");
-                }
-            }
-            catch (Exception ex) {
-                Trace.Warning("Can't check permissions for agent root folder:");
-                Trace.Warning(ex.Message);
-                _term.Write(StringUtil.Loc("agentRootFolderCheckError"));
-            }
-        }
-
         public async Task ConfigureAsync(CommandSettings command)
         {
             ArgUtil.NotNull(command, nameof(command));
 
             if (PlatformUtil.RunningOnWindows)
             { 
-                checkAgentRootDirectorySecure();
+                CheckAgentRootDirectorySecure();
             }
 
             Trace.Info(nameof(ConfigureAsync));
@@ -770,6 +722,54 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             _term.WriteLine();
             _term.WriteLine($">> {message}:");
             _term.WriteLine();
+        }
+
+        private void CheckAgentRootDirectorySecure()
+        {
+            Trace.Info(nameof(CheckAgentRootDirectorySecure));
+
+            try
+            {
+                string rootDirPath = HostContext.GetDirectory(WellKnownDirectory.Root);
+
+                if (!String.IsNullOrEmpty(rootDirPath))
+                {
+                    // Get info about root folder
+                    DirectoryInfo dirInfo = new DirectoryInfo(rootDirPath);
+
+                    // Get directory access control list 
+                    DirectorySecurity directorySecurityInfo = dirInfo.GetAccessControl();
+                    AuthorizationRuleCollection dirAccessRules = directorySecurityInfo.GetAccessRules(true, true, typeof(NTAccount));
+
+
+                    // Get identity reference of the BUILTIN\Users group
+                    IdentityReference bulitInUsersGroup = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null).Translate(typeof(NTAccount));
+
+                    // Check if BUILTIN\Users group have modify/write rights for the agent root folder
+                    List<FileSystemAccessRule> potentiallyInsecureRules = dirAccessRules.OfType<FileSystemAccessRule>().AsParallel()
+                                                                          .Where(rule => rule.IdentityReference == bulitInUsersGroup && (rule.FileSystemRights.HasFlag(FileSystemRights.Write) || rule.FileSystemRights.HasFlag(FileSystemRights.Modify)))
+                                                                          .ToList<FileSystemAccessRule>();
+
+                    // Notify user if there are some potentially insecure access rules for the agent root folder
+                    if (potentiallyInsecureRules.Count != 0)
+                    {
+                        Trace.Warning("The {0} group have the following permissions to the agent root folder: ", bulitInUsersGroup.ToString());
+
+                        potentiallyInsecureRules.ForEach(accessRule => Trace.Warning("- {0}", accessRule.FileSystemRights.ToString()));
+
+                        _term.Write(StringUtil.Loc("agentRootFolderInsecure", bulitInUsersGroup.ToString()));
+                    }
+                }
+                else 
+                {
+                    Trace.Warning("Can't get path to the agent root folder, check was skipped.");
+                }
+            }
+            catch (Exception ex) {
+                Trace.Warning("Can't check permissions for agent root folder:");
+                Trace.Warning(ex.Message);
+                _term.Write(StringUtil.Loc("agentRootFolderCheckError"));
+            }
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA2000:Dispose objects before losing scope", MessageId = "locationServer")]

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -71,10 +71,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         {
             Trace.Info(nameof(checkAgentRootDirectorySecure));
 
-            string rootDirPath = HostContext.GetDirectory(WellKnownDirectory.Root);
-
             try
             {
+                string rootDirPath = HostContext.GetDirectory(WellKnownDirectory.Root);
+
                 if (!String.IsNullOrEmpty(rootDirPath))
                 {
                     // Get info about root folder
@@ -115,9 +115,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                         _term.Write(StringUtil.Loc("agentRootFolderInsecure", bulitInUsersGroup.ToString()));
                     }
                 }
+                else 
+                {
+                    Trace.Warning("Can't get path to the agent root folder, check was skipped.");
+                }
             }
             catch (Exception ex) {
-                Trace.Warning("Catch exception during checking access right of the agent root folder.");
+                Trace.Warning("Can't check permissions for agent root folder:");
                 Trace.Warning(ex.Message);
                 _term.Write(StringUtil.Loc("agentRootFolderCheckError"));
             }

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -151,7 +151,7 @@ if [[ "$PACKAGERUNTIME" == "win-x64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x64/node.lib" node/bin
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x64/node.exe" node10/bin
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x64/node.lib" node10/bin
-    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" nuget
+    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 fi
 
 if [[ "$PACKAGERUNTIME" == "win-x86" ]]; then
@@ -164,7 +164,7 @@ if [[ "$PACKAGERUNTIME" == "win-x86" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE_VERSION}/win-x86/node.lib" node/bin
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x86/node.exe" node10/bin
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x86/node.lib" node10/bin
-    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" nuget
+    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 fi
 
 # Download the external tools only for OSX.

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -19,7 +19,7 @@
   "AgentNameLog": "Agent name: '{0}'",
   "AgentReplaced": "Successfully replaced the agent",
   "agentRootFolderCheckError": "Unable to check access rules of the agent root folder. Please examine the log for more details.",
-  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify to the agent folder. Please examine the log for more details.",
+  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify the agent folder. Please examine the log for more details.",
   "AgentRunningBehindProxy": "Agent is running behind proxy server: '{0}'",
   "AgentVersion": "Current agent version: '{0}'",
   "AgentWithSameNameAlreadyExistInPool": "Pool {0} already contains an agent with name {1}.",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -18,6 +18,8 @@
   "AgentName": "agent name",
   "AgentNameLog": "Agent name: '{0}'",
   "AgentReplaced": "Successfully replaced the agent",
+  "agentRootFolderCheckError": "Unable to check access rules of the agent root folder. Please examine the log for more details.",
+  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify to the agent folder. Please examine the log for more details.",
   "AgentRunningBehindProxy": "Agent is running behind proxy server: '{0}'",
   "AgentVersion": "Current agent version: '{0}'",
   "AgentWithSameNameAlreadyExistInPool": "Pool {0} already contains an agent with name {1}.",
@@ -636,7 +638,5 @@
   "WorkFolderDescription": "work folder",
   "WorkspaceMappingNotMatched": "Workspace mappings are not matched for workspace {0}",
   "Y": "Y",
-  "ZipSlipFailure": "Entry is outside of the target dir: {0}",
-  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify to the agent folder. Please examine the log for more details.",
-  "agentRootFolderCheckError": "Unable to check access rules of the agent root folder. Please examine the log for more details."
+  "ZipSlipFailure": "Entry is outside of the target dir: {0}"
 }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -636,5 +636,7 @@
   "WorkFolderDescription": "work folder",
   "WorkspaceMappingNotMatched": "Workspace mappings are not matched for workspace {0}",
   "Y": "Y",
-  "ZipSlipFailure": "Entry is outside of the target dir: {0}"
+  "ZipSlipFailure": "Entry is outside of the target dir: {0}",
+  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify to the agent folder. Please check out the logs for more details.",
+  "agentRootFolderCheckError": "Unable to check access right of the agent root folder, please investigated diag logs for more details."
 }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -637,6 +637,6 @@
   "WorkspaceMappingNotMatched": "Workspace mappings are not matched for workspace {0}",
   "Y": "Y",
   "ZipSlipFailure": "Entry is outside of the target dir: {0}",
-  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify to the agent folder. Please check out the logs for more details.",
-  "agentRootFolderCheckError": "Unable to check access right of the agent root folder, please investigated diag logs for more details."
+  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify to the agent folder. Please examine the log for more details.",
+  "agentRootFolderCheckError": "Unable to check access rules of the agent root folder. Please examine the log for more details."
 }

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -60,11 +60,11 @@ then
                 print_errormessage
                 exit 1
             fi
-            
+
 	        # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
             # other debian linux use libssl1.0.0
-            apt install -y libssl1.0.0 || apt install -y libssl1.0.2 || apt install -y libssl1.1
+            apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -72,8 +72,8 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-            apt install -y libicu52 || apt install -y libicu55 || apt install -y libicu57 || apt install -y libicu60 || apt install -y libicu63
+            # libicu versions: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+            apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -95,7 +95,7 @@ then
                 # debian 10 uses libssl1.1
                 # debian 9 uses libssl1.0.2
                 # other debian linux use libssl1.0.0
-                apt-get install -y libssl1.0.0 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.1
+                apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -103,8 +103,8 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-                apt-get install -y libicu52 || apt-get install -y libicu55 || apt-get install -y libicu57 || apt-get install -y libicu60 || apt-get install -y libicu63
+                # libicu versions: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+                apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"

--- a/src/Test/L0/Worker/TaskRunnerL0.cs
+++ b/src/Test/L0/Worker/TaskRunnerL0.cs
@@ -178,5 +178,49 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 }
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void VerifyTasksTests()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Setup 
+                var taskRunner = new TaskRunner();
+                Mock<IConfigurationStore> store = new Mock<IConfigurationStore>();
+                AgentSettings settings = new AgentSettings();
+                settings.AlwaysExtractTask = true;
+                store.Setup(x => x.GetSettings()).Returns(settings);
+                hc.SetSingleton(store.Object);
+                taskRunner.Initialize(hc);
+                Definition definition = new Definition() { ZipPath = "test" };
+                Mock<ITaskManager> taskManager = new Mock<ITaskManager>();
+                taskManager.Setup(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()));
+
+                // Each Verify call should Extract since the ZipPath is given and AlwaysExtract = True
+                taskRunner.VerifyTask(taskManager.Object, definition);
+                taskManager.Verify(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()), Times.Exactly(1));
+                taskRunner.VerifyTask(taskManager.Object, definition);
+                taskManager.Verify(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()), Times.Exactly(2));
+                taskRunner.VerifyTask(taskManager.Object, definition);
+                taskManager.Verify(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()), Times.Exactly(3));
+
+                // Verify call should not Extract since AlwaysExtract = False
+                settings.AlwaysExtractTask = false;
+                taskRunner.VerifyTask(taskManager.Object, definition);
+                taskManager.Verify(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()), Times.Exactly(3));
+
+                // Setting back to AlwaysExtract = true causes Extract to be called
+                settings.AlwaysExtractTask = true;
+                taskRunner.VerifyTask(taskManager.Object, definition);
+                taskManager.Verify(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()), Times.Exactly(4));
+
+                // Clearing the ZipPath should not Extract
+                definition.ZipPath = null;
+                taskRunner.VerifyTask(taskManager.Object, definition);
+                taskManager.Verify(x => x.Extract(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.TaskStep>()), Times.Exactly(4));
+            }
+        }
     }
 }


### PR DESCRIPTION
**Description**:
This PR implements a check of the access rules to the agent's root directory. The check also notifies the user if the agent's root directory is writable/modify by members of the `BUILTIN\Users` group.

_Changes_:
**Agent.Listener**
- Added a `checkAgentRootDirectorySecure` method to check agent's root folder access rules 
- Added call of the `checkAgentRootDirectorySecure` method to `ConfigureAsync` method

**Added unit tests:** No

**Attached related issue:** 
* https://github.com/microsoft/build-task-team/issues/313