### PR TITLE
Install "lttng-ust" from EPEL repository on RHEL/CentOS 7

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -194,8 +194,8 @@ then
                     exit 1
                 fi
 
-                # install lttng-ust separately since it's not part of offical package repository
-                yum install -y wget && wget -P /etc/yum.repos.d/ https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo && rpmkeys --import https://packages.efficios.com/rhel/repo.key && yum updateinfo -y && yum install -y lttng-ust
+                # install lttng-ust separately since it's not part of official package repository
+                yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y lttng-ust
                 if [ $? -ne 0 ]
                 then                    
                     echo "'lttng-ust' installation failed with exit code '$?'"


### PR DESCRIPTION
On RHEL/CentOS 7 install the "lttng-ust" package from EPEL repository.

Installation fail from the previous repository "packages.efficios.com" because of an outdated certificate, in addition, this repository is in "extended maintenance" ans won't be updated.

EPEL is the most common third party repository on CentOS/RHEL.

Note that the  "lttng-ust" package version is older (2.4.1 instead of 2.10.7), but I tested the Azure agent successfully with it on CentOS 7.

Fix #3556
