### PR TITLE
Allow to specify MTU value for networks used by container jobs

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                         }
                         else
                         {
-                            Trace.Info($"Autologon is configured on the machine but current Agent.Listner.exe is launched from the windows service");
+                            Trace.Info($"Autologon is configured on the machine but current Agent.Listener.exe is launched from the windows service");
                         }
                     }
                 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -34,8 +34,8 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_SKIP_POST_EXECUTION_IF_CONTAINER_STOPPED"),
             new BuiltInDefaultKnobSource("false"));
 
-        public static readonly Knob SetMTU = new Knob(
-            nameof(SetMTU),
+        public static readonly Knob SetMTUForContainerJobs = new Knob(
+            nameof(SetMTUForContainerJobs),
             "Set MTU value manually",
             new EnvironmentKnobSource("AGENT_MTU_VALUE"),
             new BuiltInDefaultKnobSource(string.Empty));

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -34,8 +34,8 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_SKIP_POST_EXECUTION_IF_CONTAINER_STOPPED"),
             new BuiltInDefaultKnobSource("false"));
 
-        public static readonly Knob SetMTUForContainerJobs = new Knob(
-            nameof(SetMTUForContainerJobs),
+        public static readonly Knob MTUValueForContainerJobs = new Knob(
+            nameof(MTUValueForContainerJobs),
             "Allow to specify MTU value for networks used by container jobs (useful for docker-in-docker scenarios in k8s cluster).",
             new EnvironmentKnobSource("AGENT_MTU_VALUE"),
             new BuiltInDefaultKnobSource(string.Empty));

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -34,6 +34,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_SKIP_POST_EXECUTION_IF_CONTAINER_STOPPED"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob SetMTU = new Knob(
+            nameof(SetMTU),
+            "Set MTU value manually",
+            new RuntimeKnobSource("AGENT_MTU_VALUE"),
+            new EnvironmentKnobSource("AGENT_MTU_VALUE"),
+            new BuiltInDefaultKnobSource("1500"));
+
         // Directory structure
         public static readonly Knob AgentToolsDirectory = new Knob(
             nameof(AgentToolsDirectory),

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -36,7 +36,7 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob SetMTUForContainerJobs = new Knob(
             nameof(SetMTUForContainerJobs),
-            "Set MTU value manually",
+            "Allow to specify MTU value for networks used by container jobs (useful for docker-in-docker scenarios in k8s cluster).",
             new EnvironmentKnobSource("AGENT_MTU_VALUE"),
             new BuiltInDefaultKnobSource(string.Empty));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -37,7 +37,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob MTUValueForContainerJobs = new Knob(
             nameof(MTUValueForContainerJobs),
             "Allow to specify MTU value for networks used by container jobs (useful for docker-in-docker scenarios in k8s cluster).",
-            new EnvironmentKnobSource("AGENT_MTU_VALUE"),
+            new EnvironmentKnobSource("AGENT_DOCKER_MTU_VALUE"),
             new BuiltInDefaultKnobSource(string.Empty));
 
         // Directory structure

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -37,7 +37,6 @@ namespace Agent.Sdk.Knob
         public static readonly Knob SetMTU = new Knob(
             nameof(SetMTU),
             "Set MTU value manually",
-            new RuntimeKnobSource("AGENT_MTU_VALUE"),
             new EnvironmentKnobSource("AGENT_MTU_VALUE"),
             new BuiltInDefaultKnobSource(string.Empty));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -39,7 +39,7 @@ namespace Agent.Sdk.Knob
             "Set MTU value manually",
             new RuntimeKnobSource("AGENT_MTU_VALUE"),
             new EnvironmentKnobSource("AGENT_MTU_VALUE"),
-            new BuiltInDefaultKnobSource("1500"));
+            new BuiltInDefaultKnobSource(string.Empty));
 
         // Directory structure
         public static readonly Knob AgentToolsDirectory = new Knob(

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -226,11 +226,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             ArgUtil.NotNull(network, nameof(network));
             var usingWindowsContainers = context.Containers.Where(x => x.ExecutionOS != PlatformUtil.OS.Windows).Count() == 0;
             var networkDrivers = await ExecuteDockerCommandAsync(context, "info", "-f \"{{range .Plugins.Network}}{{println .}}{{end}}\"");
-            var MTUValue = AgentKnobs.SetMTU.GetValue(_knobContext).AsInt();
-
+            var MTUValue = AgentKnobs.SetMTU.GetValue(_knobContext).AsString();
             string optionMTU = "";
             
-            if (Convert.ToBoolean(MTUValue)) {
+            if (!String.IsNullOrEmpty(MTUValue)) {
                 optionMTU = $"-o \"com.docker.network.driver.mtu={MTUValue}\"";
             }   
 

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -229,10 +229,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             var MTUValue = AgentKnobs.SetMTU.GetValue(_knobContext).AsInt();
 
             if (usingWindowsContainers && networkDrivers.Contains("nat"))
-            {
-                return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} -o {MTUValue} --driver nat", context.CancellationToken);
+            {   
+                if (MTUValue) {
+                    return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} -o {MTUValue} --driver nat", context.CancellationToken);
+                }
+
+                return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} --driver nat", context.CancellationToken);
             }
-            return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} -o {MTUValue} ", context.CancellationToken);
+
+            if (MTUValue) {
+                return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} -o {MTUValue}", context.CancellationToken);
+            }
+    
+            return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network}", context.CancellationToken);
         }
 
         public async Task<int> DockerNetworkRemove(IExecutionContext context, string network)

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             ArgUtil.NotNull(network, nameof(network));
             var usingWindowsContainers = context.Containers.Where(x => x.ExecutionOS != PlatformUtil.OS.Windows).Count() == 0;
             var networkDrivers = await ExecuteDockerCommandAsync(context, "info", "-f \"{{range .Plugins.Network}}{{println .}}{{end}}\"");
-            var MTUValue = AgentKnobs.SetMTU.GetValue(_knobContext).AsString();
+            var MTUValue = AgentKnobs.SetMTUForContainerJobs.GetValue(_knobContext).AsString();
             string optionMTU = "";
             
             if (!String.IsNullOrEmpty(MTUValue)) {
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
 
             if (usingWindowsContainers && networkDrivers.Contains("nat"))
             {   
-                return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} {optionMTU} --driver nat", context.CancellationToken);
+               return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} {optionMTU} --driver nat", context.CancellationToken);
             }
 
             return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} {optionMTU}", context.CancellationToken);

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -234,8 +234,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             }   
 
             if (usingWindowsContainers && networkDrivers.Contains("nat"))
-            {   
-               return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} {optionMTU} --driver nat", context.CancellationToken);
+            {
+                return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} {optionMTU} --driver nat", context.CancellationToken);
             }
 
             return await ExecuteDockerCommandAsync(context, "network", $"create --label {DockerInstanceLabel} {network} {optionMTU}", context.CancellationToken);

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -226,11 +226,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             ArgUtil.NotNull(network, nameof(network));
             var usingWindowsContainers = context.Containers.Where(x => x.ExecutionOS != PlatformUtil.OS.Windows).Count() == 0;
             var networkDrivers = await ExecuteDockerCommandAsync(context, "info", "-f \"{{range .Plugins.Network}}{{println .}}{{end}}\"");
-            var MTUValue = AgentKnobs.SetMTUForContainerJobs.GetValue(_knobContext).AsString();
+            var valueMTU = AgentKnobs.MTUValueForContainerJobs.GetValue(_knobContext).AsString();
             string optionMTU = "";
             
-            if (!String.IsNullOrEmpty(MTUValue)) {
-                optionMTU = $"-o \"com.docker.network.driver.mtu={MTUValue}\"";
+            if (!String.IsNullOrEmpty(valueMTU)) {
+                optionMTU = $"-o \"com.docker.network.driver.mtu={valueMTU}\"";
             }   
 
             if (usingWindowsContainers && networkDrivers.Contains("nat"))


### PR DESCRIPTION
For issue #3243

Allow specifying MTU value for networks used by container jobs (useful for docker-in-docker scenarios in k8s cluster).

Set the environment variable AGENT_MTU_VALUE to set the MTU value, after that config and run the self-hosted agent.
