### PR TITLE
Fixed installdependencies.sh script for Ubuntu 20.04

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -82,7 +82,7 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
+            # libicu versions: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
             apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
@@ -123,7 +123,7 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
+                # libicu versions: libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
                 apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -60,11 +60,21 @@ then
                 print_errormessage
                 exit 1
             fi
-            
+
+            # ubuntu 18 uses libcurl4
+            # ubuntu 14, 16 and other linux use libcurl3
+            apt install -y libcurl4 || apt install -y libcurl3
+            if [ $? -ne 0 ]
+            then
+                echo "'apt' failed with exit code '$?'"
+                print_errormessage
+                exit 1
+            fi
+
 	        # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
             # other debian linux use libssl1.0.0
-            apt install -y libssl1.0.0 || apt install -y libssl1.0.2 || apt install -y libssl1.1
+            apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -73,7 +83,7 @@ then
             fi
 
             # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-            apt install -y libicu52 || apt install -y libicu55 || apt install -y libicu57 || apt install -y libicu60 || apt install -y libicu63
+            apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -91,11 +101,21 @@ then
                     print_errormessage
                     exit 1
                 fi
+
+                # ubuntu 18 uses libcurl4
+                # ubuntu 14, 16 and other linux use libcurl3
+                apt-get install -y libcurl4 || apt-get install -y libcurl3
+                if [ $? -ne 0 ]
+                then
+                    echo "'apt-get' failed with exit code '$?'"
+                    print_errormessage
+                    exit 1
+                fi
                 
                 # debian 10 uses libssl1.1
                 # debian 9 uses libssl1.0.2
                 # other debian linux use libssl1.0.0
-                apt-get install -y libssl1.0.0 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.1
+                apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -104,7 +124,7 @@ then
                 fi
 
                 # libicu versions: libicu52 -> libicu55 -> libicu57 -> libicu60 -> libicu63
-                apt-get install -y libicu52 || apt-get install -y libicu55 || apt-get install -y libicu57 || apt-get install -y libicu60 || apt-get install -y libicu63
+                apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -61,16 +61,6 @@ then
                 exit 1
             fi
 
-            # ubuntu 18 uses libcurl4
-            # ubuntu 14, 16 and other linux use libcurl3
-            apt install -y libcurl4 || apt install -y libcurl3
-            if [ $? -ne 0 ]
-            then
-                echo "'apt' failed with exit code '$?'"
-                print_errormessage
-                exit 1
-            fi
-
 	        # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
             # other debian linux use libssl1.0.0
@@ -95,16 +85,6 @@ then
             if [ $? -eq 0 ]
             then
                 apt-get update && apt-get install -y liblttng-ust0 libkrb5-3 zlib1g
-                if [ $? -ne 0 ]
-                then
-                    echo "'apt-get' failed with exit code '$?'"
-                    print_errormessage
-                    exit 1
-                fi
-
-                # ubuntu 18 uses libcurl4
-                # ubuntu 14, 16 and other linux use libcurl3
-                apt-get install -y libcurl4 || apt-get install -y libcurl3
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
Added libicu66 package installation - to fix issue on Ubuntu 20.04.
Reversed order of packages installation - now it installs them starting from latest one.

