### PR TITLE
Use %AZP25 instead of %25 for escaping

### DIFF
--- a/docs/design/percentEncoding.md
+++ b/docs/design/percentEncoding.md
@@ -8,7 +8,11 @@ The reason this is impossible is because we escape certain values needed for the
 
 ### Solution
 
-We've introduced encoding for `%` which will map to `%25`. This means that any time the agent receives `%25` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%25]a%25` will now set a variable `test%: a%`.
+We've introduced encoding for `%` which will map to `%VSTS`. This means that any time the agent receives `%VSTS` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%VSTS]a%VSTS` will now set a variable `test%: a%`.
+
+NOTE: This was previously designed to use %25 instead of %VSTS as the escape sequence. We decided to go with %VSTS instead since %25 was used somewhat often
+because of its role in url encoding. Some agents may continue to emit warnings for %25 as this change rolls out (or if you haven't updated to the most recent agent),
+these are safe to ignore.
 
 This behavior will be enabled by default in March 2021. To disable it, you can set a job level variable DECODE_PERCENTS to false. To avoid getting warnings about it and opt into the behavior early, set a job level variable DECODE_PERCENTS to true.
 
@@ -20,7 +24,7 @@ jobs:
     value: true
 
   steps:
-  - powershell: Write-Host '##vso[task.setvariable variable=test]a%25'
+  - powershell: Write-Host '##vso[task.setvariable variable=test]a%VSTS'
     displayName: 'Set Variable'
 
   # This will print the a% correctly as the value of test

--- a/docs/design/percentEncoding.md
+++ b/docs/design/percentEncoding.md
@@ -11,8 +11,8 @@ The reason this is impossible is because we escape certain values needed for the
 We've introduced encoding for `%` which will map to `%VS_TS`. This means that any time the agent receives `%VS_TS` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%VS_TS]a%VS_TS` will now set a variable `test%: a%`.
 
 NOTE: This was previously designed to use %25 instead of %VS_TS as the escape sequence. We decided to go with %VS_TS instead since %25 was used somewhat often
-because of its role in url encoding. Some agents may continue to emit warnings for %25 as this change rolls out (or if you haven't updated to the most recent agent),
-these are safe to ignore.
+because of its role in url encoding. Some agents may continue to emit warnings for %25 as this change rolls out (or if you haven't updated to the most recent agent).
+These warnings are safe to ignore.
 
 This behavior will be enabled by default in March 2021. To disable it, you can set a job level variable DECODE_PERCENTS to false. To avoid getting warnings about it and opt into the behavior early, set a job level variable DECODE_PERCENTS to true.
 

--- a/docs/design/percentEncoding.md
+++ b/docs/design/percentEncoding.md
@@ -8,9 +8,9 @@ The reason this is impossible is because we escape certain values needed for the
 
 ### Solution
 
-We've introduced encoding for `%` which will map to `%VS_TS`. This means that any time the agent receives `%VS_TS` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%VS_TS]a%VS_TS` will now set a variable `test%: a%`.
+We've introduced encoding for `%` which will map to `%AZP25`. This means that any time the agent receives `%AZP25` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%AZP25]a%AZP25` will now set a variable `test%: a%`.
 
-NOTE: This was previously designed to use %25 instead of %VS_TS as the escape sequence. We decided to go with %VS_TS instead since %25 was used somewhat often
+NOTE: This was previously designed to use %25 instead of %AZP25 as the escape sequence. We decided to go with %AZP25 instead since %25 was used somewhat often
 because of its role in url encoding. Some agents may continue to emit warnings for %25 as this change rolls out (or if you haven't updated to the most recent agent).
 These warnings are safe to ignore.
 
@@ -24,7 +24,7 @@ jobs:
     value: true
 
   steps:
-  - powershell: Write-Host '##vso[task.setvariable variable=test]a%VS_TS'
+  - powershell: Write-Host '##vso[task.setvariable variable=test]a%AZP25'
     displayName: 'Set Variable'
 
   # This will print the a% correctly as the value of test

--- a/docs/design/percentEncoding.md
+++ b/docs/design/percentEncoding.md
@@ -8,9 +8,9 @@ The reason this is impossible is because we escape certain values needed for the
 
 ### Solution
 
-We've introduced encoding for `%` which will map to `%VSTS`. This means that any time the agent receives `%VSTS` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%VSTS]a%VSTS` will now set a variable `test%: a%`.
+We've introduced encoding for `%` which will map to `%VS_TS`. This means that any time the agent receives `%VS_TS` as part of a command, it will automatically decode it to `%`. So `##vso[task.setvariable variable=test%VS_TS]a%VS_TS` will now set a variable `test%: a%`.
 
-NOTE: This was previously designed to use %25 instead of %VSTS as the escape sequence. We decided to go with %VSTS instead since %25 was used somewhat often
+NOTE: This was previously designed to use %25 instead of %VS_TS as the escape sequence. We decided to go with %VS_TS instead since %25 was used somewhat often
 because of its role in url encoding. Some agents may continue to emit warnings for %25 as this change rolls out (or if you haven't updated to the most recent agent),
 these are safe to ignore.
 
@@ -24,7 +24,7 @@ jobs:
     value: true
 
   steps:
-  - powershell: Write-Host '##vso[task.setvariable variable=test]a%VSTS'
+  - powershell: Write-Host '##vso[task.setvariable variable=test]a%VS_TS'
     displayName: 'Set Variable'
 
   # This will print the a% correctly as the value of test

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -206,7 +206,7 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob DecodePercents = new Knob(
             nameof(DecodePercents),
-            "By default, the agent does not decodes %VS_TS as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
+            "By default, the agent does not decodes %AZP25 as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
             new RuntimeKnobSource("DECODE_PERCENTS"),
             new EnvironmentKnobSource("DECODE_PERCENTS"),
             new BuiltInDefaultKnobSource(""));

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -206,7 +206,7 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob DecodePercents = new Knob(
             nameof(DecodePercents),
-            "By default, the agent does not decodes %25 as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
+            "By default, the agent does not decodes %VSTS as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
             new RuntimeKnobSource("DECODE_PERCENTS"),
             new EnvironmentKnobSource("DECODE_PERCENTS"),
             new BuiltInDefaultKnobSource(""));

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -206,7 +206,7 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob DecodePercents = new Knob(
             nameof(DecodePercents),
-            "By default, the agent does not decodes %VSTS as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
+            "By default, the agent does not decodes %VS_TS as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
             new RuntimeKnobSource("DECODE_PERCENTS"),
             new EnvironmentKnobSource("DECODE_PERCENTS"),
             new BuiltInDefaultKnobSource(""));

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -335,7 +335,7 @@ namespace Agent.Sdk
         {
             if (AgentKnobs.DecodePercents.GetValue(this).AsBoolean())
             {
-                input = input.Replace("%", "%25");
+                input = input.Replace("%", "%VSTS");
             }
             foreach (var mapping in _commandEscapeMappings)
             {

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -335,7 +335,7 @@ namespace Agent.Sdk
         {
             if (AgentKnobs.DecodePercents.GetValue(this).AsBoolean())
             {
-                input = input.Replace("%", "%VS_TS");
+                input = input.Replace("%", "%AZP25");
             }
             foreach (var mapping in _commandEscapeMappings)
             {

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -335,7 +335,7 @@ namespace Agent.Sdk
         {
             if (AgentKnobs.DecodePercents.GetValue(this).AsBoolean())
             {
-                input = input.Replace("%", "%VSTS");
+                input = input.Replace("%", "%VS_TS");
             }
             foreach (var mapping in _commandEscapeMappings)
             {

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     AddUserSuppliedSecret(variable.Value.Value);
                     // also, we escape some characters for variables when we print them out in debug mode. We need to
                     // add the escaped version of these secrets as well
-                    var escapedSecret = variable.Value.Value.Replace("%", "%VSTS")
+                    var escapedSecret = variable.Value.Value.Replace("%", "%VS_TS")
                                                             .Replace("\r", "%0D")
                                                             .Replace("\n", "%0A");
                     AddUserSuppliedSecret(escapedSecret);

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -136,10 +136,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     AddUserSuppliedSecret(variable.Value.Value);
                     // also, we escape some characters for variables when we print them out in debug mode. We need to
                     // add the escaped version of these secrets as well
-                    var escapedSecret = variable.Value.Value.Replace("%", "%25")
+                    var escapedSecret = variable.Value.Value.Replace("%", "%VSTS")
                                                             .Replace("\r", "%0D")
                                                             .Replace("\n", "%0A");
                     AddUserSuppliedSecret(escapedSecret);
+
+                    // Since % escaping may be turned off, also mask a version escaped with just newlines
+                    var escapedSecret2 = variable.Value.Value.Replace("\r", "%0D")
+                                                             .Replace("\n", "%0A");
+                    AddUserSuppliedSecret(escapedSecret2);
                 }
             }
 

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     AddUserSuppliedSecret(variable.Value.Value);
                     // also, we escape some characters for variables when we print them out in debug mode. We need to
                     // add the escaped version of these secrets as well
-                    var escapedSecret = variable.Value.Value.Replace("%", "%VS_TS")
+                    var escapedSecret = variable.Value.Value.Replace("%", "%AZP25")
                                                             .Replace("\r", "%0D")
                                                             .Replace("\n", "%0A");
                     AddUserSuppliedSecret(escapedSecret);

--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -132,9 +132,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
 
             // Only if we've successfully parsed do we show this warning
-            if (AgentKnobs.DecodePercents.GetValue(context).AsString() == "" && input.Contains("%25"))
+            if (AgentKnobs.DecodePercents.GetValue(context).AsString() == "" && input.Contains("%VSTS"))
             {
-                context.Warning("%25 detected in ##vso command. In March 2021, the agent command parser will be updated to unescape this to %. To opt out of this behavior, set a job level variable DECODE_PERCENTS to false. Setting to true will force this behavior immediately. More information can be found at https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md");
+                context.Warning("%VSTS detected in ##vso command. In March 2021, the agent command parser will be updated to unescape this to %. To opt out of this behavior, set a job level variable DECODE_PERCENTS to false. Setting to true will force this behavior immediately. More information can be found at https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md");
             }
 
             return true;

--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -132,9 +132,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
 
             // Only if we've successfully parsed do we show this warning
-            if (AgentKnobs.DecodePercents.GetValue(context).AsString() == "" && input.Contains("%VS_TS"))
+            if (AgentKnobs.DecodePercents.GetValue(context).AsString() == "" && input.Contains("%AZP25"))
             {
-                context.Warning("%VS_TS detected in ##vso command. In March 2021, the agent command parser will be updated to unescape this to %. To opt out of this behavior, set a job level variable DECODE_PERCENTS to false. Setting to true will force this behavior immediately. More information can be found at https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md");
+                context.Warning("%AZP25 detected in ##vso command. In March 2021, the agent command parser will be updated to unescape this to %. To opt out of this behavior, set a job level variable DECODE_PERCENTS to false. Setting to true will force this behavior immediately. More information can be found at https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md");
             }
 
             return true;

--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -132,9 +132,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
 
             // Only if we've successfully parsed do we show this warning
-            if (AgentKnobs.DecodePercents.GetValue(context).AsString() == "" && input.Contains("%VSTS"))
+            if (AgentKnobs.DecodePercents.GetValue(context).AsString() == "" && input.Contains("%VS_TS"))
             {
-                context.Warning("%VSTS detected in ##vso command. In March 2021, the agent command parser will be updated to unescape this to %. To opt out of this behavior, set a job level variable DECODE_PERCENTS to false. Setting to true will force this behavior immediately. More information can be found at https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md");
+                context.Warning("%VS_TS detected in ##vso command. In March 2021, the agent command parser will be updated to unescape this to %. To opt out of this behavior, set a job level variable DECODE_PERCENTS to false. Setting to true will force this behavior immediately. More information can be found at https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md");
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.Services.Agent/Command.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Command.cs
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             if (unescapePercents)
             {
-                unescaped = unescaped.Replace("%VS_TS", "%");
+                unescaped = unescaped.Replace("%AZP25", "%");
             }
 
             return unescaped;

--- a/src/Microsoft.VisualStudio.Services.Agent/Command.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Command.cs
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             if (unescapePercents)
             {
-                unescaped = unescaped.Replace("%25", "%");
+                unescaped = unescaped.Replace("%VSTS", "%");
             }
 
             return unescaped;

--- a/src/Microsoft.VisualStudio.Services.Agent/Command.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Command.cs
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             if (unescapePercents)
             {
-                unescaped = unescaped.Replace("%VSTS", "%");
+                unescaped = unescaped.Replace("%VS_TS", "%");
             }
 
             return unescaped;

--- a/src/Test/L0/Worker/LoggingCommandL0.cs
+++ b/src/Test/L0/Worker/LoggingCommandL0.cs
@@ -43,12 +43,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 test = null;
                 verify = null;
                 //##vso[area.event k1=%3B=%0D=%0A=%5D;]%3B-%0D-%0A-%5D
-                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VS_TS;]%3B-%0D-%0A-%5D%VS_TS3B";
+                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%AZP25;]%3B-%0D-%0A-%5D%AZP253B";
                 test = new Command("area", "event")
                 {
-                    Data = ";-\r-\n-]%VS_TS3B",
+                    Data = ";-\r-\n-]%AZP253B",
                 };
-                test.Properties.Add("k1", ";=\r=\n=]%VS_TS");
+                test.Properties.Add("k1", ";=\r=\n=]%AZP25");
                 Assert.True(Command.TryParse(vso, false, out verify));
                 Assert.True(IsEqualCommand(hc, test, verify));
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 test = null;
                 verify = null;
                 //##vso[area.event k1=%3B=%0D=%0A=%5D;]%3B-%0D-%0A-%5D
-                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VS_TS;]%3B-%0D-%0A-%5D%VS_TS3B";
+                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%AZP25;]%3B-%0D-%0A-%5D%AZP253B";
                 test = new Command("area", "event")
                 {
                     Data = ";-\r-\n-]%3B",

--- a/src/Test/L0/Worker/LoggingCommandL0.cs
+++ b/src/Test/L0/Worker/LoggingCommandL0.cs
@@ -43,12 +43,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 test = null;
                 verify = null;
                 //##vso[area.event k1=%3B=%0D=%0A=%5D;]%3B-%0D-%0A-%5D
-                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%25;]%3B-%0D-%0A-%5D%253B";
+                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VSTS;]%3B-%0D-%0A-%5D%VSTS3B";
                 test = new Command("area", "event")
                 {
-                    Data = ";-\r-\n-]%253B",
+                    Data = ";-\r-\n-]%VSTS3B",
                 };
-                test.Properties.Add("k1", ";=\r=\n=]%25");
+                test.Properties.Add("k1", ";=\r=\n=]%VSTS");
                 Assert.True(Command.TryParse(vso, false, out verify));
                 Assert.True(IsEqualCommand(hc, test, verify));
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 test = null;
                 verify = null;
                 //##vso[area.event k1=%3B=%0D=%0A=%5D;]%3B-%0D-%0A-%5D
-                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%25;]%3B-%0D-%0A-%5D%253B";
+                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VSTS;]%3B-%0D-%0A-%5D%VSTS3B";
                 test = new Command("area", "event")
                 {
                     Data = ";-\r-\n-]%3B",

--- a/src/Test/L0/Worker/LoggingCommandL0.cs
+++ b/src/Test/L0/Worker/LoggingCommandL0.cs
@@ -43,12 +43,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 test = null;
                 verify = null;
                 //##vso[area.event k1=%3B=%0D=%0A=%5D;]%3B-%0D-%0A-%5D
-                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VSTS;]%3B-%0D-%0A-%5D%VSTS3B";
+                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VS_TS;]%3B-%0D-%0A-%5D%VS_TS3B";
                 test = new Command("area", "event")
                 {
-                    Data = ";-\r-\n-]%VSTS3B",
+                    Data = ";-\r-\n-]%VS_TS3B",
                 };
-                test.Properties.Add("k1", ";=\r=\n=]%VSTS");
+                test.Properties.Add("k1", ";=\r=\n=]%VS_TS");
                 Assert.True(Command.TryParse(vso, false, out verify));
                 Assert.True(IsEqualCommand(hc, test, verify));
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 test = null;
                 verify = null;
                 //##vso[area.event k1=%3B=%0D=%0A=%5D;]%3B-%0D-%0A-%5D
-                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VSTS;]%3B-%0D-%0A-%5D%VSTS3B";
+                vso = "##vso[area.event k1=%3B=%0D=%0A=%5D%VS_TS;]%3B-%0D-%0A-%5D%VS_TS3B";
                 test = new Command("area", "event")
                 {
                     Data = ";-\r-\n-]%3B",


### PR DESCRIPTION
Using %25 has introduced a lot of false positives where people don't expect their value to be decoded, specifically because %25 is used in a lot of Urls that people might set as variables.

Using %VS_TS should help us avoid this problem since it is a very uncommon string for people to intentionally use. It is less efficient and breaks from the standard URL encoding scheme, but that is probably outweighed by avoiding breaking customers.

This will require task-lib changes to use %VS_TS instead of %25 once it is fully rolled out.

I chose %VS_TS because I thought that would be obvious that it was something we were doing from the Azure DevOps side, but I was worried %VSTS might actually collide with something