### PR TITLE
Update Agent.OSVersion support fot .net 5 and later

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Capabilities/AgentCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Capabilities/AgentCapabilitiesProvider.cs
@@ -98,8 +98,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
        // https://en.wikipedia.org/wiki/Darwin_%28operating_system%29
        // with Big Sur Apple made the jump from 10.* to 11.* that means that
        // the version reported from that point is 20.1.0.0 for 11.0.1
-        private static string GetDarwinVersionString() {
+        private static string GetDarwinVersionString()
+        {
+            // from .net 5 onwards the runtime returns the product version instead of the darwin kernel version
             var version = Environment.OSVersion.Version;
+            if (Environment.Version.Major >= 5)
+            {
+                return $"{version.Major}.{version.Minor}";
+            }
+
             if (version.Major < 5)
             {
                 return "10.0";


### PR DESCRIPTION
The .net runtime changed the way the OS version is returned and it does
not longer return the Darwin kernel version but the produce version, for
reference: https://github.com/dotnet/runtime/pull/36029