### PR TITLE
Installing dependencies for SUSE systems - fixed issue with incorrect ID parameter picking up

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -211,10 +211,10 @@ then
     else
 
         # we might on OpenSUSE
-        OSTYPE=$(grep ID_LIKE /etc/os-release | cut -f2 -d=)
+        OSTYPE=$(grep ^ID_LIKE /etc/os-release | cut -f2 -d=)
         if [ -z $OSTYPE ]
         then
-            OSTYPE=$(grep ID /etc/os-release | cut -f2 -d=)
+            OSTYPE=$(grep ^ID /etc/os-release | cut -f2 -d=)
         fi
         echo $OSTYPE
 


### PR DESCRIPTION
Previously for suse systems - all parameters containing ID and ID_LIKE were picked up.
Updated match pattern - to avoid picking up parameters like VERSION_ID (which is incorrect).
Related issue - https://github.com/microsoft/azure-pipelines-agent/issues/3508