### PR TITLE
Decode %AZP25 to % by default

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -209,7 +209,7 @@ namespace Agent.Sdk.Knob
             "By default, the agent does not decodes %AZP25 as % which may be needed to allow users to work around reserved values. Setting this to true enables this behavior.",
             new RuntimeKnobSource("DECODE_PERCENTS"),
             new EnvironmentKnobSource("DECODE_PERCENTS"),
-            new BuiltInDefaultKnobSource(""));
+            new BuiltInDefaultKnobSource("true"));
 
         public static readonly Knob AllowTfvcUnshelveErrors = new Knob(
             nameof(AllowTfvcUnshelveErrors),


### PR DESCRIPTION
We promised to turn this on in March in our doc, and we haven't had any complaints about it. This has caused a lot of support load, so getting this fix out and eventually into the task-lib/tasks should happen soon