### PR TITLE
Add support for setvariable restrictions

### DIFF
--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -611,7 +611,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (!context.Restrictions.All(restrictions => restrictions.SetVariableAllowed(name)))
             {
-                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed"));
+                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed", name));
             }
 
             context.SetVariable(name, data, isSecret: isSecret, isOutput: isOutput, isReadOnly: isReadOnly);
@@ -790,7 +790,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (!context.Restrictions.All(restrictions => restrictions.SetVariableAllowed(Constants.PathVariable)))
             {
-                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed"));
+                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed", Constants.PathVariable));
             }
 
             var data = command.Data;

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -611,7 +611,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (!context.Restrictions.All(restrictions => restrictions.SetVariableAllowed(name)))
             {
-                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed", name));
+                context.Warning(StringUtil.Loc("SetVariableNotAllowed", name));
+                return;
             }
 
             context.SetVariable(name, data, isSecret: isSecret, isOutput: isOutput, isReadOnly: isReadOnly);
@@ -790,7 +791,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (!context.Restrictions.All(restrictions => restrictions.SetVariableAllowed(Constants.PathVariable)))
             {
-                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed", Constants.PathVariable));
+                context.Warning(StringUtil.Loc("SetVariableNotAllowed", Constants.PathVariable));
+                return;
             }
 
             var data = command.Data;

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -4,6 +4,7 @@
 using Agent.Sdk.Knob;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
+using Minimatch;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -608,6 +609,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
             }
 
+            if (!context.Restrictions.All(restrictions => restrictions.SetVariableAllowed(name)))
+            {
+                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed"));
+            }
+
             context.SetVariable(name, data, isSecret: isSecret, isOutput: isOutput, isReadOnly: isReadOnly);
         }
     }
@@ -782,6 +788,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(context, nameof(context));
             ArgUtil.NotNull(command, nameof(command));
 
+            if (!context.Restrictions.All(restrictions => restrictions.SetVariableAllowed(Constants.PathVariable)))
+            {
+                throw new InvalidOperationException(StringUtil.Loc("SetVariableNotAllowed"));
+            }
+
             var data = command.Data;
 
             ArgUtil.NotNullOrEmpty(data, this.Name);
@@ -849,5 +860,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public static readonly String EndpointId = "id";
         public static readonly String Field = "field";
         public static readonly String Key = "key";
+    }
+
+    internal static class TaskRestrictionExtension
+    {
+        public static Boolean SetVariableAllowed(this TaskRestrictions restrictions, String variable)
+        {
+            var allowedList = restrictions.SettableVariables?.Allowed;
+            if (allowedList == null)
+            {
+                return true;
+            }
+
+            var opts = new Options() { IgnoreCase = true };
+            foreach (String pattern in allowedList)
+            {
+                if (Minimatcher.Check(variable, pattern, opts))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -336,6 +336,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public ExecutionData PreJobExecution { get; set; }
         public ExecutionData Execution { get; set; }
         public ExecutionData PostJobExecution { get; set; }
+        public TaskRestrictions Restrictions { get; set; }
     }
 
     public sealed class OutputVariable

--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.155-private</VssApiVersion>
+    <VssApiVersion>0.5.156-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
   </PropertyGroup>
 

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -559,6 +559,7 @@
   "SessionExistStopRetry": "Stop retry on SessionConflictException after retried for {0} seconds.",
   "SetBuildVars": "Set build variables.",
   "SetEnvVar": "Setting environment variable {0}",
+  "SetVariableNotAllowed": "Setting the variable '{0}' is not allowed.",
   "ShallowCheckoutFail": "Git checkout failed on shallow repository, this might because of git fetch with depth '{0}' doesn't include the checkout commit '{1}'. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=829603)",
   "ShallowLfsFetchFail": "Git lfs fetch failed on shallow repository, this might because of git fetch with depth '{0}' doesn't include the lfs fetch commit '{1}'. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=829603)",
   "ShutdownMessage": "Restarting the machine in order to launch agent in interactive mode.",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -559,7 +559,7 @@
   "SessionExistStopRetry": "Stop retry on SessionConflictException after retried for {0} seconds.",
   "SetBuildVars": "Set build variables.",
   "SetEnvVar": "Setting environment variable {0}",
-  "SetVariableNotAllowed": "Setting the variable '{0}' is not allowed.",
+  "SetVariableNotAllowed": "Setting variable '{0}' has been disabled by the task or build definition.",
   "ShallowCheckoutFail": "Git checkout failed on shallow repository, this might because of git fetch with depth '{0}' doesn't include the checkout commit '{1}'. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=829603)",
   "ShallowLfsFetchFail": "Git lfs fetch failed on shallow repository, this might because of git fetch with depth '{0}' doesn't include the lfs fetch commit '{1}'. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=829603)",
   "ShutdownMessage": "Restarting the machine in order to launch agent in interactive mode.",

--- a/src/Test/L0/Worker/ExecutionContextL0.cs
+++ b/src/Test/L0/Worker/ExecutionContextL0.cs
@@ -159,9 +159,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var jobRequest = new Pipelines.AgentJobRequestMessage(plan, timeline, JobId, jobName, jobName, null, new Dictionary<string, string>(),
                     new Dictionary<string, VariableValue>(), new List<MaskHint>(), resources, new Pipelines.WorkspaceOptions(), steps);
 
-                // Arrange: Setup command manager
-                var commandMock = new Mock<IWorkerCommandManager>();
-                hc.SetSingleton(commandMock.Object);
+                // Arrange
                 var pagingLogger = new Mock<IPagingLogger>();
                 hc.EnqueueInstance(pagingLogger.Object);
 
@@ -171,7 +169,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
                 // Assert.
                 Assert.IsType<ContainerInfo>(ec.StepTarget());
-                commandMock.Verify(x => x.SetCommandRestrictionPolicy(It.IsAny<UnrestricedWorkerCommandRestrictionPolicy>()));
             }
         }
 
@@ -211,9 +208,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var jobRequest = new Pipelines.AgentJobRequestMessage(plan, timeline, JobId, jobName, jobName, null, new Dictionary<string, string>(),
                     new Dictionary<string, VariableValue>(), new List<MaskHint>(), resources, new Pipelines.WorkspaceOptions(), steps);
 
-                // Arrange: Setup command manager
-                var commandMock = new Mock<IWorkerCommandManager>();
-                hc.SetSingleton(commandMock.Object);
+                // Arrange
                 var pagingLogger = new Mock<IPagingLogger>();
                 hc.EnqueueInstance(pagingLogger.Object);
 
@@ -223,7 +218,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
                 // Assert.
                 Assert.IsType<HostInfo>(ec.StepTarget());
-                commandMock.Verify(x => x.SetCommandRestrictionPolicy(It.IsAny<AttributeBasedWorkerCommandRestrictionPolicy>()));
             }
         }
 

--- a/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
+++ b/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.VisualStudio.Services.Agent.Worker;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
+{
+    public sealed class SetVariableRestrictionsL0
+    {
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void NoRestrictions()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var variable = "myVar";
+                var value = "myValue";
+                var setVariable = new TaskSetVariableCommand();
+                var command = SetVariableCommand(variable, value);
+                setVariable.Execute(_ec.Object, command);
+                Assert.Equal(value, _variables.Get(variable));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void NullVariableRestrictions()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _ec.Object.Restrictions.Add(new TaskRestrictions());
+                var variable = "myVar";
+                var value = "myValue";
+                var setVariable = new TaskSetVariableCommand();
+                var command = SetVariableCommand(variable, value);
+                setVariable.Execute(_ec.Object, command);
+                Assert.Equal(value, _variables.Get(variable));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void EmptyAllowed()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _ec.Object.Restrictions.Add(new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() });
+                var command = SetVariableCommand("myVar", "myVal");
+                Assert.Throws<InvalidOperationException>(() => new TaskSetVariableCommand().Execute(_ec.Object, command));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void ExactMatchAllowed()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var restrictions = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                restrictions.SettableVariables.Allowed.Add("myVar");
+                restrictions.SettableVariables.Allowed.Add("otherVar");
+                _ec.Object.Restrictions.Add(restrictions);
+
+                TaskSetVariableCommand setVariable;
+                Command command;
+                var value = "myValue";
+
+                foreach(String variable in new String[] { "myVar", "myvar", "MYVAR", "otherVAR" })
+                {
+                    command = SetVariableCommand(variable, value);
+                    setVariable = new TaskSetVariableCommand();
+                    setVariable.Execute(_ec.Object, command);
+                    Assert.Equal(value, _variables.Get(variable));
+                }
+
+                var badVar = "badVar";
+                command = SetVariableCommand(badVar, value);
+                setVariable = new TaskSetVariableCommand();
+                Assert.Throws<InvalidOperationException>(() => setVariable.Execute(_ec.Object, command));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MiniMatchAllowed()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var restrictions = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                restrictions.SettableVariables.Allowed.Add("my*");
+                _ec.Object.Restrictions.Add(restrictions);
+
+                TaskSetVariableCommand setVariable;
+                Command command;
+                var value = "myValue";
+
+                foreach(String variable in new String[] { "myVar", "mything", "MY" })
+                {
+                    command = SetVariableCommand(variable, value);
+                    setVariable = new TaskSetVariableCommand();
+                    setVariable.Execute(_ec.Object, command);
+                    Assert.Equal(value, _variables.Get(variable));
+                }
+
+                var badVar = "badVar";
+                command = SetVariableCommand(badVar, value);
+                setVariable = new TaskSetVariableCommand();
+                Assert.Throws<InvalidOperationException>(() => setVariable.Execute(_ec.Object, command));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MultipleRestrictionsMostRestrictive()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // multiple sets of restrictions, such as from task.json and the pipeline yaml
+                var restrictions1 = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                restrictions1.SettableVariables.Allowed.Add("my*");
+                restrictions1.SettableVariables.Allowed.Add("otherVar");
+                _ec.Object.Restrictions.Add(restrictions1);
+                var restrictions2 = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                restrictions2.SettableVariables.Allowed.Add("myVar");
+                restrictions2.SettableVariables.Allowed.Add("myThing");
+                restrictions2.SettableVariables.Allowed.Add("extra");
+                _ec.Object.Restrictions.Add(restrictions2);
+
+                TaskSetVariableCommand setVariable;
+                Command command;
+                var value = "myValue";
+
+                // settable is both allowed lists
+                foreach(String variable in new String[] { "myVar", "myThing" })
+                {
+                    command = SetVariableCommand(variable, value);
+                    setVariable = new TaskSetVariableCommand();
+                    setVariable.Execute(_ec.Object, command);
+                    Assert.Equal(value, _variables.Get(variable));
+                }
+
+                // settable in only one
+                foreach (String variable in new String[] { "myStuff", "otherVar", "extra", "neither" })
+                {
+                    command = SetVariableCommand(variable, value);
+                    setVariable = new TaskSetVariableCommand();
+                    Assert.Throws<InvalidOperationException>(() => setVariable.Execute(_ec.Object, command));
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MultipleRestrictionsNothingAllowed()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                var restrictions1 = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                restrictions1.SettableVariables.Allowed.Add("myVar");
+                restrictions1.SettableVariables.Allowed.Add("otherVar");
+                _ec.Object.Restrictions.Add(restrictions1);
+                var restrictions2 = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                _ec.Object.Restrictions.Add(restrictions2);
+
+                TaskSetVariableCommand setVariable;
+                Command command;
+                var value = "myValue";
+
+                // nothing is settable based on the second, empty allowed list
+                foreach (String variable in new String[] { "myVar", "otherVar", "neither" })
+                {
+                    command = SetVariableCommand(variable, value);
+                    setVariable = new TaskSetVariableCommand();
+                    Assert.Throws<InvalidOperationException>(() => setVariable.Execute(_ec.Object, command));
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void PrependPathAllowed()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // everything allowed
+                TaskPrepandPathCommand prependPath = new TaskPrepandPathCommand();
+                Command command = PrependPathCommand("path1");
+                prependPath.Execute(_ec.Object, command);
+                Assert.True(_ec.Object.PrependPath.Contains("path1"));
+
+                // disallow path
+                var restrictions = new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() };
+                _ec.Object.Restrictions.Add(restrictions);
+                prependPath = new TaskPrepandPathCommand();
+                command = PrependPathCommand("path2");
+                Assert.Throws<InvalidOperationException>(() => prependPath.Execute(_ec.Object, command));
+
+                // allow path
+                restrictions.SettableVariables.Allowed.Add("path");
+                prependPath = new TaskPrepandPathCommand();
+                command = PrependPathCommand("path3");
+                prependPath.Execute(_ec.Object, command);
+                Assert.True(_ec.Object.PrependPath.Contains("path3"));
+            }
+        }
+        private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
+        {
+            var hc = new TestHostContext(this, testName);
+
+            _variables = new Variables(
+                hostContext: hc,
+                copy: new Dictionary<string, VariableValue>(),
+                warnings: out _);
+
+            _ec = new Mock<IExecutionContext>();
+            _ec.SetupAllProperties();
+            _ec.Setup(x => x.PrependPath).Returns(new List<string>());
+            _ec.Setup(x => x.Restrictions).Returns(new List<TaskRestrictions>());
+            _ec.Setup(x => x.GetHostContext()).Returns(hc);
+            _ec.Setup(x => x.Variables).Returns(_variables);
+            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Callback<string, string, bool, bool, bool, bool>((name, value, secret, b2, b3, readOnly) => _variables.Set(name, value, secret, readOnly));
+
+            return hc;
+        }
+
+        private Command SetVariableCommand(String name, String value)
+        {
+            var command = new Command("task", "setvariable");
+            command.Properties.Add("variable", name);
+            command.Data = value;
+            return command;
+        }
+
+        private Command PrependPathCommand(String value)
+        {
+            var command = new Command("task", "prependpath");
+            command.Data = value;
+            return command;
+        }
+
+        private Mock<IExecutionContext> _ec;
+        private Variables _variables;
+    }
+}

--- a/src/Test/L0/Worker/TaskManagerL0.cs
+++ b/src/Test/L0/Worker/TaskManagerL0.cs
@@ -467,6 +467,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             ""target"": ""no such target""
         }
     },
+    ""restrictions"": {
+        ""commands"": {
+            ""mode"": ""restricted""
+        },
+        ""settableVariables"": {
+            ""allowed"": [
+                ""okVar"",
+                ""otherVar""
+            ]
+        }
+    },
     ""someExtraSection"": {
         ""someExtraKey"": ""Some extra value""
     }
@@ -524,6 +535,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                         Assert.Equal("Some process target", definition.Data.Execution.Process.Target);
                         Assert.Equal("Some process working directory", definition.Data.Execution.Process.WorkingDirectory);
                     }
+
+                    // restrictions
+                    Assert.NotNull(definition.Data.Restrictions);
+                    Assert.Equal(TaskCommandMode.Restricted, definition.Data.Restrictions.Commands.Mode);
+                    Assert.Equal(2, definition.Data.Restrictions.SettableVariables.Allowed.Count);
+                    Assert.Equal("okVar", definition.Data.Restrictions.SettableVariables.Allowed[0]);
+                    Assert.Equal("otherVar", definition.Data.Restrictions.SettableVariables.Allowed[1]);
                 }
             }
             finally


### PR DESCRIPTION
Add support for limiting which variables a task
can set via an explicitly allowed list. Also,
extend support for the existing restricted command
mode to the task.json