### PR TITLE
[AgentService] Fix invalid argument passing on reruns

### DIFF
--- a/src/Misc/layoutbin/AgentService.js
+++ b/src/Misc/layoutbin/AgentService.js
@@ -25,10 +25,10 @@ var runService = function() {
             if (interactive) {
                 console.log('Starting Agent listener interactively');                
                 // skip all paramters before interactive (inclusive)
-                listenerArgs = ['run'].concat(process.argv.splice(3));
+                listenerArgs = ['run'].concat(process.argv.slice(3));
             } else {
                 console.log('Starting Agent listener with startup type: service');
-                listenerArgs = ['run', '--startuptype', 'service'].concat(process.argv.splice(2))
+                listenerArgs = ['run', '--startuptype', 'service'].concat(process.argv.slice(2))
             }
 
             listener = childProcess.spawn(listenerExePath, listenerArgs, { env: process.env });


### PR DESCRIPTION
Looks like the author of https://github.com/microsoft/azure-pipelines-agent/pull/2353 confused `slice` method with `splice`.
Changing `process.argv` values causes the script to lose some of the passed arguments. Thus, subsequent runs of the listener process are performed with a different set of arguments. This issue only affects linux and darwin agents.

[Agent service for windows](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Service/Windows/AgentService.cs) does not support passing parameters and does not need to be changed.