### PR TITLE
Remove unneeded blob telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreClientTelemetryTfs.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreClientTelemetryTfs.cs
@@ -26,8 +26,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
 
         public async Task CommitTelemetry(Guid planId, Guid jobId)
         {
-            var ciSender = this.senders.OfType<CustomerIntelligenceTelemetrySender>().First();
-            await ciSender.CommitTelemetry(planId, jobId);
+            var ciSender = this.senders.OfType<CustomerIntelligenceTelemetrySender>().FirstOrDefault();
+            await ciSender?.CommitTelemetry(planId, jobId);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreClientTelemetryTfs.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreClientTelemetryTfs.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
         public async Task CommitTelemetry(Guid planId, Guid jobId)
         {
             var ciSender = this.senders.OfType<CustomerIntelligenceTelemetrySender>().FirstOrDefault();
-            await ciSender?.CommitTelemetry(planId, jobId);
+            await (ciSender?.CommitTelemetry(planId, jobId) ?? Task.CompletedTask);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreClientTelemetryTfs.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreClientTelemetryTfs.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
@@ -12,26 +13,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
 {
     public class BlobStoreClientTelemetryTfs : BlobStoreClientTelemetry
     {
-        private CustomerIntelligenceTelemetrySender _ciSender;
-
         public BlobStoreClientTelemetryTfs(IAppTraceSource tracer, Uri baseAddress, VssConnection connection) 
-            : base(tracer, baseAddress)
+            : base(tracer, baseAddress, new CustomerIntelligenceTelemetrySender(connection))
         {
-            _ciSender = new CustomerIntelligenceTelemetrySender(connection);
-            this.senders.Add(_ciSender);
         }
 
         // for testing
         public BlobStoreClientTelemetryTfs(IAppTraceSource tracer, Uri baseAddress, VssConnection connection, ITelemetrySender sender)
             : base(tracer, baseAddress, sender)
         {
-            _ciSender = new CustomerIntelligenceTelemetrySender(connection);
-            this.senders.Add(_ciSender);
         }
 
         public async Task CommitTelemetry(Guid planId, Guid jobId)
         {
-            await _ciSender.CommitTelemetry(planId, jobId);
+            var ciSender = this.senders.OfType<CustomerIntelligenceTelemetrySender>().First();
+            await ciSender.CommitTelemetry(planId, jobId);
         }
     }
 }


### PR DESCRIPTION
`BlobStoreClientTelemetryTfs` is designed to collect telemetry from all files uploaded and only send it to CustomerIntelligence once (CommitTelemetry)
The default implementation also includes `BlobStoreApplicationInsightsTelemetrySender` which sends data every file! We don't actually need this data going to two difference places, so remove `BlobStoreApplicationInsightsTelemetrySender`.