### PR TITLE
Added auto assign action

### DIFF
--- a/.github/workflows/autoAssignABTT.yml
+++ b/.github/workflows/autoAssignABTT.yml
@@ -1,0 +1,24 @@
+name: Auto Assign ABTT to Project Board
+
+on:
+  issues:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.ABTT_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to ABTT Project
+    steps:
+    - name: "Add triage and area labels"
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: |
+          "Area: Agent"
+          triage
+    - name: "Assign issues with 'Area: ABTT' label to project board"
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      with:
+        project: 'https://github.com/orgs/microsoft/projects/48'
+        column_name: 'Backlog'


### PR DESCRIPTION
Added auto assign action - to add 'Area: Agent' and 'triage' labels for new issues, and put them to the team board.