### PR TITLE
Bump VssApiVersion to 0.5.164-private

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.163-private</VssApiVersion>
+    <VssApiVersion>0.5.164-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
   </PropertyGroup>
 


### PR DESCRIPTION
Contains a fix for PipelineArtifacts to retry from a secondary storage account when persistent download failures occur.