### PR TITLE
Summarized view of Xunit hierarchal tests based on a FF

### DIFF
--- a/src/Agent.Worker/TestResults/Parser.cs
+++ b/src/Agent.Worker/TestResults/Parser.cs
@@ -5,6 +5,7 @@ using Microsoft.TeamFoundation.TestClient.PublishTestResults;
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 {
@@ -96,7 +97,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         protected override ITestResultParser GetTestResultParser(IExecutionContext executionContext)
         {
             var traceListener = new CommandTraceListener(executionContext);
-            return new TrxResultParser(traceListener);
+            var featureFlagService = executionContext.GetHostContext().GetService<IFeatureFlagService>();
+            var enableXUnitHeirarchicalParsing = featureFlagService.GetFeatureFlagState(TestResultsConstants.EnableXUnitHeirarchicalParsing, TestResultsConstants.TFSServiceInstanceGuid);
+            return new TrxResultParser(traceListener, enableXUnitHeirarchicalParsing);
         }
 
     }

--- a/src/Agent.Worker/TestResults/Utils/FeatureFlagService.cs
+++ b/src/Agent.Worker/TestResults/Utils/FeatureFlagService.cs
@@ -39,8 +39,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
                 var featureFlag = featureAvailabilityHttpClient?.GetFeatureFlagByNameAsync(featureFlagName).Result;
                 if (featureFlag != null && featureFlag.EffectiveState.Equals("On", StringComparison.OrdinalIgnoreCase))
                 {
+                    _executionContext.Debug(StringUtil.Format("{0} is on", featureFlagName));
                     return true;
                 }
+                _executionContext.Debug(StringUtil.Format("{0} is off", featureFlagName));
             }
             catch
             {

--- a/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
+++ b/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
@@ -20,5 +20,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
         public static readonly string UseNewRunSummaryAPIFeatureFlag = "TestManagement.Server.UseNewRunSummaryAPIForPublishTestResultsTask";
 
         public const string EnableFlakyCheckInAgentFeatureFlag = "TestManagement.Agent.PTR.EnableFlakyCheck";
+
+        public static readonly string EnableXUnitHeirarchicalParsing = "TestManagement.PublishTestResultsTask.EnableXUnitHeirarchicalParsing";
     }
 }

--- a/src/Test/L0/Worker/TestResults/ParserTests.cs
+++ b/src/Test/L0/Worker/TestResults/ParserTests.cs
@@ -12,12 +12,14 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
+using Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
 {
     public class ParserTests
     {
         private Mock<IExecutionContext> _ec;
+        private Mock<IFeatureFlagService> _mockFeatureFlagService;
 
         [Fact]
         [Trait("Level", "L0")]
@@ -407,6 +409,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
                 {
                   Console.Error.WriteLine(tag + ": " + message);
                 });
+            _mockFeatureFlagService = new Mock<IFeatureFlagService>();
+            _mockFeatureFlagService.Setup(x => x.GetFeatureFlagState(It.IsAny<string>(), It.IsAny<Guid>())).Returns(true);
+            _ec.Setup(x => x.GetHostContext()).Returns(hc);
+            hc.SetSingleton(_mockFeatureFlagService.Object);
 
         }
     }


### PR DESCRIPTION
<!--
If you're new to deploying `github/github` please read the https://thehub.github.com/engineering/development-and-ops/deployment/deploying-dotcom/
-->

### What are you trying to accomplish?
Getting control to enable/disable summarized view of xunit hierarchal test results

### What approach did you choose and why?
Using an already present FF for a summarized view of xunit hierarchal test results.

### What should reviewers focus on?
Since this is my first PR, please look if this change is not going to break any intended scenario.

### If something goes wrong, what are the mitigation strategies?
Can be controlled by TestManagement.PublishTestResultsTask.EnableXUnitHeirarchicalParsing FF 

### Performance Impact

N/A

### Observability

N/A
