### PR TITLE
Fix clean parameter behavior in jobs with multiple checkouts

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -190,7 +190,7 @@ namespace Agent.Sdk.Knob
             nameof(DisableAgentDowngrade),
             "Disable agent downgrades. Upgrades will still be allowed.",
             new EnvironmentKnobSource("AZP_AGENT_DOWNGRADE_DISABLED"),
-            new BuiltInDefaultKnobSource("true"));
+            new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob PermissionsCheckFailsafe = new Knob(
             nameof(PermissionsCheckFailsafe),

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -190,7 +190,7 @@ namespace Agent.Sdk.Knob
             nameof(DisableAgentDowngrade),
             "Disable agent downgrades. Upgrades will still be allowed.",
             new EnvironmentKnobSource("AZP_AGENT_DOWNGRADE_DISABLED"),
-            new BuiltInDefaultKnobSource("false"));
+            new BuiltInDefaultKnobSource("true"));
 
         public static readonly Knob PermissionsCheckFailsafe = new Knob(
             nameof(PermissionsCheckFailsafe),

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -183,7 +183,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         private void UpdateCheckoutTasksAndVariables(IExecutionContext executionContext, IList<JobStep> steps, string pipelineWorkspaceDirectory)
         {
-            System.Diagnostics.Debugger.Launch();
             bool? submoduleCheckout = null;
             // RepoClean may be set from the server, so start with the server value
             bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -183,6 +183,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         private void UpdateCheckoutTasksAndVariables(IExecutionContext executionContext, IList<JobStep> steps, string pipelineWorkspaceDirectory)
         {
+            System.Diagnostics.Debugger.Launch();
             bool? submoduleCheckout = null;
             // RepoClean may be set from the server, so start with the server value
             bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -186,8 +186,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             bool? submoduleCheckout = null;
             // RepoClean may be set from the server, so start with the server value
             bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);
-            // Check if RepoClean was setuped from the server, this requered to overwrite checkout step clean option only in case this value comes from the server
-            // This flag is requred for handling multi checkout job scenarious
+            // Check if RepoClean was setuped from the server, this flag is requred for handling multi checkout
+            // job scenarious to overwrite clean option in checkout tasks only in case this value comes from the server
             bool repoCleanFromServer = repoClean != null;
 
             var checkoutTasks = steps.Where(x => x.IsCheckoutTask()).Select(x => x as TaskStep).ToList();

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -185,10 +185,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         {
             bool? submoduleCheckout = null;
             // RepoClean may be set from the server, so start with the server value
-            bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);
-            // Check if RepoClean was setuped from the server, this flag is requred for handling multi checkout
-            // job scenarious to overwrite clean option in checkout tasks only in case this value comes from the server
-            bool repoCleanFromServer = repoClean != null;
+            bool? repoCleanFromServer = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);
+            // The value for the global clean option will be set in this variable based on Self repository clean input if the global value weren't set by the server
+            bool? repoCleanFromSelf = null;
 
             var checkoutTasks = steps.Where(x => x.IsCheckoutTask()).Select(x => x as TaskStep).ToList();
             var hasOnlyOneCheckoutTask = checkoutTasks.Count == 1;
@@ -202,9 +201,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 }
 
                 // Update the checkout "Clean" property for all repos, if the variable was set by the server.
-                if (repoClean != null && repoCleanFromServer)
+                if (repoCleanFromServer.HasValue)
                 {
-                    checkoutTask.Inputs[PipelineConstants.CheckoutTaskInputs.Clean] = repoClean.Value.ToString();
+                    checkoutTask.Inputs[PipelineConstants.CheckoutTaskInputs.Clean] = repoCleanFromServer.Value.ToString();
                 }
 
                 Trace.Info($"Checking repository name {repositoryAlias}");
@@ -215,9 +214,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 if (hasOnlyOneCheckoutTask || RepositoryUtil.IsPrimaryRepositoryName(repositoryAlias))
                 {
                     submoduleCheckout = checkoutTask.Inputs.ContainsKey(PipelineConstants.CheckoutTaskInputs.Submodules);
-                    if (repoClean == null && checkoutTask.Inputs.TryGetValue(PipelineConstants.CheckoutTaskInputs.Clean, out string cleanInputValue))
+                    if (!repoCleanFromServer.HasValue && checkoutTask.Inputs.TryGetValue(PipelineConstants.CheckoutTaskInputs.Clean, out string cleanInputValue))
                     {
-                        repoClean = Boolean.TryParse(cleanInputValue, out bool cleanValue) ? cleanValue : true;
+                        repoCleanFromSelf = Boolean.TryParse(cleanInputValue, out bool cleanValue) ? cleanValue : true;
                     }
                 }
 
@@ -255,9 +254,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 executionContext.SetVariable(Constants.Variables.Build.RepoGitSubmoduleCheckout, submoduleCheckout.Value.ToString());
             }
 
-            if (repoClean.HasValue)
+            if (repoCleanFromSelf.HasValue)
             {
-                executionContext.SetVariable(Constants.Variables.Build.RepoClean, repoClean.Value.ToString());
+                executionContext.SetVariable(Constants.Variables.Build.RepoClean, repoCleanFromSelf.Value.ToString());
             }
         }
 

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 if (hasOnlyOneCheckoutTask || RepositoryUtil.IsPrimaryRepositoryName(repositoryAlias))
                 {
                     submoduleCheckout = checkoutTask.Inputs.ContainsKey(PipelineConstants.CheckoutTaskInputs.Submodules);
-                    if (checkoutTask.Inputs.TryGetValue(PipelineConstants.CheckoutTaskInputs.Clean, out string cleanInputValue))
+                    if (repoClean == null && checkoutTask.Inputs.TryGetValue(PipelineConstants.CheckoutTaskInputs.Clean, out string cleanInputValue))
                     {
                         repoClean = Boolean.TryParse(cleanInputValue, out bool cleanValue) ? cleanValue : true;
                     }

--- a/src/Agent.Worker/Build/BuildJobExtension.cs
+++ b/src/Agent.Worker/Build/BuildJobExtension.cs
@@ -186,6 +186,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             bool? submoduleCheckout = null;
             // RepoClean may be set from the server, so start with the server value
             bool? repoClean = executionContext.Variables.GetBoolean(Constants.Variables.Build.RepoClean);
+            // Check if RepoClean was setuped from the server, this requered to overwrite checkout step clean option only in case this value comes from the server
+            // This flag is requred for handling multi checkout job scenarious
             bool repoCleanFromServer = repoClean != null;
 
             var checkoutTasks = steps.Where(x => x.IsCheckoutTask()).Select(x => x as TaskStep).ToList();
@@ -216,7 +218,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     if (checkoutTask.Inputs.TryGetValue(PipelineConstants.CheckoutTaskInputs.Clean, out string cleanInputValue))
                     {
                         repoClean = Boolean.TryParse(cleanInputValue, out bool cleanValue) ? cleanValue : true;
-                    } 
+                    }
                 }
 
                 // Update the checkout task display name if not already set


### PR DESCRIPTION
This PR should fix an issue from the [FeedbackTicket 1806209](https://developercommunity2.visualstudio.com/t/Azure-Pipelines-checkout-clean:-true-d/1304099)

**What worked wrong:**

There was broken logic for overwriting the Clean parameter in jobs with multiple checkouts.
Clean parameter of Self checkout job overrides Clean option for all other checkout tasks that were executed after it.
That was caused by the fact that in case the global clean parameter wasn't set from the server, UpdateCheckoutTasksAndVariables set is based on the value of Self checkout task. Because of it, users could see strange behavior when the order of tasks in definition affecting Clean parameter value (if Self repo is first it will override all the parameters, if it last, all the tasks will have the right value in Clean input).
The setting of the global clean parameter based on the value of the Clean parameter in the checkout task also works wrong, since it doesn't respect the value that was passed in this parameter but just checks if the user has passed this parameter.

**How it works now:**

Was added a flag that defines if the repoClean parameter was settled globally from the server if so checkout tasks' Clean input will be overwritten according to this parameter. If the global parameter wasn't set tasks' will have either the default Clean value (which is true) or the one that was set by the user.
Was fixed the logic that set repoClean based on the value of Self repository Clean parameter, now it isn't just checking if this parameter was passed but also get its value.

References to test pipeline:
* [Check that tasks has the right value that was passed the in input](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=1842&view=logs&j=e7b80b24-15e8-561b-2b9b-3069817c0357&t=72beb26e-9f5f-53ed-21fb-adae0384cca4)
* [Check that global clean value overwrites tasks' inputs with a true value](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=1840&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=47344039-8be0-5b07-fad9-fe3916c2f226)
* [Check that global clean value overwrites tasks' inputs with a false value](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=1841&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=6d902f23-eac0-5816-73b8-641480037156)
