### PR TITLE
Allow the server to control PostLines speed

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -454,6 +454,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                     Trace.Info($"Skip message deletion for cancellation message '{message.MessageId}'.");
                                 }
                             }
+                            else if (string.Equals(message.MessageType, JobMetadataMessage.MessageType, StringComparison.OrdinalIgnoreCase))
+                            {
+                                var metadataMessage = JsonUtility.FromString<JobMetadataMessage>(message.Body);
+                                jobDispatcher.MetadataUpdate(metadataMessage);
+                            }
                             else
                             {
                                 Trace.Error($"Received message {message.MessageId} with unsupported message type {message.MessageType}.");

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     public interface IJobRunner : IAgentService
     {
         Task<TaskResult> RunAsync(Pipelines.AgentJobRequestMessage message, CancellationToken jobRequestCancellationToken);
+        void UpdateMetadata(JobMetadataMessage message);
     }
 
     public sealed class JobRunner : AgentService, IJobRunner
@@ -323,6 +324,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
 
                 await ShutdownQueue(throwOnFailure: false);
+            }
+        }
+
+        public void UpdateMetadata(JobMetadataMessage message)
+        {
+            if (message.PostLinesFrequencyMillis.HasValue)
+            {
+                _jobServerQueue.UpdateWebConsoleLineRate(message.PostLinesFrequencyMillis.Value);
             }
         }
 

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -67,38 +67,52 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Trace.Info($"Job message:{Environment.NewLine} {StringUtil.ConvertToJson(WorkerUtilities.ScrubPiiData(jobMessage))}");
                 Task<TaskResult> jobRunnerTask = jobRunner.RunAsync(jobMessage, jobRequestCancellationToken.Token);
 
-                // Start listening for a cancel message from the channel.
-                Trace.Info("Listening for cancel message from the channel.");
-                Task<WorkerMessage> channelTask = channel.ReceiveAsync(channelTokenSource.Token);
-
-                // Wait for one of the tasks to complete.
-                Trace.Info("Waiting for the job to complete or for a cancel message from the channel.");
-                Task.WaitAny(jobRunnerTask, channelTask);
-
-                // Handle if the job completed.
-                if (jobRunnerTask.IsCompleted)
+                bool cancel = false;
+                while (!cancel)
                 {
-                    Trace.Info("Job completed.");
-                    channelTokenSource.Cancel(); // Cancel waiting for a message from the channel.
-                    return TaskResultUtil.TranslateToReturnCode(await jobRunnerTask);
-                }
+                    // Start listening for a cancel message from the channel.
+                    Trace.Info("Listening for cancel message from the channel.");
+                    Task<WorkerMessage> channelTask = channel.ReceiveAsync(channelTokenSource.Token);
 
-                // Otherwise a cancel message was received from the channel.
-                Trace.Info("Cancellation/Shutdown message received.");
-                channelMessage = await channelTask;
-                switch (channelMessage.MessageType)
-                {
-                    case MessageType.CancelRequest:
-                        jobRequestCancellationToken.Cancel();   // Expire the host cancellation token.
-                        break;
-                    case MessageType.AgentShutdown:
-                        HostContext.ShutdownAgent(ShutdownReason.UserCancelled);
-                        break;
-                    case MessageType.OperatingSystemShutdown:
-                        HostContext.ShutdownAgent(ShutdownReason.OperatingSystemShutdown);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(channelMessage.MessageType), channelMessage.MessageType, nameof(channelMessage.MessageType));
+                    // Wait for one of the tasks to complete.
+                    Trace.Info("Waiting for the job to complete or for a cancel message from the channel.");
+                    await Task.WhenAny(jobRunnerTask, channelTask);
+
+                    // Handle if the job completed.
+                    if (jobRunnerTask.IsCompleted)
+                    {
+                        Trace.Info("Job completed.");
+                        channelTokenSource.Cancel(); // Cancel waiting for a message from the channel.
+                        return TaskResultUtil.TranslateToReturnCode(await jobRunnerTask);
+                    }
+
+                    // Otherwise a message was received from the channel.
+                    channelMessage = await channelTask;
+                    switch (channelMessage.MessageType)
+                    {
+                        case MessageType.CancelRequest:
+                            Trace.Info("Cancellation/Shutdown message received.");
+                            cancel = true;
+                            jobRequestCancellationToken.Cancel();   // Expire the host cancellation token.
+                            break;
+                        case MessageType.AgentShutdown:
+                            Trace.Info("Cancellation/Shutdown message received.");
+                            cancel = true;
+                            HostContext.ShutdownAgent(ShutdownReason.UserCancelled);
+                            break;
+                        case MessageType.OperatingSystemShutdown:
+                            Trace.Info("Cancellation/Shutdown message received.");
+                            cancel = true;
+                            HostContext.ShutdownAgent(ShutdownReason.OperatingSystemShutdown);
+                            break;
+                        case MessageType.JobMetadataUpdate:
+                            Trace.Info("Metadata update message received.");
+                            var metadataMessage = JsonUtility.FromString<JobMetadataMessage>(channelMessage.Body);
+                            jobRunner.UpdateMetadata(metadataMessage);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(channelMessage.MessageType), channelMessage.MessageType, nameof(channelMessage.MessageType));
+                    }
                 }
 
                 // Await the job.

--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.161-private</VssApiVersion>
+    <VssApiVersion>0.5.162-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualStudio.Services.Agent/ProcessChannel.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ProcessChannel.cs
@@ -20,7 +20,8 @@ namespace Microsoft.VisualStudio.Services.Agent
         NewJobRequest = 1,
         CancelRequest = 2,
         AgentShutdown = 3,
-        OperatingSystemShutdown = 4
+        OperatingSystemShutdown = 4,
+        JobMetadataUpdate = 5,
     }
 
     public struct WorkerMessage


### PR DESCRIPTION
Currently, PostLines is sent up to 4 times per second for 60 seconds and then up to 2 times per second until the job completes.

This is a lot of requests, especially given that the majority of builds aren't being watched. This change allows the server to dynamically adjust the speed of PostLines, taking into account factors such as whether a customer is watching the logs.

This change also makes the "aggressive" PostLines timeframe only 15 seconds and halves the default rates.