### PR TITLE
Do not try to move non-existent directory on checkout to a custom path

### DIFF
--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -158,25 +158,33 @@ namespace Agent.Plugins.Repository
             executionContext.Debug($"Repository requires to be placed at '{expectRepoPath}', current location is '{currentRepoPath}'");
             if (!string.Equals(currentRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), expectRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), IOUtil.FilePathStringComparison))
             {
-                executionContext.Output($"Repository is current at '{currentRepoPath}', move to '{expectRepoPath}'.");
-                var count = 1;
-                var staging = Path.Combine(tempDirectory, $"_{count}");
-                while (Directory.Exists(staging))
+                if (Directory.Exists(currentRepoPath))
                 {
-                    count++;
-                    staging = Path.Combine(tempDirectory, $"_{count}");
+                    executionContext.Output($"Repository is current at '{currentRepoPath}', move to '{expectRepoPath}'.");
+                    var count = 1;
+                    var staging = Path.Combine(tempDirectory, $"_{count}");
+                    while (Directory.Exists(staging))
+                    {
+                        count++;
+                        staging = Path.Combine(tempDirectory, $"_{count}");
+                    }
+    
+                    try
+                    {
+                        executionContext.Debug($"Move existing repository '{currentRepoPath}' to '{expectRepoPath}' via staging directory '{staging}'.");
+                        IOUtil.MoveDirectory(currentRepoPath, expectRepoPath, staging, CancellationToken.None);
+                    }
+                    catch (Exception ex)
+                    {
+                        executionContext.Debug("Catch exception during repository move.");
+                        executionContext.Debug(ex.ToString());
+                        executionContext.Warning("Unable move and reuse existing repository to required location.");
+                        IOUtil.DeleteDirectory(expectRepoPath, CancellationToken.None);
+                    }
                 }
-
-                try
+                else
                 {
-                    executionContext.Debug($"Move existing repository '{currentRepoPath}' to '{expectRepoPath}' via staging directory '{staging}'.");
-                    IOUtil.MoveDirectory(currentRepoPath, expectRepoPath, staging, CancellationToken.None);
-                }
-                catch (Exception ex)
-                {
-                    executionContext.Debug("Catch exception during repository move.");
-                    executionContext.Debug(ex.ToString());
-                    executionContext.Warning("Unable move and reuse existing repository to required location.");
+                    executionContext.Debug($"Current repository directory '{currentRepoPath}' does not exist, clearing '{expectRepoPath}'");
                     IOUtil.DeleteDirectory(expectRepoPath, CancellationToken.None);
                 }
 


### PR DESCRIPTION
Fixes a warning on a first run of a multi-repo job with custom repo paths.

```yaml
steps:
- checkout: self
  path: s
- checkout: my-other-repo
  path: s/deps/my-other-repo
```

Currently, the first build of this pipeline attempts to move the non-existing `s/my-other-repo` directory to `s/deps/my-other-repo` which fails, and a build warning is displayed (we use self-hosted agents):
```
##[debug]Processed: ##vso[plugininternal.updaterepositorypath alias=my-other-repo;]D:\B\A1\_work\143\s\deps\my-other-repo
##[debug]Repository requires to be placed at 'D:\B\A1\_work\143\s\deps\my-other-repo', current location is 'D:\B\A1\_work\143\s\my-other-repo'
Repository is current at 'D:\B\A1\_work\143\s\my-other-repo', move to 'D:\B\A1\_work\143\s\deps\my-other-repo'.
##[debug]Move existing repository 'D:\B\A1\_work\143\s\my-other-repo' to 'D:\B\A1\_work\143\s\deps\my-other-repo' via staging directory 'D:\B\A1\_work\_temp\_1'.
##[debug]Catch exception during repository move.
##[debug]System.IO.DirectoryNotFoundException: Directory not found: 'D:\B\A1\_work\143\s\my-other-repo'
   at Microsoft.VisualStudio.Services.Agent.Util.ArgUtil.Directory(String directory, String name)
   at Microsoft.VisualStudio.Services.Agent.Util.IOUtil.MoveDirectory(String sourceDir, String targetDir, String stagingDir, CancellationToken token)
   at Agent.Plugins.Repository.CheckoutTask.RunAsync(AgentTaskPluginExecutionContext executionContext, CancellationToken token)
##[warning]Unable move and reuse existing repository to required location.
##[debug]Processed: ##vso[task.logissue type=warning;]Unable move and reuse existing repository to required location.
Repository will be located at 'D:\B\A1\_work\143\s\deps\my-other-repo'.
```

This change fixes the warning by checking that the source folder exists before trying to move it.