### PR TITLE
Added Patch Coverage API call to avoid BQC failure.

### DIFF
--- a/src/Agent.Worker/CodeCoverage/CodeCoverageConstants.cs
+++ b/src/Agent.Worker/CodeCoverage/CodeCoverageConstants.cs
@@ -96,6 +96,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage
 
         #region FeatureFlags
         public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
+        public const string TriggerCoverageMergeJobFF = "testManagement.Server.TriggerCoverageMergeJob";
         #endregion
     }
 }

--- a/src/Agent.Worker/CodeCoverage/CodeCoverageConstants.cs
+++ b/src/Agent.Worker/CodeCoverage/CodeCoverageConstants.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage
 
         #region FeatureFlags
         public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
-        public const string TriggerCoverageMergeJobFF = "testManagement.Server.TriggerCoverageMergeJob";
+        public const string TriggerCoverageMergeJobFF = "TestManagement.Server.TriggerCoverageMergeJob";
         #endregion
     }
 }

--- a/src/Agent.Worker/TestResults/Legacy/TestResultsServer.cs
+++ b/src/Agent.Worker/TestResults/Legacy/TestResultsServer.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
             CancellationToken cancellationToken = default(CancellationToken));
         Task<TestRunStatistic> GetTestRunSummaryByOutcomeAsync(string project,int runId,object userState = null,
             CancellationToken cancellationToken = default);
+        Task<CodeCoverageSummary> UpdateCodeCoverageSummaryAsync(VssConnection connection, string project, int buildId);
     }
 
     public class TestResultsServer : AgentService, ITestResultsServer
@@ -49,6 +50,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
             {
                 TestHttpClient = connection.GetClient<TestManagementHttpClient>();
             }
+        }
+        
+        public async Task<CodeCoverageSummary> UpdateCodeCoverageSummaryAsync(VssConnection connection ,string project, int buildId)
+        {
+            TestResultsHttpClient tcmClient = connection.GetClient<TestResultsHttpClient>();
+            return await tcmClient.UpdateCodeCoverageSummaryAsync(project, buildId);     
         }
 
         public async Task<List<TestCaseResult>> AddTestResultsToTestRunAsync(

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -6,10 +6,7 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Services.Agent;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.TeamFoundation.TestClient.PublishTestResults;
@@ -17,7 +14,6 @@ using Microsoft.VisualStudio.Services.Agent.Worker.Telemetry;
 using Microsoft.VisualStudio.Services.WebPlatform;
 using Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults;
 using Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils;
-using Newtonsoft.Json;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 {

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -49,7 +49,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private bool _failTaskOnFailedTests;
 
         private string _testRunSystem;
-        private const string TriggerCoverageMergeJobFF = "TestManagement.Server.TriggerCoverageMergeJob";
 
         //telemetry parameter
         private const string _telemetryFeature = "PublishTestResultsCommand";
@@ -291,10 +290,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             }
 
             await PublishEventsAsync(connection);
-            if (GetFeatureFlagState(executionContext, connection, TriggerCoverageMergeJobFF))
-            {
-                TriggerCoverageMergeJob(_testResultFiles, _executionContext);
-            }
+          
+            TriggerCoverageMergeJob(_testResultFiles, _executionContext);
+            
         }
         
         // Queue code coverage merge job if code coverage attachments are published to avoid BQC timeout.

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -309,7 +309,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         }
         
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA2000:Dispose objects before losing scope", MessageId = "invokeScript")]
-        private string QueryItem(string accessToken, string url, out string errorMessage)
+        private string QueryItem(string accessToken, string url,System.Net.Http.HttpMethod method, out string errorMessage)
             {
             using (var request = new HttpRequestMessage(HttpMethod.Patch, url))
                 {    
@@ -333,7 +333,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                         return result;
                     }
                 }
-
             }
 
         private async Task PublishEventsAsync(VssConnection connection)

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -289,10 +289,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 _executionContext.Error(StringUtil.Loc("FailedTestsInResults"));
             }
 
-            await PublishEventsAsync(connection);
-          
-            TriggerCoverageMergeJob(_testResultFiles, _executionContext);
-            
+            await PublishEventsAsync(connection); 
+            TriggerCoverageMergeJob(_testResultFiles, _executionContext);      
         }
         
         // Queue code coverage merge job if code coverage attachments are published to avoid BQC timeout.

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -5,8 +5,10 @@ using Microsoft.TeamFoundation.TestManagement.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.TeamFoundation.TestClient.PublishTestResults;
@@ -47,6 +49,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private bool _failTaskOnFailedTests;
 
         private string _testRunSystem;
+        private const string TriggerCoverageMergeJobFF = "TestManagement.Server.TriggerCoverageMergeJob";
 
         //telemetry parameter
         private const string _telemetryFeature = "PublishTestResultsCommand";

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Services.Agent.Worker.Telemetry;
 using Microsoft.VisualStudio.Services.WebPlatform;
 using Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults;
 using Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils;
+using Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 {

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -326,7 +326,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                                 }
                                 catch (Exception e)
                                 {    
-                                _executionContext.Debug("Could not queue code coverage merge");                    
+                                _executionContext.Section($"Could not queue code coverage merge:{e}");                    
                                 }
                             }
                      }

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -317,19 +317,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                             Path.GetExtension(file).Equals(".covb", StringComparison.OrdinalIgnoreCase) ||
                             Path.GetExtension(file).Equals(".coverage", StringComparison.OrdinalIgnoreCase)
                             )
-                        {           
-                            _testResultsServer.InitializeServer(connection, _executionContext);
-                         
-                            try
-                            {
-                                var codeCoverageResults =  _testResultsServer.UpdateCodeCoverageSummaryAsync(connection,_executionContext, _executionContext.Variables.System_TeamProjectId.ToString(), _executionContext.Variables.Build_BuildId.GetValueOrDefault());
+                            {           
+                                 _testResultsServer.InitializeServer(connection, _executionContext);                     
+                                try
+                                {
+                                var codeCoverageResults =  _testResultsServer.UpdateCodeCoverageSummaryAsync(connection,_executionContext.Variables.System_TeamProjectId.ToString(), _executionContext.Variables.Build_BuildId.GetValueOrDefault());
+                                }
+                                catch (Exception e)
+                                {    
+                                _executionContext.Debug("Could not queue code coverage merge");                    
+                                }
                             }
-                            catch (Exception e)
-                            {    
-                              _executionContext.Debug("Could not queue code coverage merge");                    
-                            }
-                        }
-                    }
+                     }
                 }
             }
         }


### PR DESCRIPTION
Adding Patch Coverage API call to avoid BQC failure.

Today, we have to apply this mitigation to for the timeout issue with the BQC task in dotnet test task scenario
Disable feature flag in TFS service.

There are good number of customers where we have disabled  flag now and requests keep coming once in a while.
Though the mitigation helps, it takes away the enhancement done in TCM attachment area where with this new feature large attachments were supported. i.e. for accounts with this flag disabled may have the need to upload large attachments (more than 100 MB) and then we will find ourselves in a situation where we cannot have both the features working.

So we have fixed the dotnet test task to support invoking the PATCH coverage API call after attachment upload