### PR TITLE
Implemented a knob to allow TFVC unshelve command errors

### DIFF
--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -384,7 +384,8 @@ namespace Agent.Plugins.Repository
                 }
 
                 // Unshelve.
-                await tf.UnshelveAsync(shelveset: shelvesetName, false);
+                bool unshelveErrorsAllowed = AgentKnobs.AllowTfvcUnshelveErrors.GetValue(executionContext).AsBoolean();
+                await tf.UnshelveAsync(shelveset: shelvesetName, unshelveErrorsAllowed);
 
                 // Ensure we undo pending changes for shelveset build at the end.
                 executionContext.SetTaskVariable("UndoShelvesetPendingChanges", bool.TrueString);

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -210,6 +210,13 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("DECODE_PERCENTS"),
             new EnvironmentKnobSource("DECODE_PERCENTS"),
             new BuiltInDefaultKnobSource(""));
+
+        public static readonly Knob AllowTfvcUnshelveErrors = new Knob(
+            nameof(AllowTfvcUnshelveErrors),
+            "By default, the TFVC unshelve command does not throw errors e.g. when there's no mapping for one or more files shelved. Setting this to true enables this behavior.",
+            new RuntimeKnobSource("ALLOW_TFVC_UNSHELVE_ERRORS"),
+            new EnvironmentKnobSource("ALLOW_TFVC_UNSHELVE_ERRORS"),
+            new BuiltInDefaultKnobSource("false"));
     }
 
 }


### PR DESCRIPTION
Related work item: #3198

TFVC unshelve command doesn't throw errors by default. It allows unshelving only mapped files. This behavior was introduced in the PR #3064. 
The implemented knob allows disabling suppressing and make a pipeline fail if it's set to true and not all shelved files are mapped.

Here's examples:
[Default behavior](https://dev.azure.com/v-egbryz/TestProject/_build/results?buildId=1632&view=logs&j=cfa20e98-6997-523c-4233-f0a7302c929f&t=cfa20e98-6997-523c-4233-f0a7302c929f)
[The knob set to true.](https://dev.azure.com/v-egbryz/TestProject/_build/results?buildId=1634&view=logs&j=cfa20e98-6997-523c-4233-f0a7302c929f&t=c543f4ff-491c-5ad1-8e22-98d6522d2503)