### PR TITLE
Improve the exception message for changing file attributes

### DIFF
--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -453,12 +453,32 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }
         }
 
+        private static void SetAttributesWithDiagnostic(FileSystemInfo item, FileAttributes attributes)
+        {
+            try
+            {
+                item.Attributes = attributes;
+            }
+            catch (ArgumentException ex)
+            {
+                string exceptionMessage = "ArgumentException was thrown when trying to set file attributes.";
+                exceptionMessage += $"\n  File path: {item.FullName}";
+                exceptionMessage += $"\n  File exists: {item.Exists}";
+                exceptionMessage += $"\n  File attributes: {item.Attributes.ToString()}";
+                exceptionMessage += $"\n  File attributes as int: {(int)item.Attributes}";
+                exceptionMessage += $"\n  File attributes as binary string: {Convert.ToString((int)item.Attributes, 2).PadLeft(16, '0')}";
+                exceptionMessage += $"\n  Exception message: {ex.Message}";
+                throw new ArgumentException(exceptionMessage);
+            }
+        }
+
         private static void RemoveReadOnly(FileSystemInfo item)
         {
             ArgUtil.NotNull(item, nameof(item));
             if (item.Attributes.HasFlag(FileAttributes.ReadOnly))
             {
-                item.Attributes = item.Attributes & ~FileAttributes.ReadOnly;
+                FileAttributes newAttributes = item.Attributes & ~FileAttributes.ReadOnly;
+                SetAttributesWithDiagnostic(item, newAttributes);
             }
         }
 

--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -453,20 +453,25 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }
         }
 
-        private static void SetAttributesWithDiagnostic(FileSystemInfo item, FileAttributes attributes)
+        private static string GetAttributesAsBinary(FileAttributes attributes)
+        {
+            return Convert.ToString((int)attributes, 2).PadLeft(16, '0');
+        }
+
+        private static void SetAttributesWithDiagnostics(FileSystemInfo item, FileAttributes newAttributes)
         {
             try
             {
-                item.Attributes = attributes;
+                item.Attributes = newAttributes;
             }
             catch (ArgumentException ex)
             {
-                string exceptionMessage = "ArgumentException was thrown when trying to set file attributes.";
+                string exceptionMessage = "Exception was thrown when trying to set file attributes.";
                 exceptionMessage += $"\n  File path: {item.FullName}";
                 exceptionMessage += $"\n  File exists: {item.Exists}";
-                exceptionMessage += $"\n  File attributes: {item.Attributes.ToString()}";
-                exceptionMessage += $"\n  File attributes as int: {(int)item.Attributes}";
-                exceptionMessage += $"\n  File attributes as binary string: {Convert.ToString((int)item.Attributes, 2).PadLeft(16, '0')}";
+                exceptionMessage += $"\n  File attributes: {item.Attributes.ToString()} -> {newAttributes.ToString()}";
+                exceptionMessage += $"\n    As int: {(int)item.Attributes} -> {(int)newAttributes}";
+                exceptionMessage += $"\n    As binary string: {GetAttributesAsBinary(item.Attributes)} -> {GetAttributesAsBinary(newAttributes)}";
                 exceptionMessage += $"\n  Exception message: {ex.Message}";
                 throw new ArgumentException(exceptionMessage);
             }
@@ -478,7 +483,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             if (item.Attributes.HasFlag(FileAttributes.ReadOnly))
             {
                 FileAttributes newAttributes = item.Attributes & ~FileAttributes.ReadOnly;
-                SetAttributesWithDiagnostic(item, newAttributes);
+                SetAttributesWithDiagnostics(item, newAttributes);
             }
         }
 


### PR DESCRIPTION
**Description**: We have [an issue](https://github.com/microsoft/azure-pipelines-agent/issues/3307) with removing the `ReadOnly` file attribute, so we need to add more detailed information about the `ArgumentException` thrown when trying to set new attributes for a file.

**Related docs**:

* [about file attributes](https://docs.microsoft.com/en-us/dotnet/api/system.io.fileattributes?view=net-5.0)

* [about this exception](https://docs.microsoft.com/en-us/dotnet/api/system.io.file.setattributes?view=net-5.0#exceptions)

* [where the exception is thrown](https://github.com/dotnet/corefx/blob/release/3.1/src/System.IO.FileSystem/src/System/IO/FileStatus.Unix.cs#L108)

**Changelog**:

* `src/Agent.Sdk/Util/IOUtil.cs` — the `SetAttributesWithDiagnostics` and `GetAttributesAsBinary` methods are implemented