### PR TITLE
Git version update to solved vulnulability #3325

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -10,7 +10,7 @@ CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
 NODE10_VERSION="10.24.0"
-MINGIT_VERSION="2.28.0"
+MINGIT_VERSION="2.31.0"
 
 get_abs_path() {
   # exploits the fact that pwd will print abs path when no args


### PR DESCRIPTION
GIT Arbitrary Code Execution Vulnerability

CVE references CVE-2021-21300

Solution:

Update to version 2.30.2, 2.29.3, 2.28.1

#3325