### PR TITLE
Align minimatch options of DownloadBuildArtifactsV1 to DownloadBuildArtifactsV0

### DIFF
--- a/src/Agent.Plugins/Artifact/ArtifactDownloadParameters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactDownloadParameters.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Minimatch;
 
 namespace Agent.Plugins
 {
@@ -29,6 +30,7 @@ namespace Agent.Plugins
         public int ParallelizationLimit { get; set; } = 8;
         public int RetryDownloadCount { get; set; } = 4;
         public bool CheckDownloadedFiles { get; set; } = false;
+        public Options CustomMinimatchOptions { get; set; } = null;
     }
 
     internal enum BuildArtifactRetrievalOptions

--- a/src/Agent.Plugins/Artifact/FileContainerProvider.cs
+++ b/src/Agent.Plugins/Artifact/FileContainerProvider.cs
@@ -91,7 +91,7 @@ namespace Agent.Plugins
             var items = await containerClient.QueryContainerItemsAsync(containerIdAndRoot.Item1, projectId, isShallow: false, includeBlobMetadata: true, containerIdAndRoot.Item2);
 
             tracer.Info($"Start downloading FCS artifact- {artifact.Name}");
-            IEnumerable<Func<string, bool>> minimatcherFuncs = MinimatchHelper.GetMinimatchFuncs(minimatchPatterns, tracer);
+            IEnumerable<Func<string, bool>> minimatcherFuncs = MinimatchHelper.GetMinimatchFuncs(minimatchPatterns, tracer, downloadParameters.CustomMinimatchOptions);
 
             if (minimatcherFuncs != null && minimatcherFuncs.Count() != 0)
             {

--- a/src/Agent.Plugins/Artifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/Artifact/PipelineArtifactServer.cs
@@ -175,7 +175,8 @@ namespace Agent.Plugins
                             downloadParameters.TargetDirectory,
                             proxyUri: null,
                             minimatchPatterns: downloadParameters.MinimatchFilters,
-                            minimatchFilterWithArtifactName: downloadParameters.MinimatchFilterWithArtifactName);
+                            minimatchFilterWithArtifactName: downloadParameters.MinimatchFilterWithArtifactName,
+                            customMinimatchOptions: downloadParameters.CustomMinimatchOptions);
 
                         PipelineArtifactActionRecord downloadRecord = clientTelemetry.CreateRecord<PipelineArtifactActionRecord>((level, uri, type) =>
                             new PipelineArtifactActionRecord(level, uri, type, nameof(DownloadAsync), context));
@@ -229,7 +230,8 @@ namespace Agent.Plugins
                         manifestId,
                         downloadParameters.TargetDirectory,
                         proxyUri: null,
-                        minimatchPatterns: downloadParameters.MinimatchFilters);
+                        minimatchPatterns: downloadParameters.MinimatchFilters,
+                        customMinimatchOptions: downloadParameters.CustomMinimatchOptions);
 
                     PipelineArtifactActionRecord downloadRecord = clientTelemetry.CreateRecord<PipelineArtifactActionRecord>((level, uri, type) =>
                             new PipelineArtifactActionRecord(level, uri, type, nameof(DownloadAsync), context));

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
 using Minimatch;
+using System.Text.RegularExpressions;
 
 namespace Agent.Plugins.BuildArtifacts
 {
@@ -110,7 +111,7 @@ namespace Agent.Plugins.BuildArtifacts
                 StringSplitOptions.RemoveEmptyEntries
             );
 
-            minimatchPatterns = minimatchPatterns.Select(item => item.Replace("\\\\", "/")).ToArray();
+            minimatchPatterns = minimatchPatterns.Select(item => Regex.Replace(item, "/\\/g", "/")).ToArray();
 
             string[] tagsInput = tags.Split(
                 new[] { "," },

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -17,7 +17,6 @@ using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
 using Minimatch;
-using System.Text.RegularExpressions;
 
 namespace Agent.Plugins.BuildArtifacts
 {

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -73,9 +73,7 @@ namespace Agent.Plugins.BuildArtifacts
         static readonly string buildVersionToDownloadLatestFromBranch = "latestFromBranch";
         static readonly Options minimatchOptions = new Options() {
             Dot = true,
-            NoBrace = true,
-            NoCase = false,
-            AllowWindowsPaths = true
+            NoBrace = true
         };
 
         protected override async Task ProcessCommandInternalAsync(
@@ -111,6 +109,8 @@ namespace Agent.Plugins.BuildArtifacts
                 new[] { "\n" },
                 StringSplitOptions.RemoveEmptyEntries
             );
+
+            minimatchPatterns = minimatchPatterns.Select(item => item.Replace("\\\\", "/")).ToArray();
 
             string[] tagsInput = tags.Split(
                 new[] { "," },

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -73,8 +73,9 @@ namespace Agent.Plugins.BuildArtifacts
         static readonly string buildVersionToDownloadSpecific = "specific";
         static readonly string buildVersionToDownloadLatestFromBranch = "latestFromBranch";
         static readonly Options minimatchOptions = new Options() {
-            Dot = true,
-            NoBrace = true
+           Dot = true,
+           NoBrace = true,
+           AllowWindowsPaths = PlatformUtil.RunningOnWindows
         };
 
         protected override async Task ProcessCommandInternalAsync(
@@ -110,8 +111,6 @@ namespace Agent.Plugins.BuildArtifacts
                 new[] { "\n" },
                 StringSplitOptions.RemoveEmptyEntries
             );
-
-            minimatchPatterns = minimatchPatterns.Select(item => Regex.Replace(item, "/\\/g", "/")).ToArray();
 
             string[] tagsInput = tags.Split(
                 new[] { "," },

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
+using Minimatch;
 
 namespace Agent.Plugins.BuildArtifacts
 {
@@ -70,6 +71,12 @@ namespace Agent.Plugins.BuildArtifacts
         static readonly string buildVersionToDownloadLatest = "latest";
         static readonly string buildVersionToDownloadSpecific = "specific";
         static readonly string buildVersionToDownloadLatestFromBranch = "latestFromBranch";
+        static readonly Options minimatchOptions = new Options() {
+            Dot = true,
+            NoBrace = true,
+            NoCase = false,
+            AllowWindowsPaths = true
+        };
 
         protected override async Task ProcessCommandInternalAsync(
             AgentTaskPluginExecutionContext context,
@@ -174,7 +181,8 @@ namespace Agent.Plugins.BuildArtifacts
                     MinimatchFilterWithArtifactName = true,
                     ParallelizationLimit = int.TryParse(parallelizationLimit, out var parallelLimit) ? parallelLimit : 8,
                     RetryDownloadCount = int.TryParse(retryDownloadCount, out var retryCount) ? retryCount : 4,
-                    CheckDownloadedFiles = bool.TryParse(checkDownloadedFiles, out var checkDownloads) && checkDownloads
+                    CheckDownloadedFiles = bool.TryParse(checkDownloadedFiles, out var checkDownloads) && checkDownloads,
+                    CustomMinimatchOptions = minimatchOptions
                 };
             }
             else if (buildType == buildTypeSpecific)
@@ -268,7 +276,8 @@ namespace Agent.Plugins.BuildArtifacts
                     MinimatchFilterWithArtifactName = true,
                     ParallelizationLimit = int.TryParse(parallelizationLimit, out var parallelLimit) ? parallelLimit : 8,
                     RetryDownloadCount = int.TryParse(retryDownloadCount, out var retryCount) ? retryCount : 4,
-                    CheckDownloadedFiles = bool.TryParse(checkDownloadedFiles, out var checkDownloads) && checkDownloads
+                    CheckDownloadedFiles = bool.TryParse(checkDownloadedFiles, out var checkDownloads) && checkDownloads,
+                    CustomMinimatchOptions = minimatchOptions
                 };
             }
             else

--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.166-private</VssApiVersion>
+    <VssApiVersion>0.5.167-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
   </PropertyGroup>
 


### PR DESCRIPTION
What changed:

* Bumped VssApiVersion to 0.167.0 to allow the passing of custom minimatch option to the GetMinimatchFuncs method.
* Updated BuildArtifactPluginV1 to pass custom minimatch options
* Added CustomMinimatchOptions property to the ArtifactDownloadParameters
* Updated FileContainerProvider and PipelineArtifactServer to work with custom minimatch options

[Ref](https://github.com/microsoft/azure-pipelines-extensions/blob/abe243f4b9743108c1f3a42e75dcc2515f064dbd/Extensions/ArtifactEngine/Engine/artifactEngine.ts#L86) to original minimatch options in ArtifactEngine