### PR TITLE
Fix git lfs folder search location when using x86 agent on x64 windows

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -88,7 +88,7 @@ namespace Agent.Plugins.Repository
                 string agentHomeDir = context.Variables.GetValueOrDefault("agent.homedirectory")?.Value;
                 ArgUtil.NotNullOrEmpty(agentHomeDir, nameof(agentHomeDir));
                 gitPath = Path.Combine(agentHomeDir, "externals", "git", "cmd", $"git.exe");
-                gitLfsPath = Path.Combine(agentHomeDir, "externals", "git", PlatformUtil.IsX86 ? "mingw32" : "mingw64", "bin", "git-lfs.exe");
+                gitLfsPath = Path.Combine(agentHomeDir, "externals", "git", PlatformUtil.BuiltOnX86 ? "mingw32" : "mingw64", "bin", "git-lfs.exe");
 
                 // Prepend the PATH.
                 context.Output(StringUtil.Loc("Prepending0WithDirectoryContaining1", "Path", Path.GetFileName(gitPath)));

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -131,42 +131,16 @@ namespace Agent.Sdk
             get => PlatformUtil.HostArchitecture == Architecture.Arm64;
         }
 
-        public static Architecture BuiltOnArchitecture
+        public static bool BuiltOnX86
         {
             get
             {
 #if X86
-                return Architecture.X86;
-#elif X64
-                return Architecture.X64;
-#elif ARM
-                return Architecture.Arm;
-#elif ARM64            
-                return Architecture.Arm64;
+                return true;
 #else  
-                #error Unknown Architecture
+                return false;
 #endif
             }
-        }
-
-        public static bool BuiltOnX86
-        {
-            get => BuiltOnArchitecture == Architecture.X86;
-        }
-
-        public static bool BuiltOnX64
-        {
-            get => BuiltOnArchitecture == Architecture.X64;
-        }
-
-        public static bool BuiltOnArm
-        {
-            get => BuiltOnArchitecture == Architecture.Arm;
-        }
-
-        public static bool BuiltOnArm64
-        {
-            get => BuiltOnArchitecture == Architecture.Arm64;
         }
 
         public static bool UseLegacyHttpHandler

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -137,7 +137,7 @@ namespace Agent.Sdk
             {
 #if X86
                 return true;
-#else  
+#else
                 return false;
 #endif
             }

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -131,6 +131,44 @@ namespace Agent.Sdk
             get => PlatformUtil.HostArchitecture == Architecture.Arm64;
         }
 
+        public static Architecture BuiltOnArchitecture
+        {
+            get
+            {
+#if X86
+                return Architecture.X86;
+#elif X64
+                return Architecture.X64;
+#elif ARM
+                return Architecture.Arm;
+#elif ARM64            
+                return Architecture.Arm64;
+#else  
+                #error Unknown Architecture
+#endif
+            }
+        }
+
+        public static bool BuiltOnX86
+        {
+            get => BuiltOnArchitecture == Architecture.X86;
+        }
+
+        public static bool BuiltOnX64
+        {
+            get => BuiltOnArchitecture == Architecture.X64;
+        }
+
+        public static bool BuiltOnArm
+        {
+            get => BuiltOnArchitecture == Architecture.Arm;
+        }
+
+        public static bool BuiltOnArm64
+        {
+            get => BuiltOnArchitecture == Architecture.Arm64;
+        }
+
         public static bool UseLegacyHttpHandler
         {
             // In .NET Core 2.1, we couldn't use the new SocketsHttpHandler for Windows or Linux

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 if (PlatformUtil.RunningOnWindows)
                 {
                     _gitPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "git", "cmd", $"git{IOUtil.ExeExtension}");
-                    _gitLfsPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "git", PlatformUtil.IsX86 ? "mingw32" : "mingw64", "bin", "git-lfs.exe");
+                    _gitLfsPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "git", PlatformUtil.BuiltOnX86 ? "mingw32" : "mingw64", "bin", "git-lfs.exe");
 
                     // Prepend the PATH.
                     context.Output(StringUtil.Loc("Prepending0WithDirectoryContaining1", Constants.PathVariable, Path.GetFileName(_gitPath)));


### PR DESCRIPTION
Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3451

We had an the following bug related to git-lfs bundling (https://github.com/microsoft/azure-pipelines-agent/pull/3397):
When building an x86 agent, we put git-lfs.exe to mingw32 folder
When using an agent, we searched for git-lfs.exe depending on host OS arch. This meant that when we run x86 agent on x64 system we were looking for the mingw64 folder, but the proper folder is mingw32.

To fix this, we now choose the folder depending on which architecture the agent was built for.