### PR TITLE
Allow to ignore certificate validation while agent update

### DIFF
--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         private PackageMetadata _targetPackage;
         private ITerminal _terminal;
         private IAgentServer _agentServer;
+        private IAgentCertificateManager _agentCertManager;
         private int _poolId;
         private int _agentId;
 
@@ -46,6 +47,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             var settings = configStore.GetSettings();
             _poolId = settings.PoolId;
             _agentId = settings.AgentId;
+            _agentCertManager = HostContext.GetService<IAgentCertificateManager>();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA2000:Dispose objects before losing scope", MessageId = "invokeScript")]
@@ -175,7 +177,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             int agentSuffix = 1;
             string archiveFile = null;
             bool downloadSucceeded = false;
-
             try
             {
                 // Download the agent, using multiple attempts in order to be resilient against any networking/CDN issues
@@ -226,13 +227,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
                             //open zip stream in async mode
                             using (var handler = HostContext.CreateHttpClientHandler())
-                            using (var httpClient = new HttpClient(handler))
-                            using (var fs = new FileStream(archiveFile, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
-                            using (var result = await httpClient.GetStreamAsync(_targetPackage.DownloadUrl))
                             {
-                                //81920 is the default used by System.IO.Stream.CopyTo and is under the large object heap threshold (85k).
-                                await result.CopyToAsync(fs, 81920, downloadCts.Token);
-                                await fs.FlushAsync(downloadCts.Token);
+                                if (_agentCertManager.SkipServerCertificateValidation)
+                                {
+                                    Trace.Info($"Certificate validation will be skipped, since --sslskipcertvalidation option was passed during configuration");
+                                    handler.CheckCertificateRevocationList = true;
+                                    handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                                }
+                                using (var httpClient = new HttpClient(handler))
+                                using (var fs = new FileStream(archiveFile, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
+                                using (var result = await httpClient.GetStreamAsync(_targetPackage.DownloadUrl))
+                                {
+                                    //81920 is the default used by System.IO.Stream.CopyTo and is under the large object heap threshold (85k).
+                                    await result.CopyToAsync(fs, 81920, downloadCts.Token);
+                                    await fs.FlushAsync(downloadCts.Token);
+                                }
                             }
 
                             Trace.Info($"Download agent: finished download");

--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -231,6 +231,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                 if (_agentCertManager.SkipServerCertificateValidation)
                                 {
                                     Trace.Info($"Certificate validation will be skipped, since --sslskipcertvalidation option was passed during configuration");
+                                    // it is required to set this field to true otherwise we will receive error: CA5400: Ensure HttpClient certificate revocation list check is not disabled
                                     handler.CheckCertificateRevocationList = true;
                                     handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
                                 }

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -683,10 +683,18 @@ namespace Microsoft.VisualStudio.Services.Agent
     {
         public static HttpClientHandler CreateHttpClientHandler(this IHostContext context)
         {
+            System.Diagnostics.Debugger.Launch();
             ArgUtil.NotNull(context, nameof(context));
             HttpClientHandler clientHandler = new HttpClientHandler();
             var agentWebProxy = context.GetService<IVstsAgentWebProxy>();
             clientHandler.Proxy = agentWebProxy.WebProxy;
+
+            var agentCertManager = context.GetService<IAgentCertificateManager>();
+            if (agentCertManager.SkipServerCertificateValidation)
+            {
+                clientHandler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            }
+
             return clientHandler;
         }
     }

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -683,7 +683,6 @@ namespace Microsoft.VisualStudio.Services.Agent
     {
         public static HttpClientHandler CreateHttpClientHandler(this IHostContext context)
         {
-            System.Diagnostics.Debugger.Launch();
             ArgUtil.NotNull(context, nameof(context));
             HttpClientHandler clientHandler = new HttpClientHandler();
             var agentWebProxy = context.GetService<IVstsAgentWebProxy>();

--- a/src/Test/L0/HostContextExtensionL0.cs
+++ b/src/Test/L0/HostContextExtensionL0.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Moq;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests
+{
+    public sealed class HostContextExtensionL0
+    {
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void CreateHttpClientHandlerForCertValidationSkipCert()
+        {
+            // Arrange.
+            using (var _hc = Setup(true))
+            {
+                // Act.
+                var httpHandler = _hc.CreateHttpClientHandler();
+
+                // Assert.
+                Assert.NotNull(httpHandler.ServerCertificateCustomValidationCallback);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void CreateHttpClientHandlerForCertValidationDontSkipCert()
+        {
+            // Arrange.
+            using (var _hc = Setup(false))
+            {
+                // Act.
+                var httpHandler = _hc.CreateHttpClientHandler();
+
+                // Assert.
+                Assert.Null(httpHandler.ServerCertificateCustomValidationCallback);
+            }
+        }
+
+        public TestHostContext Setup(bool skipServerCertificateValidation, [CallerMemberName] string testName = "")
+        {
+            var _hc = new TestHostContext(this, testName);
+            var certService = new Mock<IAgentCertificateManager>();
+            var proxyConfig = new Mock<IVstsAgentWebProxy>();
+
+            certService.Setup(x => x.SkipServerCertificateValidation).Returns(skipServerCertificateValidation);
+
+            _hc.SetSingleton(proxyConfig.Object);
+            _hc.SetSingleton(certService.Object);
+
+            return _hc;
+        }
+    }
+}


### PR DESCRIPTION

This PR should address an issue that the agent while update does not rely on "--sslskipcertvalidation" option. With this PR agent will ignore SSL check while update in case the agent was configured with "--sslskipcertvalidation".