### PR TITLE
Fixed error on finalize job (Could not load file or assembly 'Microsoft.VisualStudio.Services.Agent'...)

### DIFF
--- a/src/Agent.Plugins/TestResultParser/ParserFactory.cs
+++ b/src/Agent.Plugins/TestResultParser/ParserFactory.cs
@@ -28,7 +28,7 @@ namespace Agent.Plugins.Log.TestResultParser.Plugin
                    }
                    catch
                    {
-                       // Skipping issues with assemblies load via reflection - since there are some issues with assemblies like Microsoft.VisualStudio.Services.Agent', although this assembly is not relevant here
+                       // Skipping issues with assemblies load via reflection - since there are some issues with 'Microsoft.VisualStudio.Services.Agent', although this assembly is not relevant here
                        return new Type[0];
                    }
                })

--- a/src/Agent.Plugins/TestResultParser/ParserFactory.cs
+++ b/src/Agent.Plugins/TestResultParser/ParserFactory.cs
@@ -20,9 +20,20 @@ namespace Agent.Plugins.Log.TestResultParser.Plugin
 
             var interfaceType = typeof(AbstractTestResultParser);
             return AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.GetTypes())
-                .Where(x => interfaceType.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
-                .Select(x => (AbstractTestResultParser)Activator.CreateInstance(x, testRunManager, logger, telemetry));
+               .SelectMany((x) =>
+               {
+                   try
+                   {
+                       return x.GetTypes();
+                   }
+                   catch
+                   {
+                       // Skipping issues with assemblies load via reflection - since there are some issues with assemblies like Microsoft.VisualStudio.Services.Agent', although this assembly is not relevant here
+                       return new Type[0];
+                   }
+               })
+             .Where(x => interfaceType.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
+            .Select(x => (AbstractTestResultParser)Activator.CreateInstance(x, testRunManager, logger, telemetry));
         }
     }
 }


### PR DESCRIPTION
There was an issue with loading of one of the assemblies ('Microsoft.VisualStudio.Services.Agent') during retrieval of test result parsers list via reflection.
As a fix - added error handling - skipping errors during assemblies load via reflection.
Related issue - https://github.com/microsoft/azure-pipelines-agent/issues/3501
Tested changes locally - it resolves the issue on Finalize job step.