### PR TITLE
[Security] Add a check of the agent's root directory access rules

### DIFF
--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -18,6 +18,8 @@
   "AgentName": "agent name",
   "AgentNameLog": "Agent name: '{0}'",
   "AgentReplaced": "Successfully replaced the agent",
+  "agentRootFolderCheckError": "Unable to check access rules of the agent root folder. Please examine the log for more details.",
+  "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify the agent folder. Please examine the log for more details.",
   "AgentRunningBehindProxy": "Agent is running behind proxy server: '{0}'",
   "AgentVersion": "Current agent version: '{0}'",
   "AgentWithSameNameAlreadyExistInPool": "Pool {0} already contains an agent with name {1}.",


### PR DESCRIPTION
**Description**:
This PR implements a check of the access rules to the agent's root directory. The check also notifies the user if the agent's root directory is writable/modify by members of the `BUILTIN\Users` group.

_Changes_:
**Agent.Listener**
- Added a `checkAgentRootDirectorySecure` method to check agent's root folder access rules 
- Added call of the `checkAgentRootDirectorySecure` method to `ConfigureAsync` method

**Added unit tests:** No

**Attached related issue:** 
* https://github.com/microsoft/build-task-team/issues/313