### PR TITLE
Work around missing PowerShell profile

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -90,6 +90,11 @@ extends:
           - powershell: |
               Write-Host "Preloading Azure modules." # This is for better performance, to avoid module-autoloading.
               Import-Module AzureRM, AzureRM.profile, AzureRM.Storage, Azure.Storage, AzureRM.Cdn -ErrorAction Ignore -PassThru
+              if (!(Test-Path "$HOME\Documents\WindowsPowerShell\profile.ps1"))
+              {
+                Write-Host "Creating empty PowerShell profile for Enable-AzureRmAlias"
+                New-Item -Path "$HOME\Documents\WindowsPowerShell\profile.ps1" -ItemType File -Force | Out-Null
+              }
               Enable-AzureRmAlias -Scope CurrentUser
               $uploadFiles = New-Object System.Collections.ArrayList
               $certificateThumbprint = (Get-ItemProperty -Path "$(ServicePrincipalReg)").ServicePrincipalCertThumbprint


### PR DESCRIPTION
Enable-AzureRmAlias wants this file to exist, but it
doesn't always on our prod agents, leading to inconsistent
failures.