### PR TITLE
Update Agent.OSVersion support of Mac OS X Big Sur agents.

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Capabilities/AgentCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Capabilities/AgentCapabilitiesProvider.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
        // Mac OS X 10.1 mapped to Darwin 5.x, and the mapping continues that way
        // So just subtract 4 from the Darwin version.
        // https://en.wikipedia.org/wiki/Darwin_%28operating_system%29
-       // with Big Sur Apple made the jum from 10.* to 11.* that means that
+       // with Big Sur Apple made the jump from 10.* to 11.* that means that
        // the version reported from that point is 20.1.0.0 for 11.0.1
         private static string GetDarwinVersionString() {
             var version = Environment.OSVersion.Version;

--- a/src/Microsoft.VisualStudio.Services.Agent/Capabilities/AgentCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Capabilities/AgentCapabilitiesProvider.cs
@@ -96,7 +96,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
        // Mac OS X 10.1 mapped to Darwin 5.x, and the mapping continues that way
        // So just subtract 4 from the Darwin version.
        // https://en.wikipedia.org/wiki/Darwin_%28operating_system%29
-        private static string GetDarwinVersionString()
-            => Environment.OSVersion.Version.Major < 5 ? "10.0" : $"10.{Environment.OSVersion.Version.Major - 4}";
+       // with Big Sur Apple made the jum from 10.* to 11.* that means that
+       // the version reported from that point is 20.1.0.0 for 11.0.1
+        private static string GetDarwinVersionString() {
+            var version = Environment.OSVersion.Version;
+            if (version.Major < 5)
+            {
+                return "10.0";
+            }
+            if (version.Major - 4 <= 15)
+            {
+                return $"10.{version.Major - 4}";
+            }
+            else
+            {
+                return $"11.{version.Major - 20}";
+            }
+        }
     }
 }


### PR DESCRIPTION
The -20 in the major is expecting that Big Sur +1 version will be 21.0.0.0 resulting in 11.1 But apple can do what ever they want.