### PR TITLE
Remove broken myget feeds

### DIFF
--- a/src/Agent.Listener/NuGet.Config
+++ b/src/Agent.Listener/NuGet.Config
@@ -5,7 +5,6 @@
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
     <add key="BuildXL.Selfhost" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL.Selfhost/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Agent.Worker/NuGet.Config
+++ b/src/Agent.Worker/NuGet.Config
@@ -5,7 +5,6 @@
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
     <add key="BuildXL.Selfhost" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL.Selfhost/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.VisualStudio.Services.Agent/NuGet.Config
+++ b/src/Microsoft.VisualStudio.Services.Agent/NuGet.Config
@@ -5,7 +5,6 @@
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
     <add key="BuildXL.Selfhost" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL.Selfhost/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -5,8 +5,6 @@
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
     <add key="BuildXL.Selfhost" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL.Selfhost/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="testresultparser" value="https://www.myget.org/F/testresultparser/api/v3/index.json " />
   </packageSources>

--- a/src/Test/NuGet.Config
+++ b/src/Test/NuGet.Config
@@ -5,8 +5,6 @@
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json" />
     <add key="BuildXL.Selfhost" value="https://pkgs.dev.azure.com/ms/BuildXL/_packaging/BuildXL.Selfhost/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Builds are failing due to cert errors with these feeds. On investigation I can't find any reason for these to be in the config at all. It looks like cruft from an earlier phase of the project.