### PR TITLE
Revert "Self-hosted agent cleaning source folder (#3237)"

### DIFF
--- a/src/Agent.Worker/Build/BuildDirectoryManager.cs
+++ b/src/Agent.Worker/Build/BuildDirectoryManager.cs
@@ -122,25 +122,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             // Set the default clone path for each repository (the Checkout task may override this later)
             foreach (var repository in repositories)
             {
-                String repoPath;
-                if (RepositoryUtil.HasMultipleCheckouts(executionContext.JobSettings))
-                {
-                    // If we have multiple checkouts they should all be rooted to the sources directory (_work/1/s/repo1)
-                    var repoSourceDirectory = newConfig?.RepositoryTrackingInfo.Where(item => string.Equals(item.Identifier, repository.Alias, StringComparison.OrdinalIgnoreCase)).Select(item => item.SourcesDirectory).FirstOrDefault();
-                    if (repoSourceDirectory != null)
-                    {
-                        repoPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), repoSourceDirectory);
-                    }
-                    else
-                    {
-                        repoPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newConfig.SourcesDirectory, RepositoryUtil.GetCloneDirectory(repository));
-                    }
-                }
-                else
-                {
-                    // For single checkouts, the repository is rooted to the sources folder (_work/1/s)
-                    repoPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), newConfig.SourcesDirectory);
-                }
+                var repoPath = GetDefaultRepositoryPath(executionContext, repository, newConfig.SourcesDirectory);
 
                 if (!string.Equals(repoPath, defaultSourceDirectory, StringComparison.Ordinal))
                 {
@@ -302,6 +284,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 {
                     return BuildCleanOption.None;
                 }
+            }
+        }
+
+        private string GetDefaultRepositoryPath(
+            IExecutionContext executionContext,
+            RepositoryResource repository,
+            string defaultSourcesDirectory)
+        {
+            if (RepositoryUtil.HasMultipleCheckouts(executionContext.JobSettings))
+            {
+                // If we have multiple checkouts they should all be rooted to the sources directory (_work/1/s/repo1)
+                return Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), defaultSourcesDirectory, RepositoryUtil.GetCloneDirectory(repository));
+            }
+            else
+            {
+                // For single checkouts, the repository is rooted to the sources folder (_work/1/s)
+                return Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), defaultSourcesDirectory);
             }
         }
     }

--- a/src/Agent.Worker/PluginInternalCommandExtension.cs
+++ b/src/Agent.Worker/PluginInternalCommandExtension.cs
@@ -60,12 +60,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 bool isSelfRepo = RepositoryUtil.IsPrimaryRepositoryName(repository.Alias);
                 bool hasMultipleCheckouts = RepositoryUtil.HasMultipleCheckouts(context.JobSettings);
 
-                var directoryManager = context.GetHostContext().GetService<IBuildDirectoryManager>();
-                string _workDirectory = context.GetHostContext().GetDirectory(WellKnownDirectory.Work);
-                var trackingConfig = directoryManager.UpdateDirectory(context, repository);
-
                 if (isSelfRepo || !hasMultipleCheckouts)
                 {
+                    var directoryManager = context.GetHostContext().GetService<IBuildDirectoryManager>();
+                    string _workDirectory = context.GetHostContext().GetDirectory(WellKnownDirectory.Work);
+
+                    var trackingConfig = directoryManager.UpdateDirectory(context, repository);
                     if (hasMultipleCheckouts)
                     {
                         // In Multi-checkout, we don't want to reset sources dir or default working dir.


### PR DESCRIPTION
This PR is reverting changes made in #3237 since they are breaking behavior of Build.Repository.LocalPath variable in some cases: #3295