### PR TITLE
dotnet-install.sh updating

### DIFF
--- a/src/Misc/dotnet-install.sh
+++ b/src/Misc/dotnet-install.sh
@@ -224,7 +224,7 @@ get_legacy_os_name() {
 machine_has() {
     eval $invocation
 
-    hash "$1" > /dev/null 2>&1
+    command -v "$1" > /dev/null 2>&1
     return $?
 }
 


### PR DESCRIPTION
We need to update the `dotnet-install.sh` file to fix [the CI](https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=15989597&view=results) of the agent.

[This unit test](https://github.com/microsoft/azure-pipelines-agent/blob/b99fdc2a509ce8b63521c8ca74755c8b39583a9a/src/Test/L0/DotnetsdkDownloadScriptL0.cs#L16)
```
Microsoft.VisualStudio.Services.Agent.Tests.DotnetsdkDownloadScriptL0.EnsureDotnetsdkBashDownloadScriptUpToDate
```
fails with the error message:
[Fix the test by updating Src/Misc/dotnet-install.sh with content from https://dot.net/v1/dotnet-install.sh](https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=15989597&view=logs&j=06a33a71-ab93-5282-5919-5a79d81723b9&t=ddf829bd-549d-5cf2-5f8f-ec008b92e506&l=99)

This PR replaces the old `dotnet-install.sh` file with a new one uploaded via the link provided in the error message.