### PR TITLE
Create PR in OneLocBuild task only on third week of sprint

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,7 +23,7 @@ stages:
       
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        if (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual'))
+        if (($env:PR_CREATION_ENABLED -eq 'True') -and (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual')))
         {
           Write-Host "shouldCreatePR was set to true"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -51,7 +51,7 @@ stages:
         outDir: '$(Build.ArtifactStagingDirectory)'
         packageSourceAuth: 'patAuth'
         patVariable: '$(OneLocBuildPAT)'
-        isCreatePrSelected: true
+        isCreatePrSelected: $(shouldCreatePR)
         repoType: 'gitHub'
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,8 +23,16 @@ stages:
       
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
-        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
+        if (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual'))
+        {
+          Write-Host "shouldCreatePR was set to true"
+          Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  
+        }
+        else
+        {
+          Write-Host "shouldCreatePR was set to false"
+          Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($false)"
+        }
       displayName: "Determine the number of the week in the sprint and sprint number"
 
     - powershell: |
@@ -34,10 +42,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
 
     - task: OneLocBuild@2
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -53,7 +61,7 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
       displayName: 'Publish an artifact'
 
     - powershell: |
@@ -69,7 +77,7 @@ stages:
         git commit -m "Removing Localize folder"
         git push origin $updateBranch
       displayName: Create and push localization update branch
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
     - task: PowerShell@2
       inputs:
@@ -79,7 +87,7 @@ stages:
       env:
         GH_TOKEN: '$(GitHubPAT)'
       displayName: Open a PR
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
     - powershell: |
         $message="Created agent localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
@@ -89,7 +97,7 @@ stages:
 
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about PR opened'
-      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+      condition: and(succeeded(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
@@ -100,5 +108,4 @@ stages:
 
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about error'
-      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
-
+      condition: and(failed(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))


### PR DESCRIPTION
This PR should resolve the issue with the incidents on the localization team side caused by missed artifacts in pipeline runs.
In previous behavior we have skipped all the tasks in case it is not the third week of the sprint and artifacts weren't published.

In new behavior, artifacts will be generated every week, but the update of the corresponding branches will only take place on the last week of the sprint. In case of manual run, PR will be created independent of the current week.