### PR TITLE
Added processing of NO_PROXY variable

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
@@ -142,17 +142,11 @@ namespace Microsoft.VisualStudio.Services.Agent
             foreach (string bypass in proxyBypassEnv.Split(new [] {',', ';'}).Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => value.Trim()))
             {
                 string saveRegexString = bypass;
-                if (saveRegexString.StartsWith("*")) {
-			        saveRegexString = saveRegexString.Replace("*", ".*");
-		        }
 
-		        var regExp = new Regex("(?<!\\\\)([.])(?!\\*)");
-		        var replace = "\\$1";
-		        var matches = Regex.Matches(saveRegexString, "regExp");
+                var regExp = new Regex("(?<!\\\\)([.])(?!\\*)");
+                var replace = "\\$1";
 
-		        saveRegexString = regExp.Replace(saveRegexString, replace);
-		
-		        Console.WriteLine(saveRegexString);
+                saveRegexString = regExp.Replace(saveRegexString, replace);
 
                 Trace.Info($"Bypass proxy for: {saveRegexString}.");
                 ProxyBypassList.Add(saveRegexString);

--- a/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
@@ -141,12 +141,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             foreach (string bypass in proxyBypassEnv.Split(new [] {',', ';'}).Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => value.Trim()))
             {
-                string saveRegexString = bypass;
-
-                var regExp = new Regex("(?<!\\\\)([.])(?!\\*)");
-                var replace = "\\$1";
-
-                saveRegexString = regExp.Replace(saveRegexString, replace);
+                const string saveRegexString = ProcessProxyByPassFromEnv(bypass);
 
                 Trace.Info($"Bypass proxy for: {saveRegexString}.");
                 ProxyBypassList.Add(saveRegexString);
@@ -226,6 +221,22 @@ namespace Microsoft.VisualStudio.Services.Agent
             {
                 Trace.Info($"No proxy setting found.");
             }
+        }
+
+        /// <summary>
+        /// Used to escape dots in proxy bypass hosts that was recieved from no_proxy variable
+        /// It is requred since we convert host string to the regular expression pattern and
+        /// all the dots that are parts of domains will be interpreted as special symbol in regular expression while converting
+        /// this leads to false positive matches while check the patterns for bepassing.
+        /// We don't escape dots that are parts of .* wildcard.
+        /// Also, we don't escape dots that are already prepended by escaping symbols.
+        /// </summary>
+        private string ProcessProxyByPassFromEnv(string bypass)
+        {
+            var regExp = new Regex("(?<!\\\\)([.])(?!\\*)");
+            var replace = "\\$1";
+
+            return regExp.Replace(saveRegexString, replace);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
@@ -141,8 +141,21 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             foreach (string bypass in proxyBypassEnv.Split(new [] {',', ';'}).Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => value.Trim()))
             {
-                Trace.Info($"Bypass proxy for: {bypass}.");
-                ProxyBypassList.Add(bypass);
+                string saveRegexString = bypass;
+                if (saveRegexString.StartsWith("*")) {
+			        saveRegexString = saveRegexString.Replace("*", ".*");
+		        }
+
+		        var regExp = new Regex("(?<!\\\\)([.])(?!\\*)");
+		        var replace = "\\$1";
+		        var matches = Regex.Matches(saveRegexString, "regExp");
+
+		        saveRegexString = regExp.Replace(saveRegexString, replace);
+		
+		        Console.WriteLine(saveRegexString);
+
+                Trace.Info($"Bypass proxy for: {saveRegexString}.");
+                ProxyBypassList.Add(saveRegexString);
             }
         }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/VstsAgentWebProxy.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Services.Agent
 
             foreach (string bypass in proxyBypassEnv.Split(new [] {',', ';'}).Where(value => !string.IsNullOrWhiteSpace(value)).Select(value => value.Trim()))
             {
-                const string saveRegexString = ProcessProxyByPassFromEnv(bypass);
+                var saveRegexString = ProcessProxyByPassFromEnv(bypass);
 
                 Trace.Info($"Bypass proxy for: {saveRegexString}.");
                 ProxyBypassList.Add(saveRegexString);
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             var regExp = new Regex("(?<!\\\\)([.])(?!\\*)");
             var replace = "\\$1";
 
-            return regExp.Replace(saveRegexString, replace);
+            return regExp.Replace(bypass, replace);
         }
     }
 }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -47,7 +47,7 @@
   "AutoLogonPoliciesWarningsHeader": "Following policies may affect the autologon:",
   "BeginArtifactItemsIntegrityCheck": "Starting artifact items integrity check",
   "BlobStoreDownloadWarning": "Artifact download from Blobstore failed, falling back to TFS. This will reduce download performance. Please ensure your agent firewall is configured properly: https://aka.ms/adoallowlist",
-  "BlobStoreUploadWarning": "Artifact upload to Blobstore failed, falling back to TFS. This will fail in the future. Please ensure your agent firewall is configured properly: https://aka.ms/adoallowlist",
+  "BlobStoreUploadWarning": "Artifact upload to Blobstore failed, falling back to TFS. This fallback will be removed in a future release. Please ensure your agent firewall is configured properly: https://aka.ms/adoallowlist",
   "BuildDirLastUseTIme": "The last time build directory '{0}' been used is: {1}",
   "BuildIdIsNotAvailable": "Trying to download pipeline artifact in '{0}' environment but build id is not present. Can only download a pipeline artifact in '{1}' environment if the artifact is a build.",
   "BuildIdIsNotValid": "Build Id is not valid: {0}",

--- a/src/Test/L0/VstsAgentWebProxyL0.cs
+++ b/src/Test/L0/VstsAgentWebProxyL0.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Moq;
+using Microsoft.VisualStudio.Services.Agent;
+using Agent.Sdk.Knob;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests
+{
+    public sealed class VstsAgentWebProxyL0
+    {
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void CanProcessBypassHostsFromEnvironmentCorrectly()
+        {
+            using (var _hc = Setup(false))
+            {
+                var answers = new string[] {
+                    "127\\.0\\.0\\.1",
+                    "\\.ing\\.net",
+                    "\\.intranet",
+                    "\\.corp\\.int",
+                    ".*corp\\.int",
+                    "127\\.0\\.0\\.1"
+                };
+
+                // Act.
+                Environment.SetEnvironmentVariable("no_proxy", "127.0.0.1,.ing.net,.intranet,.corp.int,.*corp.int,127\\.0\\.0\\.1");
+                var vstsAgentWebProxy = new VstsAgentWebProxy();
+                vstsAgentWebProxy.Initialize(_hc);
+                vstsAgentWebProxy.LoadProxyBypassList();
+
+                // Assert
+                Assert.NotNull(vstsAgentWebProxy.ProxyBypassList);
+                Assert.True(vstsAgentWebProxy.ProxyBypassList.Count == 6);
+                for (int i = 0; i < answers.Length; i++)
+                {
+                    Assert.Equal(answers[i], vstsAgentWebProxy.ProxyBypassList[i]);
+                }
+            }
+        }
+
+        public TestHostContext Setup(bool skipServerCertificateValidation, [CallerMemberName] string testName = "")
+        {
+            var _hc = new TestHostContext(this, testName);
+            var certService = new Mock<IAgentCertificateManager>();
+
+            certService.Setup(x => x.SkipServerCertificateValidation).Returns(skipServerCertificateValidation);
+
+            _hc.SetSingleton(certService.Object);
+
+            return _hc;
+        }
+    }
+}


### PR DESCRIPTION
Process NO_PROXY env variable before passing to the agent.proxybypasslist. Since we are passing hosts to the regular expression we need to escape dots as special symbols that are presented in hosts.

By new logic:
* if the host has already escaped they won't be escaped one more time
* all the unescaped dots in host templates will be
* wildcard - '.*' that could exist in host template in NO_PROXY