### PR TITLE
Increased default value for AZP_AGENT_DOWNLOAD_TIMEOUT 

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -112,7 +112,7 @@ namespace Agent.Sdk.Knob
             nameof(AgentDownloadTimeout),
             "Amount of time in seconds to wait for the agent to download a new version when updating",
             new EnvironmentKnobSource("AZP_AGENT_DOWNLOAD_TIMEOUT"),
-            new BuiltInDefaultKnobSource("900")); // 15*60
+            new BuiltInDefaultKnobSource("1500")); // 25*60
 
         public static readonly Knob TaskDownloadTimeout = new Knob(
             nameof(TaskDownloadTimeout),


### PR DESCRIPTION
Increased default value for AZP_AGENT_DOWNLOAD_TIMEOUT - since agent package size increased.
Related issue - https://github.com/microsoft/azure-pipelines-agent/issues/3197