### PR TITLE
NetworkCreate for Linux Container on a WindowsServer

### DIFF
--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -224,7 +224,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 
             var usingWindowsContainers = context.Containers.Where(x => x.ExecutionOS != PlatformUtil.OS.Windows).Count() == 0;
             var networkDrivers = await ExecuteDockerCommandAsync(context, "info", "-f \"{{range .Plugins.Network}}{{println .}}{{end}}\"");
-            if (usingWindowsContainers && networkDrivers.Contains("nat"))
+            if (usingWindowsContainers && networkDrivers.Contains("nat")||
+                !usingWindowsContainers && networkDrivers.Contains("nat") && !networkDrivers.Contains("bridge"))
             {
                 return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} --driver nat", context.CancellationToken);
             }


### PR DESCRIPTION
**Reason:**
 The Network can not be created, because the default ist 'bridge'. If the Container has the OS 'Windows' the Agent adds the parameter '--driver nat'. If the Container OS is 
 'Linux', the default driver is used. But the driver 'bridge' is not available in Windows. With this change the Agent will add the parameter at an Linux Container as well.

**Goal:**
 WindowsServer with Azure DevOps Agent to work with Windows and Linux Docker Container.

**Error:**
```
##[command]C:\Program Files\Docker\docker.EXE inspect --format="{{.Os}}" docker/debian/debian-build-linux:latest
linux
##[command]C:\Program Files\Docker\docker.EXE info -f "{{range .Plugins.Network}}{{println .}}{{end}}"
ics
internal
l2bridge
l2tunnel
nat
null
overlay
private
transparent
##[command]C:\Program Files\Docker\docker.EXE network create --label 06d2f5 vsts_network_6fd1811fd4a1490bb52796e17be24998
Error response from daemon: could not find plugin bridge in v1 plugin registry: plugin not found
##[error]Docker network create failed with exit code 1
```

**Detail Information:**
- WindowsServer Core 2019
- Agent version: '2.179.0'
- Docker version:
```
Client: Mirantis Container Runtime
 Version:           19.03.14
 API version:       1.40
 Go version:        go1.13.15
 Git commit:        e820475
 Built:             12/17/2020 19:30:16
 OS/Arch:           windows/amd64
 Experimental:      false

Server: Mirantis Container Runtime
 Engine:
  Version:          19.03.14
  API version:      1.40 (minimum version 1.24)
  Go version:       go1.13.15
  Git commit:       57e3a05525
  Built:            12/17/2020 19:29:00
  OS/Arch:          windows/amd64
  Experimental:     true
```

- SetUp for Docker:
[https://computingforgeeks.com/how-to-run-docker-containers-on-windows-server-2019](https://computingforgeeks.com/how-to-run-docker-containers-on-windows-server-2019)

**Bipline Yaml:**
```
jobs:
- job: local
  pool: Docker
  steps:
    - script: docker version   
    
- job: windowsDocker
  pool: Docker
  container:
    image: mcr-microsoft-com/windows/servercore:ltsc2019
  steps:
    - powershell: write-host "I can run inside the container (it starts by default)"
    - powershell: write-host $env:computername
    
- job: linuxDocker
  pool: Docker
  container:
    image: docker/debian/debian-build-linux:latest
  steps:
    - script: echo "I can run inside the container (it starts by default)"
    - script: printenv
```