### PR TITLE
[DownloadBuildArtifactsV1] Fix inconsistent download path

### DIFF
--- a/src/Agent.Plugins/Artifact/ArtifactDownloadParameters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactDownloadParameters.cs
@@ -31,6 +31,7 @@ namespace Agent.Plugins
         public int RetryDownloadCount { get; set; } = 4;
         public bool CheckDownloadedFiles { get; set; } = false;
         public Options CustomMinimatchOptions { get; set; } = null;
+        public bool AppendArtifactNameToTargetPath { get; set; } = true;
     }
 
     internal enum BuildArtifactRetrievalOptions

--- a/src/Agent.Plugins/Artifact/FileContainerProvider.cs
+++ b/src/Agent.Plugins/Artifact/FileContainerProvider.cs
@@ -51,7 +51,9 @@ namespace Agent.Plugins
         {
             foreach (var buildArtifact in buildArtifacts)
             {
-                var dirPath = Path.Combine(downloadParameters.TargetDirectory, buildArtifact.Name);
+                var dirPath = downloadParameters.AppendArtifactNameToTargetPath
+                    ? Path.Combine(downloadParameters.TargetDirectory, buildArtifact.Name)
+                    : downloadParameters.TargetDirectory;
                 await DownloadFileContainerAsync(downloadParameters, buildArtifact, dirPath, context, cancellationToken, isSingleArtifactDownload: false);
             }
         }

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -291,6 +291,10 @@ namespace Agent.Plugins.BuildArtifacts
             // Build artifacts always includes the artifact in the path name
             downloadParameters.IncludeArtifactNameInPath = true;
 
+            // By default, file container provider appends artifact name to target path when downloading specific files
+            // This is undesirable because DownloadBuildArtifactsV0 doesn't do that
+            downloadParameters.AppendArtifactNameToTargetPath = false;
+
             context.Output(StringUtil.Loc("DownloadArtifactTo", targetPath));
             await server.DownloadAsyncV2(context, downloadParameters, downloadOption, token);
             context.Output(StringUtil.Loc("DownloadArtifactFinished"));

--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Agent.Sdk;
+using Agent.Sdk.Knob;
 using Agent.Plugins;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
@@ -293,7 +294,10 @@ namespace Agent.Plugins.BuildArtifacts
 
             // By default, file container provider appends artifact name to target path when downloading specific files
             // This is undesirable because DownloadBuildArtifactsV0 doesn't do that
-            downloadParameters.AppendArtifactNameToTargetPath = false;
+            // We also have a blob to disable this behavior just in case we break someone.
+            // By default, its value is going to be false, so we're defaulting to V0-like target path resolution
+            downloadParameters.AppendArtifactNameToTargetPath =
+                AgentKnobs.EnableIncompatibleBuildArtifactsPathResolution.GetValue(context).AsBoolean();
 
             context.Output(StringUtil.Loc("DownloadArtifactTo", targetPath));
             await server.DownloadAsyncV2(context, downloadParameters, downloadOption, token);

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -246,5 +246,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("DISABLE_BUILD_ARTIFACTS_TO_BLOB"),
             new EnvironmentKnobSource("DISABLE_BUILD_ARTIFACTS_TO_BLOB"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob EnableIncompatibleBuildArtifactsPathResolution = new Knob(
+            nameof(EnableIncompatibleBuildArtifactsPathResolution),
+            "Return DownloadBuildArtifactsV1 target path resolution behavior back to how it was originally implemented. This breaks back compatibility with DownloadBuildArtifactsV0.",
+            new RuntimeKnobSource("ENABLE_INCOMPATIBLE_BUILD_ARTIFACTS_PATH_RESOLUTION"),
+            new EnvironmentKnobSource("ENABLE_INCOMPATIBLE_BUILD_ARTIFACTS_PATH_RESOLUTION"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }


### PR DESCRIPTION
Currently, V1 behaves differently from V0 because artifact name is appended to target directory. After this change V0 and V1 should download files to the same location.

This difference only occurs when trying to download specific items (multi-artifact download).
For example, if we publish a single file, `file.txt`, and then try to download it, it will be downloaded to different directories depending on task version:
DownloadBuildArtifactsV0 downloads to `$(System.ArtifactsDirectory)/drop/file.txt`
DownloadBuildArtifactsV1 downloads to `$(System.ArtifactsDirectory)/drop/drop/file.txt`

Repro:
```yaml
steps:
- bash: mkdir artifacts
- bash: echo "some content" > artifacts/file.txt

- task: PublishBuildArtifacts@1
  inputs:
    PathtoPublish: 'artifacts/file.txt'
    ArtifactName: drop
    publishLocation: 'Container'
- bash: ls -lR artifacts
- bash: rm -rf artifacts

# Result: artifacts/drop/file.txt
- task: DownloadBuildArtifacts@0
  inputs:
    buildType: 'current'
    downloadType: 'specific'
    downloadPath: 'artifacts'
- bash: ls -lR artifacts
  displayName: V0
- bash: rm -rf artifacts

# Result: artifacts/drop/drop/file.txt
- task: DownloadBuildArtifacts@1
  inputs:
    buildType: 'current'
    downloadType: 'specific'
    downloadPath: 'artifacts'
- bash: ls -lR artifacts
  displayName: V1
```

If download type is single artifact, there is no difference in downloaded file location.

This is potentially a breaking change for existing V1 users, so we should be careful about deploying this