### PR TITLE
 Backward-compat support setting proxy via environment variables

### DIFF
--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -325,6 +325,21 @@ namespace Agent.Sdk
                     WebProxy = new AgentWebProxy(proxyUrl, proxyUsername, proxyPassword, proxyBypassHosts)
                 };
             }
+            // back-compat of proxy configuration via environment variables
+            else if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("VSTS_HTTP_PROXY")))
+            {
+                var ProxyUrl = Environment.GetEnvironmentVariable("VSTS_HTTP_PROXY");
+                ProxyUrl = ProxyUrl.Trim();
+                var ProxyUsername = Environment.GetEnvironmentVariable("VSTS_HTTP_PROXY_USERNAME");
+                var ProxyPassword = Environment.GetEnvironmentVariable("VSTS_HTTP_PROXY_PASSWORD");
+                return new AgentWebProxySettings()
+                {
+                    ProxyAddress = ProxyUrl,
+                    ProxyUsername = ProxyUsername,
+                    ProxyPassword = ProxyPassword,
+                    WebProxy = new AgentWebProxy(proxyUrl, ProxyUsername, ProxyPassword, null)
+                };
+            }
             else
             {
                 return null;


### PR DESCRIPTION
The [doc](https://github.com/MicrosoftDocs/azure-devops-docs/blob/master/docs/pipelines/agents/proxy.md) says the proxy can be set by the env variables, but it doesn't work for the agent plugin.
Add this backward-compat support so that it won't break the customer who uses this way of proxy configuration in pipeline artifact task.

VSTS_HTTP_PROXY -> proxy url
VSTS_HTTP_PROXY_USERNAME -> username
VSTS_HTTP_PROXY_PASSWORD -> password