### PR TITLE
Introduce enforcement mode for task restrictions

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -185,6 +185,19 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AZP_USE_CREDSCAN_REGEXES"),
             new BuiltInDefaultKnobSource("false"));
 
+        // Task restrictions
+        public static readonly Knob TaskRestrictionsEnforcementMode = new Knob(
+            nameof(TaskRestrictionsEnforcementMode),
+            "The enforcement mode for command or variable restrictions defined in tasks. Values are Enabled, WarningOnly, Disabled.",
+            new RuntimeKnobSource("agent.taskRestrictionsEnforcementMode"),
+            new BuiltInDefaultKnobSource("WarningOnly"));
+
+        public static readonly Knob EnableTaskRestrictionsTelemetry = new Knob(
+            nameof(EnableTaskRestrictionsTelemetry),
+            "Enable capturing telemetry on the enforcement of command or variable restrictions defined in tasks.",
+            new RuntimeKnobSource("agent.enableTaskRestrictionsTelemetry"),
+            new BuiltInDefaultKnobSource("false"));
+
         // Misc
         public static readonly Knob DisableAgentDowngrade = new Knob(
             nameof(DisableAgentDowngrade),

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         var restrictions = new List<TaskRestrictions>();
                         if (taskDefinition.Data.Restrictions != null)
                         {
-                            restrictions.Add(taskDefinition.Data.Restrictions);
+                            restrictions.Add(new TaskDefinitionRestrictions(taskDefinition.Data));
                         }
                         if (string.Equals(WellKnownStepTargetStrings.Restricted, task.Target?.Commands, StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -326,6 +326,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
     public sealed class DefinitionData
     {
+        public DefinitionVersion Version { get; set; }
+        public string Name { get; set; }
         public string FriendlyName { get; set; }
         public string Description { get; set; }
         public string HelpMarkDown { get; set; }
@@ -337,6 +339,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public ExecutionData Execution { get; set; }
         public ExecutionData PostJobExecution { get; set; }
         public TaskRestrictions Restrictions { get; set; }
+    }
+
+    public sealed class DefinitionVersion
+    {
+        public int Major { get; set; }
+        public int Minor { get; set; }
+        public int Patch { get; set; }
     }
 
     public sealed class OutputVariable

--- a/src/Agent.Worker/TaskRestrictionsChecker.cs
+++ b/src/Agent.Worker/TaskRestrictionsChecker.cs
@@ -56,15 +56,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(warn, nameof(warn));
             ArgUtil.NotNull(publishTelemetry, nameof(publishTelemetry));
 
-            var matches = context.Restrictions?.Where(restrictions => !predicate(restrictions));
+            var failedMatches = context.Restrictions?.Where(restrictions => !predicate(restrictions));
 
-            if (matches.IsNullOrEmpty())
+            if (failedMatches.IsNullOrEmpty())
             {
                 return true;
             }
             else
             {
-                var taskMatches = matches.Where(restrictions => restrictions is TaskDefinitionRestrictions).Cast<TaskDefinitionRestrictions>();
+                var taskMatches = failedMatches.Where(restrictions => restrictions is TaskDefinitionRestrictions).Cast<TaskDefinitionRestrictions>();
 
                 if(AgentKnobs.EnableTaskRestrictionsTelemetry.GetValue(context).AsBoolean())
                 {
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 string mode = AgentKnobs.TaskRestrictionsEnforcementMode.GetValue(context).AsString();
 
-                if (String.Equals(mode, "Enabled", StringComparison.OrdinalIgnoreCase) || taskMatches.Count() != matches.Count())
+                if (String.Equals(mode, "Enabled", StringComparison.OrdinalIgnoreCase) || taskMatches.Count() != failedMatches.Count())
                 {
                     // we are enforcing restrictions from tasks, or we matched restrictions from the pipeline, which we always enforce
                     warn();

--- a/src/Agent.Worker/TaskRestrictionsChecker.cs
+++ b/src/Agent.Worker/TaskRestrictionsChecker.cs
@@ -1,0 +1,143 @@
+﻿using Agent.Sdk.Knob;
+using Microsoft.TeamFoundation.Common;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Agent.Worker.Telemetry;
+using Microsoft.VisualStudio.Services.WebPlatform;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker
+{
+    [ServiceLocator(Default = typeof(TaskRestrictionsChecker))]
+    public interface ITaskRestrictionsChecker : IAgentService
+    {
+        bool CheckCommand(IExecutionContext context, IWorkerCommand workerCommand, Command command);
+        bool CheckSettableVariable(IExecutionContext context, string variable);
+    }
+
+    public sealed class TaskRestrictionsChecker : AgentService, ITaskRestrictionsChecker
+    {
+        public bool CheckCommand(IExecutionContext context, IWorkerCommand workerCommand, Command command)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(workerCommand, nameof(workerCommand));
+            ArgUtil.NotNull(command, nameof(command));
+
+            return Check(
+                context,
+                restrictions => !restrictions.IsCommandAllowed(workerCommand),
+                () => context.Warning(StringUtil.Loc("CommandNotAllowed", command.Area, command.Event)),
+                restrictions => PublishCommandTelemetry(context, restrictions, command));
+        }
+
+        public bool CheckSettableVariable(IExecutionContext context, string variable)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(variable, nameof(variable));
+
+            return Check(
+                context,
+                restrictions => !restrictions.IsSetVariableAllowed(variable),
+                () => context.Warning(StringUtil.Loc("SetVariableNotAllowed", variable)),
+                restrictions => PublishVariableTelemetry(context, restrictions, variable));
+        }
+
+        private bool Check(
+            IExecutionContext context,
+            Func<TaskRestrictions, bool> predicate,
+            Action warn,
+            Action<TaskDefinitionRestrictions> publishTelemetry)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(predicate, nameof(predicate));
+            ArgUtil.NotNull(warn, nameof(warn));
+            ArgUtil.NotNull(publishTelemetry, nameof(publishTelemetry));
+
+            var matches = context.Restrictions?.Where(predicate);
+
+            if (matches.IsNullOrEmpty())
+            {
+                return true;
+            }
+            else
+            {
+                var taskMatches = matches.Where(restrictions => restrictions is TaskDefinitionRestrictions).Cast<TaskDefinitionRestrictions>();
+
+                if(AgentKnobs.EnableTaskRestrictionsTelemetry.GetValue(context).AsBoolean())
+                {
+                    foreach(var match in taskMatches)
+                    {
+                        publishTelemetry(match);
+                    }
+                }
+
+                string mode = AgentKnobs.TaskRestrictionsEnforcementMode.GetValue(context).AsString();
+
+                if (String.Equals(mode, "Enabled", StringComparison.OrdinalIgnoreCase) || taskMatches.Count() != matches.Count())
+                {
+                    // we are enforcing restrictions from tasks, or we matched restrictions from the pipeline, which we always enforce
+                    warn();
+                    return false;
+                }
+                else
+                {
+                    if (!String.Equals(mode, "Disabled", StringComparison.OrdinalIgnoreCase))
+                    {
+                        warn();
+                    }
+                    return true;
+                }
+            }
+        }
+
+        private void PublishCommandTelemetry(IExecutionContext context, TaskDefinitionRestrictions restrictions, Command command)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(restrictions, nameof(restrictions));
+            ArgUtil.NotNull(command, nameof(command));
+
+            var data = new Dictionary<string, object>()
+            {
+                { "Command", $"{command.Area}.{command.Event}" }
+            };
+            PublishTelemetry(context, restrictions, "TaskRestrictions_Command", data);
+        }
+
+        private void PublishVariableTelemetry(IExecutionContext context, TaskDefinitionRestrictions restrictions, string variable)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(restrictions, nameof(restrictions));
+            ArgUtil.NotNull(variable, nameof(variable));
+
+            var data = new Dictionary<string, object>()
+            {
+                { "Variable", variable }
+            };
+            PublishTelemetry(context, restrictions, "TaskRestrictions_SetVariable", data);
+        }
+
+        private void PublishTelemetry(IExecutionContext context, TaskDefinitionRestrictions restrictions, string feature, Dictionary<string, object> data)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(restrictions, nameof(restrictions));
+            ArgUtil.NotNull(feature, nameof(feature));
+            ArgUtil.NotNull(data, nameof(data));
+
+            data.Add("TaskName", restrictions.Definition.Name);
+            data.Add("TaskVersion", restrictions.Definition.Version);
+
+            CustomerIntelligenceEvent ciEvent = new CustomerIntelligenceEvent()
+            {
+                Area = "AzurePipelinesAgent",
+                Feature = feature,
+                Properties = data
+            };
+
+            var publishCommand = new PublishTelemetryCommand();
+            publishCommand.PublishEvent(context, ciEvent);
+        }
+    }
+}

--- a/src/Agent.Worker/TaskRestrictionsChecker.cs
+++ b/src/Agent.Worker/TaskRestrictionsChecker.cs
@@ -28,9 +28,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return Check(
                 context,
-                restrictions => !restrictions.IsCommandAllowed(workerCommand),
+                (TaskRestrictions restrictions) => !restrictions.IsCommandAllowed(workerCommand),
                 () => context.Warning(StringUtil.Loc("CommandNotAllowed", command.Area, command.Event)),
-                restrictions => PublishCommandTelemetry(context, restrictions, command));
+                (TaskDefinitionRestrictions restrictions) => PublishCommandTelemetry(context, restrictions, command));
         }
 
         public bool CheckSettableVariable(IExecutionContext context, string variable)

--- a/src/Agent.Worker/TaskRestrictionsChecker.cs
+++ b/src/Agent.Worker/TaskRestrictionsChecker.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return Check(
                 context,
-                (TaskRestrictions restrictions) => !restrictions.IsCommandAllowed(workerCommand),
+                (TaskRestrictions restrictions) => restrictions.IsCommandAllowed(workerCommand),
                 () => context.Warning(StringUtil.Loc("CommandNotAllowed", command.Area, command.Event)),
                 (TaskDefinitionRestrictions restrictions) => PublishCommandTelemetry(context, restrictions, command));
         }
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return Check(
                 context,
-                restrictions => !restrictions.IsSetVariableAllowed(variable),
+                restrictions => restrictions.IsSetVariableAllowed(variable),
                 () => context.Warning(StringUtil.Loc("SetVariableNotAllowed", variable)),
                 restrictions => PublishVariableTelemetry(context, restrictions, variable));
         }
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(warn, nameof(warn));
             ArgUtil.NotNull(publishTelemetry, nameof(publishTelemetry));
 
-            var matches = context.Restrictions?.Where(predicate);
+            var matches = context.Restrictions?.Where(restrictions => !predicate(restrictions));
 
             if (matches.IsNullOrEmpty())
             {

--- a/src/Agent.Worker/TaskRestrictionsChecker.cs
+++ b/src/Agent.Worker/TaskRestrictionsChecker.cs
@@ -40,9 +40,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             return Check(
                 context,
-                restrictions => restrictions.IsSetVariableAllowed(variable),
+                (TaskRestrictions restrictions) => restrictions.IsSetVariableAllowed(variable),
                 () => context.Warning(StringUtil.Loc("SetVariableNotAllowed", variable)),
-                restrictions => PublishVariableTelemetry(context, restrictions, variable));
+                (TaskDefinitionRestrictions restrictions) => PublishVariableTelemetry(context, restrictions, variable));
         }
 
         private bool Check(

--- a/src/Agent.Worker/TaskRestrictionsExtension.cs
+++ b/src/Agent.Worker/TaskRestrictionsExtension.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Minimatch;
+using System;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker
+{
+    [ AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    public sealed class CommandRestrictionAttribute : Attribute
+    {
+        public bool AllowedInRestrictedMode { get; set; }
+    }
+
+    public static class TaskRestrictionExtension
+    {
+        public static Boolean IsCommandAllowed(this TaskRestrictions restrictions, IWorkerCommand command)
+        {
+            ArgUtil.NotNull(command, nameof(command));
+
+            if (restrictions.Commands?.Mode == TaskCommandMode.Restricted)
+            {
+                foreach (var attr in command.GetType().GetCustomAttributes(typeof(CommandRestrictionAttribute), false))
+                {
+                    var cra = attr as CommandRestrictionAttribute;
+                    if (cra.AllowedInRestrictedMode)
+                    {
+                        return true;
+                    }
+                }
+                
+                return false;
+            }
+            else
+            {
+                return true;
+            } 
+        }
+
+        public static Boolean IsSetVariableAllowed(this TaskRestrictions restrictions, String variable)
+        {
+            ArgUtil.NotNull(variable, nameof(variable));
+
+            var allowedList = restrictions.SettableVariables?.Allowed;
+            if (allowedList == null)
+            {
+                return true;
+            }
+
+            var opts = new Options() { IgnoreCase = true };
+            foreach (String pattern in allowedList)
+            {
+                if (Minimatcher.Check(variable, pattern, opts))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public sealed class TaskDefinitionRestrictions : TaskRestrictions
+    {
+        public TaskDefinitionRestrictions(DefinitionData definition) : base()
+        {
+            Definition = definition;
+            Commands = definition.Restrictions?.Commands;
+            SettableVariables = definition.Restrictions?.SettableVariables;
+        }
+
+        public DefinitionData Definition { get; }
+    }
+}

--- a/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs
+++ b/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Telemetry
         public string Name => "publish";
         public List<string> Aliases => null;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA2000:Dispose objects before losing scope", MessageId = "GetVssConnection")]
         public void Execute(IExecutionContext context, Command command)
         {
             ArgUtil.NotNull(context, nameof(context));
@@ -67,6 +66,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Telemetry
                 throw new ArgumentException(StringUtil.Loc("TelemetryCommandDataError", data, ex.Message));
             }
 
+            PublishEvent(context, ciEvent);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA2000:Dispose objects before losing scope", MessageId = "GetVssConnection")]
+        public void PublishEvent(IExecutionContext context, CustomerIntelligenceEvent ciEvent)
+        {
             ICustomerIntelligenceServer ciService;
             VssConnection vssConnection;
             try

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -214,6 +214,7 @@
     ".{0}config.{1} remove --unattended --auth negotiate --username myDomain\\myUserName --password myPassword"
   ],
   "CommandNotAllowed": "##vso[{0}.{1}] is not allowed in this step due to policy restrictions. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
+  "CommandNotAllowedWarnOnly": "##vso[{0}.{1}] has been declared as disallowed due to policy restrictions. This command will be suppressed at a future date. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
   "CommandNotFound": "Cannot find command extension for ##vso[{0}.command]. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
   "CommandNotFound2": "##vso[{0}.{1}] is not a recognized command for {2} command extension. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296).",
   "CommandNotSupported": "{0} commands are not supported for {1} flow. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=817296)",
@@ -560,6 +561,7 @@
   "SetBuildVars": "Set build variables.",
   "SetEnvVar": "Setting environment variable {0}",
   "SetVariableNotAllowed": "Setting variable '{0}' has been disabled by the task or build definition.",
+  "SetVariableNotAllowedWarnOnly": "Setting variable '{0}' has been declared as disallowed by the task or build definition. This command will be suppressed at a future date.",
   "ShallowCheckoutFail": "Git checkout failed on shallow repository, this might because of git fetch with depth '{0}' doesn't include the checkout commit '{1}'. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=829603)",
   "ShallowLfsFetchFail": "Git lfs fetch failed on shallow repository, this might because of git fetch with depth '{0}' doesn't include the lfs fetch commit '{1}'. Please reference documentation (http://go.microsoft.com/fwlink/?LinkId=829603)",
   "ShutdownMessage": "Restarting the machine in order to launch agent in interactive mode.",

--- a/src/Test/L0/ServiceInterfacesL0.cs
+++ b/src/Test/L0/ServiceInterfacesL0.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 typeof(IResultReader),
                 typeof(INUnitResultsXmlReader),
                 typeof(IWorkerCommand),
-                typeof(IWorkerCommandRestrictionPolicy)
+                typeof(ITaskRestrictionsChecker)
             };
             Validate(
                 assembly: typeof(IStepsRunner).GetTypeInfo().Assembly,

--- a/src/Test/L0/Worker/CodeCoverage/CodeCoverageCommandExtensionTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CodeCoverageCommandExtensionTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
         private Mock<IAsyncCommandContext> _mockCommandContext;
         private List<CodeCoverageStatistics> _codeCoverageStatistics;
         private Variables _variables;
-        private IWorkerCommandRestrictionPolicy _policy = new UnrestricedWorkerCommandRestrictionPolicy();
 
         #region publish code coverage tests
         [Fact]
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                 publishCCCommand.Initialize(_hc);
                 var command = new Command("codecoverage", "publish");
                 command.Properties.Add("summaryfile", "a.xml");
-                Assert.Throws<ArgumentException>(() => publishCCCommand.ProcessCommand(_ec.Object, command, _policy));
+                Assert.Throws<ArgumentException>(() => publishCCCommand.ProcessCommand(_ec.Object, command));
             }
         }
 
@@ -55,7 +54,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                 publishCCCommand.Initialize(_hc);
                 var command = new Command("codecoverage", "publish");
                 _variables.Set("system.hostType", "release");
-                publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                publishCCCommand.ProcessCommand(_ec.Object, command);
                 Assert.Equal(1, _warnings.Count);
                 Assert.Equal(0, _errors.Count);
             }
@@ -71,7 +70,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                 var publishCCCommand = new CodeCoverageCommandExtension();
                 publishCCCommand.Initialize(_hc);
                 var command = new Command("codecoverage", "publish");
-                Assert.Throws<ArgumentException>(() => publishCCCommand.ProcessCommand(_ec.Object, command, _policy));
+                Assert.Throws<ArgumentException>(() => publishCCCommand.ProcessCommand(_ec.Object, command));
             }
         }
 
@@ -87,7 +86,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                 var command = new Command("codecoverage", "publish");
                 command.Properties.Add("codecoveragetool", "InvalidTool");
                 command.Properties.Add("summaryfile", "a.xml");
-                Assert.Throws<ArgumentException>(() => publishCCCommand.ProcessCommand(_ec.Object, command, _policy));
+                Assert.Throws<ArgumentException>(() => publishCCCommand.ProcessCommand(_ec.Object, command));
             }
         }
 
@@ -113,7 +112,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("codecoveragetool", "cobertura");
                     command.Properties.Add("summaryfile", coberturaXml);
                     command.Properties.Add("reportdirectory", reportDirectory);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(0, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageSummaryAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<IEnumerable<CodeCoverageStatistics>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
@@ -149,7 +148,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("codecoveragetool", "mockCCTool");
                     command.Properties.Add("summaryfile", summaryFile);
                     command.Properties.Add("reportdirectory", reportDirectory);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(0, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageSummaryAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<IEnumerable<CodeCoverageStatistics>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
@@ -185,7 +184,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("codecoveragetool", "mockCCTool");
                     command.Properties.Add("summaryfile", summaryFile);
                     command.Properties.Add("reportdirectory", reportDirectory);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(0, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageSummaryAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<IEnumerable<CodeCoverageStatistics>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
@@ -218,7 +217,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("summaryfile", summaryFile);
                     _mocksummaryReader.Setup(x => x.GetCodeCoverageSummary(It.IsAny<IExecutionContext>(), It.IsAny<string>()))
                     .Returns((List<CodeCoverageStatistics>)null);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(1, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageFilesAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<List<Tuple<string, string>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()));
@@ -249,7 +248,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("codecoveragetool", "mockCCTool");
                     command.Properties.Add("summaryfile", summaryFile);
                     command.Properties.Add("reportdirectory", reportDirectory);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(0, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageSummaryAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<IEnumerable<CodeCoverageStatistics>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
@@ -280,7 +279,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("codecoveragetool", "mockCCTool");
                     command.Properties.Add("summaryfile", summaryFile);
                     command.Properties.Add("additionalcodecoveragefiles", summaryFile);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(0, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageSummaryAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<IEnumerable<CodeCoverageStatistics>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
@@ -314,7 +313,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                     command.Properties.Add("summaryfile", summaryFile);
                     command.Properties.Add("reportdirectory", reportDirectory);
                     command.Properties.Add("additionalcodecoveragefiles", summaryFile);
-                    publishCCCommand.ProcessCommand(_ec.Object, command, _policy);
+                    publishCCCommand.ProcessCommand(_ec.Object, command);
                     Assert.Equal(0, _warnings.Count);
                     Assert.Equal(0, _errors.Count);
                     _mockCodeCoveragePublisher.Verify(x => x.PublishCodeCoverageSummaryAsync(It.IsAny<IAsyncCommandContext>(), It.IsAny<IEnumerable<CodeCoverageStatistics>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
@@ -332,6 +331,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
         private TestHostContext SetupMocks([CallerMemberName] string name = "")
         {
             var _hc = new TestHostContext(this, name);
+            _hc.SetSingleton(new TaskRestrictionsChecker() as ITaskRestrictionsChecker);
             _codeCoverageStatistics = new List<CodeCoverageStatistics> { new CodeCoverageStatistics { Label = "label", Covered = 10, Total = 10, Position = 1 } };
             _mocksummaryReader = new Mock<ICodeCoverageSummaryReader>();
             if (String.Equals(name, "Publish_CoberturaNewIndexFile"))
@@ -366,6 +366,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
             endpointAuthorization.Parameters[EndpointAuthorizationParameters.AccessToken] = "accesstoken";
 
             _ec = new Mock<IExecutionContext>();
+            _ec.Setup(x => x.Restrictions).Returns(new List<TaskRestrictions>());
             _ec.Setup(x => x.Endpoints).Returns(new List<ServiceEndpoint> { new ServiceEndpoint { Url = new Uri("http://dummyurl"), Name = WellKnownServiceEndpointNames.SystemVssConnection, Authorization = endpointAuthorization } });
             _ec.Setup(x => x.Variables).Returns(_variables);
             _ec.Setup(x => x.TranslateToHostPath(It.IsAny<string>())).Returns( (string x) => x );

--- a/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
+++ b/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
@@ -275,7 +275,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 if (warningExpected)
                 {
                     Assert.Equal(1, _warnings.Count);
-                    Assert.Contains("SetVariableNotAllowed", _warnings[0]);
+                    if (variableExpected)
+                    {
+                        Assert.EndsWith("SetVariableNotAllowedWarnOnly", _warnings[0]);
+                    }
+                    else
+                    {
+                        Assert.EndsWith("SetVariableNotAllowed", _warnings[0]);
+                    }
                 }
                 else
                 {

--- a/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
+++ b/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
@@ -248,9 +248,66 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             }
         }
 
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("Enabled", false, true)]
+        [InlineData("enabled", false, true)]
+        [InlineData("WarningOnly", true, true)]
+        [InlineData("Disabled", true, false)]
+        [InlineData("disAbled", true, false)]
+        [InlineData("Unexpected", true, true)]
+        public void TaskDefinitionRestrictionsEnforcementMode(string mode, bool variableExpected, bool warningExpected)
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                _ec.Setup(x => x.GetVariableValueOrDefault("agent.taskRestrictionsEnforcementMode")).Returns(mode);
+                var definition = new DefinitionData { Name = "TestTask", Version = new DefinitionVersion { Major = 2, Minor = 7, Patch = 1 } };
+                // allow no variables
+                var restrictions = new TaskDefinitionRestrictions(definition) { SettableVariables = new TaskVariableRestrictions() };
+                _ec.Object.Restrictions.Add(restrictions);
+                var variable = "myVar";
+                var value = "myValue";
+                Command command = SetVariableCommand(variable, value);
+                TaskSetVariableCommand setVariable = new TaskSetVariableCommand();
+                setVariable.Execute(_ec.Object, command);
+                Assert.Equal((variableExpected ? value : null), _variables.Get(variable));
+                if (warningExpected)
+                {
+                    Assert.Equal(1, _warnings.Count);
+                    Assert.Contains("SetVariableNotAllowed", _warnings[0]);
+                }
+                else
+                {
+                    Assert.Equal(0, _warnings.Count);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void EnforcementModeDoesNotImpactPipelineRestrictions()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // This does nothing because this isn't using a TaskDefinitionRestrictions
+                _ec.Setup(x => x.GetVariableValueOrDefault("agent.taskRestrictionsEnforcementMode")).Returns("Disabled");
+                _ec.Object.Restrictions.Add(new TaskRestrictions() { SettableVariables = new TaskVariableRestrictions() });
+                var variable = "myVar";
+                var setVariable = new TaskSetVariableCommand();
+                var command = SetVariableCommand(variable, "myVal");
+                setVariable.Execute(_ec.Object, command);
+                Assert.Equal(null, _variables.Get(variable));
+                Assert.Equal(1, _warnings.Count);
+                Assert.Contains("SetVariableNotAllowed", _warnings[0]);
+            }
+        }
+
         private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
         {
             var hc = new TestHostContext(this, testName);
+            hc.SetSingleton(new TaskRestrictionsChecker() as ITaskRestrictionsChecker);
 
             _variables = new Variables(
                 hostContext: hc,

--- a/src/Test/L0/Worker/TaskCommandExtensionL0.cs
+++ b/src/Test/L0/Worker/TaskCommandExtensionL0.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
     {
         private Mock<IExecutionContext> _ec;
         private ServiceEndpoint _endpoint;
-        private IWorkerCommandRestrictionPolicy _policy = new UnrestricedWorkerCommandRestrictionPolicy();
 
         [Fact]
         [Trait("Level", "L0")]
@@ -32,7 +31,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("id", Guid.Empty.ToString());
                 cmd.Properties.Add("key", "test");
 
-                commandExtension.ProcessCommand(_ec.Object, cmd, _policy);
+                commandExtension.ProcessCommand(_ec.Object, cmd);
 
                 Assert.Equal(_endpoint.Authorization.Parameters["test"], "blah");
             }
@@ -52,7 +51,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("id", Guid.Empty.ToString());
                 cmd.Properties.Add("key", "test");
 
-                commandExtension.ProcessCommand(_ec.Object, cmd, _policy);
+                commandExtension.ProcessCommand(_ec.Object, cmd);
 
                 Assert.Equal(_endpoint.Data["test"], "blah");
             }
@@ -71,7 +70,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "url");
                 cmd.Properties.Add("id", Guid.Empty.ToString());
 
-                commandExtension.ProcessCommand(_ec.Object, cmd, _policy);
+                commandExtension.ProcessCommand(_ec.Object, cmd);
 
                 Assert.Equal(_endpoint.Url.ToString(), cmd.Data);
             }
@@ -86,7 +85,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             {
                 TaskCommandExtension commandExtension = new TaskCommandExtension();
                 var cmd = new Command("task", "setEndpoint");
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
@@ -100,7 +99,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 TaskCommandExtension commandExtension = new TaskCommandExtension();
                 var cmd = new Command("task", "setEndpoint");
 
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
@@ -115,7 +114,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var cmd = new Command("task", "setEndpoint");
                 cmd.Properties.Add("field", "blah");
 
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
@@ -130,7 +129,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var cmd = new Command("task", "setEndpoint");
                 cmd.Properties.Add("field", "url");
 
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
@@ -146,7 +145,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "url");
                 cmd.Properties.Add("id", "blah");
 
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
@@ -162,7 +161,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "authParameter");
                 cmd.Properties.Add("id", Guid.Empty.ToString());
 
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
@@ -179,13 +178,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 cmd.Properties.Add("field", "url");
                 cmd.Properties.Add("id", Guid.Empty.ToString());
 
-                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd, _policy));
+                Assert.Throws<ArgumentNullException>(() => commandExtension.ProcessCommand(_ec.Object, cmd));
             }
         }
 
         private TestHostContext SetupMocks([CallerMemberName] string name = "")
         {
             var _hc = new TestHostContext(this, name);
+            _hc.SetSingleton(new TaskRestrictionsChecker() as ITaskRestrictionsChecker);
             _ec = new Mock<IExecutionContext>();
 
             _endpoint = new ServiceEndpoint()


### PR DESCRIPTION
Based on a feature variable (agent.taskRestrictionsEnforcementMode), don't enforce restrictions
from task.json, or just warn, or warn and enforce normally. Restrictions from the Pipeline YAML itself continue to be enforced always.
This also adds support for collecting telemetry when task restrictions are matched, so we can see where they'd be applied before fully enabling them.
The principle awkwardness of this change is that the VSO command code itself didn't have access to information about the task being executed it order to conditionally log and enforce, so there is a decent amount of refactoring to make the things needed available at the right places. Some of the logic is moved from the `TaskCommandExtensions` into a new `TaskRestrictionChecker`, for better sharing the new conditional logic between types of restrictions (commands and variables). An agent-specific `TaskRestrictions` sub-type (`TaskDefinitionRestrictions`) is introduced to capture the source of the restrictions and the related task data. I also eliminated the old `IWorkerCommandRestrictionPolicy` code in favor of the new restrictions.