### PR TITLE
Add agent package hashes to metadata and release notes

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -194,6 +194,14 @@ jobs:
         artifactName: agent
         artifactType: container
 
+    # Publish agent package hash too
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact
+      inputs:
+        pathToPublish: _package_hash
+        artifactName: hash
+        artifactType: container
+
   # Signing verification
   - ${{ if parameters.verifySigning }}:
 

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -182,6 +182,10 @@ jobs:
       workingDirectory: src
       displayName: Package Release
 
+    - script: "${{ variables.devCommand }} hash"
+      workingDirectory: src
+      displayName: Hash Package
+
     # Upload agent package zip as build artifact
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _l1
 _package
 _reports
 _dotnetsdk
+_hashes
 TestResults
 TestLogs
 .DS_Store
@@ -23,4 +24,3 @@ TestLogs
 
 #generated
 src/Microsoft.VisualStudio.Services.Agent/BuildConstants.cs
-

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,9 @@ _downloads
 _layout
 _l1
 _package
+_package_hash
 _reports
 _dotnetsdk
-_hashes
 TestResults
 TestLogs
 .DS_Store

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -125,7 +125,7 @@ extends:
             displayName: Download Agent Hashes
             inputs:
               artifactName: hash
-              targetPath: $(Build.SourcesDirectory)/_hashes
+              downloadPath: $(Build.SourcesDirectory)/_hashes
 
           # Fill release notes with agent version and package hashes
           - script: |
@@ -191,7 +191,7 @@ extends:
             displayName: Download Agent Hashes
             inputs:
               artifactName: hash
-              targetPath: $(Build.SourcesDirectory)/_hashes
+              downloadPath: $(Build.SourcesDirectory)/_hashes
 
           - bash: |
               set -x

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -30,7 +30,7 @@ extends:
     publishArtifacts: true
 
     ${{ if not(parameters.buildStageOnly) }}:
-      postBuildStages:
+      preBuildStages:
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
         - stage: Create_Release_Branch
           displayName: Create Release Branch
@@ -50,15 +50,6 @@ extends:
               inputs:
                 versionSpec: "14.15.1"
 
-            - task: DownloadBuildArtifacts@0
-              displayName: Download agent package hashes
-              inputs:
-                buildType: 'current'
-                downloadType: 'single'
-                artifactName: 'agent'
-                itemPattern: '**/*.sha256'
-                downloadPath: '_hashes'
-
             - script: |
                 cd release
                 npm install
@@ -68,6 +59,8 @@ extends:
                 PAT: $(GithubToken)
               displayName: Push release branch to GitHub
 
+    ${{ if not(parameters.buildStageOnly) }}:
+      postBuildStages:
       - stage: Release
         jobs:
         ################################################################################
@@ -127,10 +120,23 @@ extends:
               Publish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -LoadContent $uploadFiles
             displayName: Upload to Azure Blob
 
+          # Copy all hash files to a directory that is more convinient to work with
+          - task: CopyFiles@2
+            displayName: Copy Hash Files
+            inputs:
+              SourceFolder: '$(System.ArtifactsDirectory)/agent'
+              Contents: '**/*.sha256'
+              TargetFolder: '$(Build.SourcesDirectory)/_hashes'
+
+          # Fill release notes with agent version and package hashes
+          - script: |
+              cd release
+              node fillReleaseNotesTemplate.js ${{ parameters.version }}
+
           # Create agent release on Github
           - powershell: |
               Write-Host "Creating github release."
-              $releaseNotes = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\releaseNote.md").Replace("<AGENT_VERSION>","${{ parameters.version }}")
+              $releaseNotes = [System.IO.File]::ReadAllText("$(Build.SourcesDirectory)\releaseNote.md")
               $releaseData = @{
                 tag_name = "v${{ parameters.version }}";
                 target_commitish = "$(Build.SourceVersion)";

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -44,7 +44,7 @@ extends:
 
             steps:
             - checkout: self
-          
+
             - task: NodeTool@0
               displayName: Use node 14.15.1
               inputs:
@@ -79,7 +79,7 @@ extends:
           - template: switch-branch.yml
             parameters:
               branch: ${{ variables.releaseBranch }}
-          
+
           # Download all agent packages from all previous phases
           - task: DownloadBuildArtifacts@0
             displayName: Download Agent Packages
@@ -120,13 +120,12 @@ extends:
               Publish-AzureRmCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -LoadContent $uploadFiles
             displayName: Upload to Azure Blob
 
-          # Copy all hash files to a directory that is more convinient to work with
-          - task: CopyFiles@2
-            displayName: Copy Hash Files
+          # Download all agent hashes created in previous phases
+          - task: DownloadBuildArtifacts@0
+            displayName: Download Agent Hashes
             inputs:
-              SourceFolder: '$(System.ArtifactsDirectory)/agent'
-              Contents: '**/*.sha256'
-              TargetFolder: '$(Build.SourcesDirectory)/_hashes'
+              artifactName: hash
+              targetPath: $(Build.SourcesDirectory)/_hashes
 
           # Fill release notes with agent version and package hashes
           - script: |
@@ -186,6 +185,13 @@ extends:
           - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
             - script: git checkout ${{ variables.releaseBranch }}
               displayName: Checkout release branch
+
+          # Download all agent hashes created in previous phases
+          - task: DownloadBuildArtifacts@0
+            displayName: Download Agent Hashes
+            inputs:
+              artifactName: hash
+              targetPath: $(Build.SourcesDirectory)/_hashes
 
           - bash: |
               set -x

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -131,6 +131,7 @@ extends:
           - script: |
               cd release
               node fillReleaseNotesTemplate.js ${{ parameters.version }}
+            displayName: Fill release notes
 
           # Create agent release on Github
           - powershell: |

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -30,7 +30,7 @@ extends:
     publishArtifacts: true
 
     ${{ if not(parameters.buildStageOnly) }}:
-      preBuildStages:
+      postBuildStages:
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
         - stage: Create_Release_Branch
           displayName: Create Release Branch
@@ -50,6 +50,15 @@ extends:
               inputs:
                 versionSpec: "14.15.1"
 
+            - task: DownloadBuildArtifacts@0
+              displayName: Download agent package hashes
+              inputs:
+                buildType: 'current'
+                downloadType: 'single'
+                artifactName: 'agent'
+                itemPattern: '**/*.sha256'
+                downloadPath: '_hashes'
+
             - script: |
                 cd release
                 npm install
@@ -59,8 +68,6 @@ extends:
                 PAT: $(GithubToken)
               displayName: Push release branch to GitHub
 
-    ${{ if not(parameters.buildStageOnly) }}:
-      postBuildStages:
       - stage: Release
         jobs:
         ################################################################################

--- a/release/createAdoPr.js
+++ b/release/createAdoPr.js
@@ -26,7 +26,8 @@ const connection = new azdev.WebApi('https://dev.azure.com/mseng', authHandler);
 function createIntegrationFiles(newRelease, callback)
 {
     fs.mkdirSync(INTEGRATION_DIR, { recursive: true });
-    util.versionifySync(path.join(__dirname, '..', 'src', 'Misc', 'InstallAgentPackage.template.xml'),
+    util.fillInstallAgentPackageParameters(
+        path.join(__dirname, '..', 'src', 'Misc', 'InstallAgentPackage.template.xml'),
         path.join(INTEGRATION_DIR, 'InstallAgentPackage.xml'),
         newRelease
     );

--- a/release/createReleaseBranch.js
+++ b/release/createReleaseBranch.js
@@ -241,6 +241,28 @@ function checkGitStatus()
     return git_status;
 }
 
-// main();
+async function main()
+{
+    try {
+        var newRelease = opt.argv[0];
+        if (newRelease === undefined)
+        {
+            console.log('Error: You must supply a version');
+            process.exit(-1);
+        }
+        util.verifyMinimumNodeVersion();
+        util.verifyMinimumGitVersion();
+        await verifyNewReleaseTagOk(newRelease);
+        checkGitStatus();
+        writeAgentVersionFile(newRelease);
+        await fetchPRsSinceLastReleaseAndEditReleaseNotes(newRelease);
+        commitAgentChanges(path.join(__dirname, '..'), newRelease);
+        console.log('done.');
+    }
+    catch (err) {
+        tl.setResult(tl.TaskResult.Failed, err.message || 'run() failed', true);
+        throw err;
+    }
+}
 
-fetchPRsSinceLastReleaseAndEditReleaseNotes('2.130.30')
+main();

--- a/release/createReleaseBranch.js
+++ b/release/createReleaseBranch.js
@@ -123,7 +123,7 @@ async function fetchPRsSinceLastReleaseAndEditReleaseNotes(newRelease, callback)
 function editReleaseNotesFile(body)
 {
     var releaseNotesFile = path.join(__dirname, '..', 'releaseNote.md');
-    var existingReleaseNotes = fs.readFileSync(releaseNotesFile, 'utf-8');
+    var existingReleaseNotes = fs.readFileSync(releaseNotesFile);
     var newPRs = { 'Features': [], 'Bugs': [], 'Misc': [] };
     body.items.forEach(function (item) {
         var category = 'Misc';
@@ -155,9 +155,7 @@ function editReleaseNotesFile(body)
         newReleaseNotes += `## ${category}\n${newPRs[category].join('\n')}\n\n`;
     });
 
-    const existingReleaseNotesWithHashes = addHashesToReleaseNotes(existingReleaseNotes);
-
-    newReleaseNotes += existingReleaseNotesWithHashes;
+    newReleaseNotes += existingReleaseNotes;
     var editorCmd = `${process.env.EDITOR} ${releaseNotesFile}`;
     console.log(editorCmd);
     if (opt.options.dryrun)
@@ -182,27 +180,6 @@ function editReleaseNotesFile(body)
             process.exit(-1);
         }
     }
-}
-
-function addHashesToReleaseNotes(releaseNotes) {
-    const hashes = util.getHashes();
-
-    const lines = releaseNotes.split('\n');
-    const modifiedLines = lines.map((line) => {
-        if (!line.includes('<HASH>')) {
-            return line;
-        }
-
-        // Package is the second column in the releaseNote.md file, get it's value
-        const columns = line.split('|').filter((column) => column.length !== 0);
-        const packageColumn = columns[1];
-        // Inside package column, we have the package name inside the square brackets
-        const packageName = packageColumn.substring(packageColumn.indexOf('[') + 1, packageColumn.indexOf(']'));
-
-        return line.replace('<HASH>', hashes[packageName]);
-    });
-
-    return modifiedLines.join('\n');
 }
 
 function commitAndPush(directory, release, branch)

--- a/release/createReleaseBranch.js
+++ b/release/createReleaseBranch.js
@@ -123,7 +123,7 @@ async function fetchPRsSinceLastReleaseAndEditReleaseNotes(newRelease, callback)
 function editReleaseNotesFile(body)
 {
     var releaseNotesFile = path.join(__dirname, '..', 'releaseNote.md');
-    var existingReleaseNotes = fs.readFileSync(releaseNotesFile);
+    var existingReleaseNotes = fs.readFileSync(releaseNotesFile, 'utf-8');
     var newPRs = { 'Features': [], 'Bugs': [], 'Misc': [] };
     body.items.forEach(function (item) {
         var category = 'Misc';
@@ -197,7 +197,7 @@ function addHashesToReleaseNotes(releaseNotes) {
         const columns = line.split('|').filter((column) => column.length !== 0);
         const packageColumn = columns[1];
         // Inside package column, we have the package name inside the square brackets
-        const packageName = packageColumn.substring(line.indexOf('[') + 1, line.indexOf(']'));
+        const packageName = packageColumn.substring(packageColumn.indexOf('[') + 1, packageColumn.indexOf(']'));
 
         return line.replace('<HASH>', hashes[packageName]);
     });
@@ -241,28 +241,6 @@ function checkGitStatus()
     return git_status;
 }
 
-async function main()
-{
-    try {
-        var newRelease = opt.argv[0];
-        if (newRelease === undefined)
-        {
-            console.log('Error: You must supply a version');
-            process.exit(-1);
-        }
-        util.verifyMinimumNodeVersion();
-        util.verifyMinimumGitVersion();
-        await verifyNewReleaseTagOk(newRelease);
-        checkGitStatus();
-        writeAgentVersionFile(newRelease);
-        await fetchPRsSinceLastReleaseAndEditReleaseNotes(newRelease);
-        commitAgentChanges(path.join(__dirname, '..'), newRelease);
-        console.log('done.');
-    }
-    catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err.message || 'run() failed', true);
-        throw err;
-    }
-}
+// main();
 
-main();
+fetchPRsSinceLastReleaseAndEditReleaseNotes('2.130.30')

--- a/release/fillReleaseNotesTemplate.js
+++ b/release/fillReleaseNotesTemplate.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const util = require('./util');
+
+function addHashesToReleaseNotes(releaseNotes) {
+    const hashes = util.getHashes();
+
+    const lines = releaseNotes.split('\n');
+    const modifiedLines = lines.map((line) => {
+        if (!line.includes('<HASH>')) {
+            return line;
+        }
+
+        // Package is the second column in the releaseNote.md file, get it's value
+        const columns = line.split('|').filter((column) => column.length !== 0);
+        const packageColumn = columns[1];
+        // Inside package column, we have the package name inside the square brackets
+        const packageName = packageColumn.substring(packageColumn.indexOf('[') + 1, packageColumn.indexOf(']'));
+
+        return line.replace('<HASH>', hashes[packageName]);
+    });
+
+    return modifiedLines.join('\n');
+}
+
+function addAgentVersionToReleaseNotes(releaseNotes, agentVersion) {
+    return releaseNotes.replace(/<AGENT_VERSION>/g, agentVersion);
+}
+
+function main() {
+    const agentVersion = process.argv[2];
+    if (agentVersion === undefined) {
+        throw new Error('Agent version argument must be supplied');
+    }
+
+    const releaseNotesPath = path.join(__dirname, '..', 'releaseNote.md');
+    const releaseNotes = fs.readFileSync(releaseNotesPath, 'utf-8');
+
+    const filledReleaseNotes = addHashesToReleaseNotes(addAgentVersionToReleaseNotes(releaseNotes, agentVersion));
+    fs.writeFileSync(releaseNotesPath, filledReleaseNotes);
+}
+
+main();

--- a/release/fillReleaseNotesTemplate.js
+++ b/release/fillReleaseNotesTemplate.js
@@ -36,7 +36,8 @@ function main() {
     const releaseNotesPath = path.join(__dirname, '..', 'releaseNote.md');
     const releaseNotes = fs.readFileSync(releaseNotesPath, 'utf-8');
 
-    const filledReleaseNotes = addHashesToReleaseNotes(addAgentVersionToReleaseNotes(releaseNotes, agentVersion));
+    const releaseNotesWithAgentVersion = addAgentVersionToReleaseNotes(releaseNotes, agentVersion);
+    const filledReleaseNotes = addHashesToReleaseNotes(releaseNotesWithAgentVersion);
     fs.writeFileSync(releaseNotesPath, filledReleaseNotes);
 }
 

--- a/release/fillReleaseNotesTemplate.js
+++ b/release/fillReleaseNotesTemplate.js
@@ -2,6 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const util = require('./util');
 
+/**
+ * @param {*} releaseNotes Release notes template text content
+ * @returns Release notes where `<HASH>` is replaced with the provided agents package hash
+ */
 function addHashesToReleaseNotes(releaseNotes) {
     const hashes = util.getHashes();
 
@@ -23,10 +27,20 @@ function addHashesToReleaseNotes(releaseNotes) {
     return modifiedLines.join('\n');
 }
 
+/**
+ * @param {string} releaseNotes Release notes template text content
+ * @param {string} agentVersion Agent version, e.g. 2.193.0
+ * @returns Release notes where `<AGENT_VERSION>` is replaced with the provided agent version
+ */
 function addAgentVersionToReleaseNotes(releaseNotes, agentVersion) {
     return releaseNotes.replace(/<AGENT_VERSION>/g, agentVersion);
 }
 
+/**
+ * Takes agent version as the first cmdline argument.
+ * 
+ * Reads the releaseNote.md template file content and replaces `<AGENT_VERSION>` and `<HASH>` with agent version and package hash respectively.
+ */
 function main() {
     const agentVersion = process.argv[2];
     if (agentVersion === undefined) {

--- a/release/util.js
+++ b/release/util.js
@@ -1,5 +1,6 @@
 const cp = require('child_process');
 const fs = require('fs');
+const path = require('path');
 
 const GIT = 'git';
 const GIT_RELEASE_RE = /([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/;
@@ -61,9 +62,9 @@ exports.fillInstallAgentPackageParameters = function(template, destination, vers
             }
 
             const packageNameStart = line.indexOf('filename="') + 'filename="'.length;
-            const packageNameEnd = line.slice(packageNameStart).indexOf('"');
+            const packageNameEnd = packageNameStart + line.slice(packageNameStart).indexOf('"');
             const packageName = line.substring(packageNameStart, packageNameEnd);
-            
+
             return line.replace('<HASH_VALUE>', hashes[packageName]);
         });
 
@@ -101,11 +102,16 @@ exports.getHashes = function() {
 
 function getAllFilesRecursively(directory) {
     const allFiles = [];
-    for (const fileOrDir of fs.readdirSync(directory)) {
+
+    for (const fileOrDirName of fs.readdirSync(directory)) {
+        const fileOrDir = path.join(directory, fileOrDirName);
+
         if (fs.statSync(fileOrDir).isDirectory()) {
-            allFiles.push(...getAllFilesRecursively(path.join(directory, fileOrDir)));
+            allFiles.push(...getAllFilesRecursively(fileOrDir));
         } else {
-            allFiles.push(path.join(directory, fileOrDir));
+            allFiles.push(fileOrDir);
         }
     }
+
+    return allFiles;
 }

--- a/release/util.js
+++ b/release/util.js
@@ -47,6 +47,13 @@ exports.execInForeground = function(command, directory, dryrun = false)
     }
 }
 
+/**
+ * Replaces `<AGENT_VERSION>` and `<HASH_VALUE>` with the right values
+ * 
+ * @param {*} template InstallAgentPackage.template.xml path
+ * @param {*} destination Path where the filled InstallAgentPackage.xml should be written
+ * @param {*} version Agent version, e.g. 2.193.0
+ */
 exports.fillInstallAgentPackageParameters = function(template, destination, version)
 {
     try
@@ -79,6 +86,9 @@ exports.fillInstallAgentPackageParameters = function(template, destination, vers
     }
 }
 
+/**
+ * @returns A map where the keys are the agent package file names and the values are corresponding packages hashes
+ */
 exports.getHashes = function() {
     const hashesDirPath = path.join(__dirname, '..', '_hashes', 'hash');
     const hashFiles = fs.readdirSync(hashesDirPath);

--- a/release/util.js
+++ b/release/util.js
@@ -80,16 +80,14 @@ exports.fillInstallAgentPackageParameters = function(template, destination, vers
 }
 
 exports.getHashes = function() {
-    const hashesDirPath = path.join(__dirname, '..', '_hashes');
-    const allFiles = getAllFilesRecursively(hashesDirPath);
-    const hashFiles = allFiles.filter((file) => file.endsWith('.sha256'));
+    const hashesDirPath = path.join(__dirname, '..', '_hashes', 'hash');
+    const hashFiles = fs.readdirSync(hashesDirPath);
 
     const hashes = {};
-    for (const hashFile of hashFiles) {
-        const hashFileName = path.basename(hashFile);
+    for (const hashFileName of hashFiles) {
         const agentPackageFileName = hashFileName.replace('.sha256', '');
 
-        const hashFileContent = fs.readFileSync(hashFile, 'utf-8').trim();
+        const hashFileContent = fs.readFileSync(path.join(hashesDirPath, hashFileName), 'utf-8').trim();
         // Last 64 characters are the sha256 hash value
         const hashStringLength = 64;
         const hash = hashFileContent.slice(hashFileContent.length - hashStringLength);
@@ -98,20 +96,4 @@ exports.getHashes = function() {
     }
 
     return hashes;
-}
-
-function getAllFilesRecursively(directory) {
-    const allFiles = [];
-
-    for (const fileOrDirName of fs.readdirSync(directory)) {
-        const fileOrDir = path.join(directory, fileOrDirName);
-
-        if (fs.statSync(fileOrDir).isDirectory()) {
-            allFiles.push(...getAllFilesRecursively(fileOrDir));
-        } else {
-            allFiles.push(fileOrDir);
-        }
-    }
-
-    return allFiles;
 }

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -1,15 +1,15 @@
 
 ## Agent Downloads
 
-|             | Package |
-| ----------- | ------- |
-| Windows x64 | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) |
-| Windows x86 | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) |
-| macOS       | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) |
-| Linux x64   | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
-| Linux ARM   | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
-| Linux ARM64 | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
-| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |
+|             | Package | SHA-256 |
+| ----------- | ------- | ------- |
+| Windows x64 | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
+| Windows x86 | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| macOS       | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux x64   | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM   | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM64 | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 
 After Download:
 
@@ -67,12 +67,12 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 This following alternate packages do not include Node 6 and are only suitable for users who do not use Node 6 dependent tasks. 
 See [notes](docs/node6.md) on Node version support for more details.
 
-|             | Package |
-| ----------- | ------- |
-| Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) |
-| Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) |
-| macOS       | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) |
-| Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) |
-| Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) |
-| Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) |
-| RHEL 6 x64  | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) |
+|             | Package | SHA-256 |
+| ----------- | ------- | ------- |
+| Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
+| Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| macOS       | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| RHEL 6 x64  | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | <HASH> |

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -6,72 +6,72 @@
   <Steps>
     <ServicingStep name="Add OSX agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="osx-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="osx-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add OSX alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="osx-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="osx-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Linux agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="linux-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="linux-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Linux alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="linux-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM Linux agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="linux-arm" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="linux-arm" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM Linux alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM64 Linux agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="linux-arm64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="linux-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM64 Linux alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="win-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x64-<AGENT_VERSION>.zip" />
+        <AddTaskPackageData packageType="agent" platform="win-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x64-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="win-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x64-<AGENT_VERSION>.zip" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x64-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x86 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="win-x86" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x86-<AGENT_VERSION>.zip" />
+        <AddTaskPackageData packageType="agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x86 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Redhat 6 agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="rhel.6-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="rhel.6-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Redhat 6 alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.6-x64" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.6-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
   </Steps>

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -218,6 +218,26 @@ function cmd_package ()
     popd > /dev/null
 }
 
+function cmd_hash ()
+{
+    pushd "$PACKAGE_DIR" > /dev/null
+
+    files=`ls -1`
+
+    number_of_files=`wc -l <<< "$files"`
+
+    if [[ number_of_files -ne 1 ]]; then
+        echo "Expecting to find exactly one file in $PACKAGE_DIR"
+        exit 1
+    fi
+
+    agent_package_file=$files
+
+    openssl dgst -sha256 $agent_package_file >> "$agent_package_file.sha256"
+
+    popd > /dev/null
+}
+
 function cmd_report ()
 {
     heading "Generating Reports"
@@ -350,6 +370,7 @@ case $DEV_CMD in
    "l") cmd_layout;;
    "package") cmd_package;;
    "p") cmd_package;;
+   "hash") cmd_hash;;
    "report") cmd_report;;
    *) echo "Invalid command. Use (l)ayout, (b)uild, (t)est, test(l0), test(l1), or (p)ackage.";;
 esac

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -227,13 +227,15 @@ function cmd_hash ()
     number_of_files=`wc -l <<< "$files"`
 
     if [[ number_of_files -ne 1 ]]; then
-        echo "Expecting to find exactly one file in $PACKAGE_DIR"
+        echo "Expecting to find exactly one file (agent package) in $PACKAGE_DIR"
         exit 1
     fi
 
     agent_package_file=$files
 
-    openssl dgst -sha256 $agent_package_file >> "$agent_package_file.sha256"
+    rm -rf ../../_package_hash
+    mkdir ../../_package_hash
+    openssl dgst -sha256 $agent_package_file >> "../../_package_hash/$agent_package_file.sha256"
 
     popd > /dev/null
 }


### PR DESCRIPTION
Updated build process to compute SHA-256 hashes of the agent package.

Hashing implementation: added a new command to the `dev.sh` script - `hash`. It looks for the agent package in the `_package` dir and computes its hash using `openssl dgst -sha256` command. The resulting hash is saved to the `_package_hash` with `.sha256` extension.

During the build job in `build-job.yml` the hash file in the `_package_hash` dir is published to the `hash` artifact.

In the main release pipeline (`.vsts.release.yml`) all of the hashes that have been published in the build job are downloaded. After that, they are used in a new `fillReleaseNotesTemplate.js` script that puts agent version and package hashes to the `releaseNotes.md` file.

Function `versionifySync` (used when creating ADO PR) in the `util.js` file is replaced with `fillInstallAgentPackageParameters` that puts both agent version and package hashes to the `InstallAgentPackage.xml` template. This function requires agent hashes files to work, so these hashes are also downloaded to the `_hashes` dir before creating ADO PR.