### PR TITLE
Filling publish script with hashes

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -171,12 +171,12 @@ extends:
               Invoke-RestMethod @assetsParams
             displayName: Create agent release on Github
 
-      - stage: CreatePR
+      - stage: CreatePRs
         jobs:
         ################################################################################
-        - job: create_ado_pr
+        - job: create_ado_prs
         ################################################################################
-          displayName: Create PR in AzureDevOps
+          displayName: Create PRs in AzureDevOps and ConfigChange
           pool:
             vmImage: ubuntu-18.04
 
@@ -200,7 +200,7 @@ extends:
               npm install
               ls
               node createAdoPrs.js ${{ parameters.version }}
-            displayName: Create PR in AzureDevOps
+            displayName: Create PRs in AzureDevOps and ConfigChange
             env:
               USER: $(User)
               PAT: $(AdoPAT)

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -199,7 +199,7 @@ extends:
               cd release
               npm install
               ls
-              node createAdoPr.js ${{ parameters.version }}
+              node createAdoPrs.js ${{ parameters.version }}
             displayName: Create PR in AzureDevOps
             env:
               USER: $(User)

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const tl = require('azure-pipelines-task-lib/task');
 const util = require('./util');
-const fetch = require('node-fetch');
+const got = require('got');
 
 const INTEGRATION_DIR = path.join(__dirname, '..', '_layout', 'integrations');
 const GIT = 'git';
@@ -152,9 +152,8 @@ async function createConfigChangePR(repoPath, agentVersion) {
  * @returns current sprint version
  */
 async function getCurrentSprint() {
-    const response = await fetch('https://whatsprintis.it/?json');
-    const responseJson = await response.json();
-    return responseJson.sprint;
+    const response = await got.get('https://whatsprintis.it/?json', { responseType: 'json' });
+    return response.body.sprint;
 }
 
 async function main()

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -121,9 +121,9 @@ async function createConfigChangePR(repoPath, agentVersion) {
     const file = path.join(INTEGRATION_DIR, 'Publish.ps1');
 
     if (opt.options.dryrun) {
-        console.log(`Fake copy file from ${file} to ${target}`);
+        console.log(`Fake copy file from ${file} to ${publishScriptPathInSystem}`);
     } else {
-        console.log(`Copy file from ${file} to ${target}`);
+        console.log(`Copy file from ${file} to ${publishScriptPathInSystem}`);
         fs.copyFileSync(file, publishScriptPathInSystem);
     }
 
@@ -138,9 +138,9 @@ async function createConfigChangePR(repoPath, agentVersion) {
         sourceRefName: `refs/heads/${newBranch}`,
         targetRefName: 'refs/heads/master',
         title: 'Update agent',
-        description: `Update agent to version ${agentVersion}`
+        description: `Update agent publish script to version ${agentVersion}`
     };
-    const repo = 'AzureDevOps';
+    const repo = 'AzureDevOps.ConfigChange';
     const project = 'AzureDevOps';
     await gitApi.createPullRequest(pullRequest, repo, project);
 }
@@ -163,7 +163,7 @@ async function main()
         var pathToAdo = path.join(INTEGRATION_DIR, 'AzureDevOps');
         await createAdoPR(pathToAdo, newRelease);
 
-        var pathToAdoConfigChange = path.join(INTEGRATION_DIR, 'AzureDevOps.ConfigChange');
+        const pathToAdoConfigChange = path.join(INTEGRATION_DIR, 'AzureDevOps.ConfigChange');
         await createConfigChangePR(pathToAdoConfigChange, newRelease);
 
         console.log('done.');

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -1,6 +1,5 @@
 const azdev = require('azure-devops-node-api');
 const fs = require('fs');
-const naturalSort = require('natural-sort');
 const path = require('path');
 const tl = require('azure-pipelines-task-lib/task');
 const util = require('./util');
@@ -13,7 +12,7 @@ var opt = require('node-getopt').create([
     ['h', 'help',                 'Display this help'],
   ])
   .setHelp(
-    'Usage: node createAdoPr.js [OPTION] <version>\n' +
+    'Usage: node createAdoPrs.js [OPTION] <version>\n' +
     '\n' +
     '[[OPTIONS]]\n'
   )
@@ -23,17 +22,27 @@ var opt = require('node-getopt').create([
 const authHandler = azdev.getPersonalAccessTokenHandler(process.env.PAT);
 const connection = new azdev.WebApi('https://dev.azure.com/mseng', authHandler);
 
-function createIntegrationFiles(newRelease, callback)
+/**
+ * Fills InstallAgentPackage.xml and Publish.ps1 templates.
+ * Replaces <AGENT_VERSION> and <HASH_VALUE> with the right values in these files.
+ * @param {string} newRelease Agent version, e.g. 2.193.0
+ */
+function createIntegrationFiles(newRelease)
 {
     fs.mkdirSync(INTEGRATION_DIR, { recursive: true });
-    util.fillInstallAgentPackageParameters(
+    util.fillAgentParameters(
         path.join(__dirname, '..', 'src', 'Misc', 'InstallAgentPackage.template.xml'),
         path.join(INTEGRATION_DIR, 'InstallAgentPackage.xml'),
         newRelease
     );
+    util.fillAgentParameters(
+        path.join(__dirname, '..', 'src', 'Misc', 'Publish.template.ps1'),
+        path.join(INTEGRATION_DIR, 'Publish.ps1'),
+        newRelease
+    );
 }
 
-commitAndPush = function(directory, release, branch)
+function commitAndPush(directory, release, branch)
 {
     util.execInForeground(`${GIT} checkout -b ${branch}`, directory);
     util.execInForeground(`${GIT} commit -m "Agent Release ${release}" `, directory);
@@ -55,14 +64,14 @@ function sparseClone(directory, url)
     util.execInForeground(`${GIT} sparse-checkout init --cone`, directory, opt.dryrun);
 }
 
-async function commitADOL2Changes(directory, release)
+async function createAdoPR(directory, release)
 {
-    var gitUrl =  `https://${process.env.PAT}@dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps`
+    var gitUrl = `https://${process.env.PAT}@dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps`;
 
     var file = path.join(INTEGRATION_DIR, 'InstallAgentPackage.xml');
     var targetDirectory = path.join('DistributedTask', 'Service', 'Servicing', 'Host', 'Deployment', 'Groups');
     var target = path.join(directory, targetDirectory, 'InstallAgentPackage.xml');
-    
+
     if (!fs.existsSync(directory))
     {
         // sparseClone(directory, gitUrl);
@@ -93,6 +102,49 @@ async function commitADOL2Changes(directory, release)
     }, 'AzureDevOps', 'AzureDevOps');
 }
 
+async function createConfigChangePR(repoPath, agentVersion) {
+    const gitUrl = `https://${process.env.PAT}@dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps.ConfigChange`;
+
+    if (!agentVersion.match(/^\d\.\d\d\d.\d+$/)) {
+        throw new Error(`Agent version should fit the pattern: x.xxx.xxx; received: ${agentVersion}`);
+    }
+
+    if (!fs.existsSync(repoPath)) {
+        util.execInForeground(`${GIT} clone --depth 1 ${gitUrl} ${repoPath}`, null, opt.dryrun);
+    }
+
+    const sprint = agentVersion.split('.')[1];
+    const publishScriptPathInRepo = path.join('tfs', `m${sprint}`, 'PipelinesAgentRelease', agentVersion, 'Publish.ps1');
+    const publishScriptPathInSystem = path.join(repoPath, publishScriptPathInRepo);
+    fs.mkdirSync(path.dirname(publishScriptPathInSystem), { recursive: true });
+
+    const file = path.join(INTEGRATION_DIR, 'Publish.ps1');
+
+    if (opt.options.dryrun) {
+        console.log(`Fake copy file from ${file} to ${target}`);
+    } else {
+        console.log(`Copy file from ${file} to ${target}`);
+        fs.copyFileSync(file, publishScriptPathInSystem);
+    }
+
+    const newBranch = `users/${process.env.USER}/agent-${agentVersion}`;
+    util.execInForeground(`${GIT} add ${publishScriptPathInRepo}`, repoPath, opt.dryrun);
+    commitAndPush(repoPath, agentVersion, newBranch);
+
+    console.log(`Creating pr from ${newBranch} into master in the AzureDevOps.ConfigChange repo`);
+
+    const gitApi = await connection.getGitApi();
+    const pullRequest = {
+        sourceRefName: `refs/heads/${newBranch}`,
+        targetRefName: 'refs/heads/master',
+        title: 'Update agent',
+        description: `Update agent to version ${agentVersion}`
+    };
+    const repo = 'AzureDevOps';
+    const project = 'AzureDevOps';
+    await gitApi.createPullRequest(pullRequest, repo, project);
+}
+
 async function main()
 {
     try {
@@ -102,13 +154,18 @@ async function main()
             console.log('Error: You must supply a version');
             process.exit(-1);
         }
-        var pathToAdo = path.join(INTEGRATION_DIR, 'AzureDevOps');
         util.verifyMinimumNodeVersion();
         util.verifyMinimumGitVersion();
         createIntegrationFiles(newRelease);
         util.execInForeground(`${GIT} config --global user.email "${process.env.USER}@microsoft.com"`, null, opt.dryrun);
         util.execInForeground(`${GIT} config --global user.name "${process.env.USER}"`, null, opt.dryrun);
-        await commitADOL2Changes(pathToAdo, newRelease);
+
+        var pathToAdo = path.join(INTEGRATION_DIR, 'AzureDevOps');
+        await createAdoPR(pathToAdo, newRelease);
+
+        var pathToAdoConfigChange = path.join(INTEGRATION_DIR, 'AzureDevOps.ConfigChange');
+        await createConfigChangePR(pathToAdoConfigChange, newRelease);
+
         console.log('done.');
     }
     catch (err) {

--- a/release/package-lock.json
+++ b/release/package-lock.json
@@ -125,10 +125,55 @@
         "@types/node": ">= 8"
       }
     },
+    "@sindresorhus/is": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "@types/keyv": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
+      "integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "13.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.6.tgz",
       "integrity": "sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA=="
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "atob-lite": {
       "version": "2.0.0",
@@ -205,6 +250,43 @@
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+    },
+    "cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -222,10 +304,25 @@
         "which": "^1.2.9"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -254,20 +351,44 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "fetch-blob": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-      "requires": {
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "got": {
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "is-plain-object": {
@@ -293,6 +414,19 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "keyv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -308,10 +442,20 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
       "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -331,19 +475,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
-    "node-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-      "requires": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^3.1.2"
-      }
-    },
     "node-getopt": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
       "integrity": "sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q=="
+    },
+    "normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -375,6 +515,11 @@
         "windows-release": "^3.1.0"
       }
     },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -398,6 +543,24 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "semver": {
       "version": "5.7.1",
@@ -449,11 +612,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
-    "web-streams-polyfill": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
     },
     "which": {
       "version": "1.3.1",

--- a/release/package-lock.json
+++ b/release/package-lock.json
@@ -69,6 +69,11 @@
         "universal-user-agent": "^5.0.0"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+          "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
+        },
         "universal-user-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
@@ -217,6 +222,11 @@
         "which": "^1.2.9"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -242,6 +252,14 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
+      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.0.3"
       }
     },
     "get-stream": {
@@ -308,20 +326,19 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
-    "natural-sort": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/natural-sort/-/natural-sort-1.0.0.tgz",
-      "integrity": "sha1-6sMB/YbCaKdxIixi3HcZQCqjQ4A="
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
+      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
+      "requires": {
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^3.1.2"
+      }
     },
     "node-getopt": {
       "version": "0.3.2",
@@ -432,6 +449,11 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
+      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
     },
     "which": {
       "version": "1.3.1",

--- a/release/package.json
+++ b/release/package.json
@@ -13,7 +13,7 @@
     "@octokit/rest": "^16.43.1",
     "azure-devops-node-api": "10.0.0",
     "azure-pipelines-task-lib": "2.9.3",
-    "node-fetch": "^3.0.0",
+    "got": "^11.8.2",
     "node-getopt": "^0.3.2"
   }
 }

--- a/release/package.json
+++ b/release/package.json
@@ -13,7 +13,7 @@
     "@octokit/rest": "^16.43.1",
     "azure-devops-node-api": "10.0.0",
     "azure-pipelines-task-lib": "2.9.3",
-    "natural-sort": "^1.0.0",
+    "node-fetch": "^3.0.0",
     "node-getopt": "^0.3.2"
   }
 }

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+
+if (<AGENT_VERSION> -NotMatch '^\d\.\d\d\d.\d+$') {
+    Write-Error "AgentVersion '<AGENT_VERSION>' is not valid."
+}
+
+if ($pwd -notlike '*tfsgheus20' ) {
+
+    # primary packages
+
+    Add-DistributedTaskPackage -PackageType agent -Platform win-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-win-x64-<AGENT_VERSION>.zip
+
+    Add-DistributedTaskPackage -PackageType agent -Platform win-x86 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-win-x86-<AGENT_VERSION>.zip
+
+    Add-DistributedTaskPackage -PackageType agent -Platform osx-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType agent -Platform linux-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType agent -Platform linux-arm -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType agent -Platform linux-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
+
+    # alternate packages
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform win-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-win-x64-<AGENT_VERSION>.zip
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform win-x86 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-win-x86-<AGENT_VERSION>.zip
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform osx-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform linux-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform linux-arm -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform linux-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
+}

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -1,9 +1,5 @@
 $ErrorActionPreference = 'Stop'
 
-if (<AGENT_VERSION> -NotMatch '^\d\.\d\d\d.\d+$') {
-    Write-Error "AgentVersion '<AGENT_VERSION>' is not valid."
-}
-
 if ($pwd -notlike '*tfsgheus20' ) {
 
     # primary packages


### PR DESCRIPTION
We need to provide `HashValue` argument to each `Add-DistributedTaskPackage` call in the agent publish script. We've decided to make this script a template and fill it in the release pipeline along with `InstallAgentPackage.xml`.
This script will now be stored in the `tfs/m<SPRINT_VERSION>/PipelinesAgentRelease/<AGENT_VERSION>/Publish.ps1`.
These changes will be pushed to the `AzureDevOps.ConfigChange` repo.