### PR TITLE
Update PowerShellCapabilitiesProvider to work with Visual Studio 2022

### DIFF
--- a/src/Misc/layoutbin/powershell/Add-MSBuildCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-MSBuildCapabilities.ps1
@@ -37,6 +37,17 @@ if ($vs16 -and $vs16.installationPath) {
     }
 }
 
+$vs17 = Get-VisualStudio -MajorVersion 17
+if ($vs17 -and $vs17.installationPath) {
+    # Add MSBuild_17.0.
+    # End with "\" for consistency with old MSBuildToolsPath value.
+    $msbuild17 = ([System.IO.Path]::Combine($vs17.installationPath, 'MSBuild\Current\Bin')) + '\'
+    if ((Test-Leaf -LiteralPath "$($msbuild17)MSBuild.exe")) {
+        Write-Capability -Name 'MSBuild_17.0' -Value $msbuild17
+        $latest = $msbuild17
+    }
+}
+
 if ($latest) {
     Write-Capability -Name "MSBuild" -Value $latest
 }
@@ -65,6 +76,16 @@ if ($vs16 -and $vs16.installationPath) {
     if ((Test-Leaf -LiteralPath "$($msbuild16)MSBuild.exe")) {
         Write-Capability -Name 'MSBuild_16.0_x64' -Value $msbuild16
         $latest = $msbuild16
+    }
+}
+
+if ($vs17 -and $vs17.installationPath) {
+    # Add MSBuild_17.0_x64.
+    # End with "\" for consistency with old MSBuildToolsPath value.
+    $msbuild17 = ([System.IO.Path]::Combine($vs17.installationPath, 'MSBuild\Current\Bin\amd64')) + '\'
+    if ((Test-Leaf -LiteralPath "$($msbuild17)MSBuild.exe")) {
+        Write-Capability -Name 'MSBuild_17.0_x64' -Value $msbuild17
+        $latest = $msbuild17
     }
 }
 

--- a/src/Misc/layoutbin/powershell/Add-VisualStudioCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-VisualStudioCapabilities.ps1
@@ -34,6 +34,7 @@ $keyName12 = 'Software\Microsoft\VisualStudio\12.0'
 $keyName14 = 'Software\Microsoft\VisualStudio\14.0'
 $keyName15 = 'Software\Microsoft\VisualStudio\15.0'
 $keyName16 = 'Software\Microsoft\VisualStudio\16.0'
+$keyName17 = 'Software\Microsoft\VisualStudio\17.0'
 
 # Add the capabilities.
 $latestVS = $null
@@ -110,6 +111,36 @@ if ($vs16 -and $vs16.installationPath) {
     if ((Add-CapabilityFromRegistry -Name 'VisualStudio_16.0' -Hive 'LocalMachine' -View 'Registry32' -KeyName $keyName16 -ValueName 'ShellFolder' -Value ([ref]$latestVS))) {
         $null = Add-CapabilityFromRegistry -Name 'VisualStudio_IDE_16.0' -Hive 'LocalMachine' -View 'Registry32' -KeyName $keyName16 -ValueName 'InstallDir' -Value ([ref]$latestIde)
         Add-TestCapability -Name 'VSTest_16.0' -ShellPath $latestVS -Value ([ref]$latestTest)
+    }
+}
+
+$vs17 = Get-VisualStudio -MajorVersion 17
+if ($vs17 -and $vs17.installationPath) {
+    # Add VisualStudio_17.0.
+    # End with "\" for consistency with old ShellFolder values.
+    $shellFolder17 = $vs17.installationPath.TrimEnd('\'[0]) + "\"
+    Write-Capability -Name 'VisualStudio_17.0' -Value $shellFolder17
+    $latestVS = $shellFolder17
+
+    # Add VisualStudio_IDE_17.0.
+    # End with "\" for consistency with old InstallDir values.
+    $installDir17 = ([System.IO.Path]::Combine($shellFolder17, 'Common7', 'IDE')) + '\'
+    if ((Test-Container -LiteralPath $installDir17)) {
+        Write-Capability -Name 'VisualStudio_IDE_17.0' -Value $installDir17
+        $latestIde = $installDir17
+    }
+
+    # Add VSTest_17.0.
+    $testWindowDir17 = [System.IO.Path]::Combine($installDir17, 'CommonExtensions\Microsoft\TestWindow')
+    $vstestConsole17 = [System.IO.Path]::Combine($testWindowDir17, 'vstest.console.exe')
+    if ((Test-Leaf -LiteralPath $vstestConsole17)) {
+        Write-Capability -Name 'VSTest_17.0' -Value $testWindowDir17
+        $latestTest = $testWindowDir17
+    }
+} else {
+    if ((Add-CapabilityFromRegistry -Name 'VisualStudio_17.0' -Hive 'LocalMachine' -View 'Registry32' -KeyName $keyName17 -ValueName 'ShellFolder' -Value ([ref]$latestVS))) {
+        $null = Add-CapabilityFromRegistry -Name 'VisualStudio_IDE_17.0' -Hive 'LocalMachine' -View 'Registry32' -KeyName $keyName17 -ValueName 'InstallDir' -Value ([ref]$latestIde)
+        Add-TestCapability -Name 'VSTest_17.0' -ShellPath $latestVS -Value ([ref]$latestTest)
     }
 }
 

--- a/src/Misc/layoutbin/powershell/CapabilityHelpers/VisualStudioFunctions.ps1
+++ b/src/Misc/layoutbin/powershell/CapabilityHelpers/VisualStudioFunctions.ps1
@@ -2,18 +2,18 @@ function Get-VisualStudio {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet(15, 16)]
+        [ValidateSet(15, 16, 17)]
         [int]$MajorVersion)
 
     try {
-        # Query for the latest 15.*/16.* version.
+        # Query for the latest 15.*/16.*/17.* version.
         #
-        # Note, the capability is registered as VisualStudio_15.0/VisualStudio_16.0, however the actual
+        # Note, the capability is registered as VisualStudio_15.0/VisualStudio_16.0/VisualStudio_17.0 however the actual
         # version may something like 15.2/16.2.
         Write-Host "Getting latest Visual Studio $MajorVersion setup instance."
         $output = New-Object System.Text.StringBuilder
-        Write-Host "& $PSScriptRoot\..\..\..\externals\vswhere\vswhere.exe -version '[$MajorVersion.0,$($MajorVersion+1).0)' -latest -format json"
-        & $PSScriptRoot\..\..\..\externals\vswhere\vswhere.exe -version "[$MajorVersion.0,$($MajorVersion+1).0)" -latest -format json 2>&1 |
+        Write-Host "& $PSScriptRoot\..\..\..\externals\vswhere\vswhere.exe -version '[$MajorVersion.0,$($MajorVersion+1).0)' -latest -prerelease -format json"
+        & $PSScriptRoot\..\..\..\externals\vswhere\vswhere.exe -version "[$MajorVersion.0,$($MajorVersion+1).0)" -latest -prerelease -format json 2>&1 |
             ForEach-Object {
                 if ($_ -is [System.Management.Automation.ErrorRecord]) {
                     Write-Host "STDERR: $($_.Exception.Message)"


### PR DESCRIPTION
Description of change:
- Added 17 version to validation set in Get-VisualStudio function for MajorVersion parameter.
- Added `-prerelease` flag to call of vswhere.exe to be able to include preview versions of VisualStudio
- Added blocks to Add-MSBuildCapabilities.ps1 and Add-VisualStudioCapabilities.ps1 to check installed VS 17

Manually tested with local self-hosted agent.