### PR TITLE
Force Npm 6

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -44,6 +44,11 @@ extends:
 
             steps:
             - checkout: self
+          
+            - task: NodeTool@0
+              displayName: Use node 14.15.1
+              inputs:
+                versionSpec: "14.15.1"
 
             - script: |
                 cd release


### PR DESCRIPTION
This forces us to use npm 6 since that's installed side by side with Node 14.15.1. This avoids collisions between different lockFileVersions used between npm 6 and 7