### PR TITLE
Fixed localization pipeline issue with already localized strings replaced

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -51,7 +51,7 @@ stages:
         gitHubPrMergeMethod: 'squash'
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    
+
     - task: PublishBuildArtifacts@1
       condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       displayName: 'Publish an artifact'

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -51,6 +51,10 @@ stages:
         gitHubPrMergeMethod: 'squash'
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    
+    - task: PublishBuildArtifacts@1
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      displayName: 'Publish an artifact'
 
     - powershell: |
         $date= Get-Date -Format "MMddyyyy"


### PR DESCRIPTION
Added artifact publishing step to the localization pipeline. This step fixes the issue with unrecognized localized strings.

**Attached related issue:** [#915](https://github.com/microsoft/build-task-team/issues/915)