### PR TITLE
Temporarily remove aspnetcidev and associated test

### DIFF
--- a/src/Test/L0/Plugin/ChunkerTests.cs
+++ b/src/Test/L0/Plugin/ChunkerTests.cs
@@ -27,12 +27,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             var bytes = new byte[byteCount];
             FillBufferWithTestContent(seed: 0, bytes);
 
-            using (var hasher = new DedupNodeHashAlgorithm())
-            {
-                hasher.ComputeHash(bytes, 0, bytes.Length);
-                var node = hasher.GetNode();
-                Assert.Equal<string>(expectedHash, node.Hash.ToHex());
-            }
+            // using (var hasher = new DedupNodeHashAlgorithm())
+            // {
+            //     hasher.ComputeHash(bytes, 0, bytes.Length);
+            //     var node = hasher.GetNode();
+            //     Assert.Equal<string>(expectedHash, node.Hash.ToHex());
+            // }
         }
 
         private static void FillBufferWithTestContent(int seed, byte[] bytes)

--- a/src/Test/L0/Plugin/ChunkerTests.cs
+++ b/src/Test/L0/Plugin/ChunkerTests.cs
@@ -10,30 +10,32 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
 {
     public class ChunkerTests
     {
-        [Theory]
-        [InlineData(0, "A7B5F4F67CDA9A678DE6DCBFDE1BE2902407CA2E6E899F843D4EFD1E62778D63")]
-        [InlineData(1, "266CCDBB8509CCADDDD739F1F0751141D154667E9C4754604EB66B1DEE133961")]
-        [InlineData(32 * 1024 - 1, "E697ED9F1250A079DC60AF3FD53793064E020231E96D69554028DD7C2E69D476")]
-        [InlineData(32 * 1024 + 0, "02BB285FBEF36871C6B7694BD684822F5A36104801379B2D225B34A6739946A0")]
-        [InlineData(32 * 1024 + 1, "41D54465B526473D36808AA1B1884CE98278FF1EC4BD83A84CA99590F8809818")]
-        [InlineData(64 * 1024 + 0, "E347F2D06AFA55AE4F928EA70A8180B37447F55B87E784EE2B31FE90B97718B0")]
-        [InlineData(2 * 64 * 1024 - 1, "540770B3F5DF9DD459319164D2AFCAD1B942CB24B41985AA1E0F081D6AC16639")]
-        [InlineData(2 * 64 * 1024 + 0, "3175B5C2595B419DBE5BDA9554208A4E39EFDBCE1FC6F7C7CB959E5B39DF2DF0")]
-        [InlineData(2 * 64 * 1024 + 1, "B39D401B85748FDFC41980A0ABE838BA05805BFFAE16344CE74EA638EE42DEA5")]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Plugin")]
-        public void ChunkerIsStable(int byteCount, string expectedHash)
-        {
-            var bytes = new byte[byteCount];
-            FillBufferWithTestContent(seed: 0, bytes);
+        // This test relies on the DedupNodeHashAlgorithm which is from aspnetcidev. This package is apparently not being published anymore.
+        // We should either fix this test or remove it soon.
+        // [Theory]
+        // [InlineData(0, "A7B5F4F67CDA9A678DE6DCBFDE1BE2902407CA2E6E899F843D4EFD1E62778D63")]
+        // [InlineData(1, "266CCDBB8509CCADDDD739F1F0751141D154667E9C4754604EB66B1DEE133961")]
+        // [InlineData(32 * 1024 - 1, "E697ED9F1250A079DC60AF3FD53793064E020231E96D69554028DD7C2E69D476")]
+        // [InlineData(32 * 1024 + 0, "02BB285FBEF36871C6B7694BD684822F5A36104801379B2D225B34A6739946A0")]
+        // [InlineData(32 * 1024 + 1, "41D54465B526473D36808AA1B1884CE98278FF1EC4BD83A84CA99590F8809818")]
+        // [InlineData(64 * 1024 + 0, "E347F2D06AFA55AE4F928EA70A8180B37447F55B87E784EE2B31FE90B97718B0")]
+        // [InlineData(2 * 64 * 1024 - 1, "540770B3F5DF9DD459319164D2AFCAD1B942CB24B41985AA1E0F081D6AC16639")]
+        // [InlineData(2 * 64 * 1024 + 0, "3175B5C2595B419DBE5BDA9554208A4E39EFDBCE1FC6F7C7CB959E5B39DF2DF0")]
+        // [InlineData(2 * 64 * 1024 + 1, "B39D401B85748FDFC41980A0ABE838BA05805BFFAE16344CE74EA638EE42DEA5")]
+        // [Trait("Level", "L0")]
+        // [Trait("Category", "Plugin")]
+        // public void ChunkerIsStable(int byteCount, string expectedHash)
+        // {
+        //     var bytes = new byte[byteCount];
+        //     FillBufferWithTestContent(seed: 0, bytes);
 
-            // using (var hasher = new DedupNodeHashAlgorithm())
-            // {
-            //     hasher.ComputeHash(bytes, 0, bytes.Length);
-            //     var node = hasher.GetNode();
-            //     Assert.Equal<string>(expectedHash, node.Hash.ToHex());
-            // }
-        }
+        //     using (var hasher = new DedupNodeHashAlgorithm())
+        //     {
+        //         hasher.ComputeHash(bytes, 0, bytes.Length);
+        //         var node = hasher.GetNode();
+        //         Assert.Equal<string>(expectedHash, node.Hash.ToHex());
+        //     }
+        // }
 
         private static void FillBufferWithTestContent(int seed, byte[] bytes)
         {

--- a/src/Test/NuGet.Config
+++ b/src/Test/NuGet.Config
@@ -7,7 +7,6 @@
     <add key="BuildXL.Selfhost" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL.Selfhost/nuget/v3/index.json" />
     <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <add key="aspnetcidev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Right now, this test is the only thing using `aspnetcidev`, which apparently is no longer published

This temporarily fixes the problem, I'll follow up with the artifacts team on this one as well