### PR TITLE
Add checking the maximum timeout value

### DIFF
--- a/src/Agent.Listener/JobDispatcher.cs
+++ b/src/Agent.Listener/JobDispatcher.cs
@@ -926,6 +926,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                 timeout = TimeSpan.FromSeconds(60);
                             }
 
+                            if (timeout.TotalMinutes > 35790)
+                            {
+                                timeout = TimeSpan.FromMinutes(35790);
+                            }
+
                             WorkerCancelTimeoutKillTokenSource.CancelAfter(timeout.Subtract(TimeSpan.FromSeconds(15)));
                             return true;
                         }


### PR DESCRIPTION
There was an issue with **cancelTimeoutInMinutes** option. If we set more than 35790 minutes it fails the pipeline and generates **ArgumentOutOfRangeException**.
   
Since **WorkerCancelTimeoutKillTokenSource.CancelAfter** method has a restriction, like all int arguments, it throws an exception when getting a value greater than 2147483647. So, 2147483647ms / 1000 / 60 ≈ 35791 minutes. 
I added an "if" statement to check the maximum timeout value, and if the timeout argument is greater than 35790, it will be set to 35790.
Just in case, in this "if" condition, I use 35790, because I think it's less risky than using 35791 minutes.