### PR TITLE
Update VssApiVersion to 0.5.170-private

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.169-private</VssApiVersion>
+    <VssApiVersion>0.5.170-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
   </PropertyGroup>
 


### PR DESCRIPTION
Make dedup redirect timeout configurable (!627856)
Default dedup redirect timeout is 1 minute. Make it configurable by VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC