### PR TITLE
Update ubuntu image in the CI

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -108,7 +108,7 @@ stages:
         jobName: build_linux_x64
         displayName: Linux (x64)
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
         os: linux
         arch: x64
         branch: ${{ parameters.branch }}
@@ -167,7 +167,7 @@ stages:
         jobName: build_rhel6_x64
         displayName: RHEL6 (x64)
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
         container: dotnetcore_centos6
         os: rhel.6
         arch: x64


### PR DESCRIPTION
We need to update the image in the CI from `ubuntu-16.04` at least to `ubuntu-18.04` since
```
Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021.
```