### PR TITLE
Bump recommended Git version, fix prune-tags for older versions

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -122,8 +122,8 @@ namespace Agent.Plugins.Repository
             Version minRequiredGitVersion = new Version(2, 0);
             EnsureGitVersion(minRequiredGitVersion, throwOnNotMatch: true);
 
-            // suggest user upgrade to 2.9 for better git experience
-            Version recommendGitVersion = new Version(2, 9);
+            // suggest user upgrade to 2.17 for better git experience
+            Version recommendGitVersion = new Version(2, 17);
             if (!EnsureGitVersion(recommendGitVersion, throwOnNotMatch: false))
             {
                 context.Output(StringUtil.Loc("UpgradeToLatestGit", recommendGitVersion, gitVersion));
@@ -175,7 +175,7 @@ namespace Agent.Plugins.Repository
             string progress = reducedOutput ? string.Empty : "--progress";
 
             // insert prune-tags if knob is false to sync tags with the remote
-            string pruneTags = AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
+            string pruneTags = !EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) ? string.Empty : AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
 
             // If shallow fetch add --depth arg
             // If the local repository is shallowed but there is no fetch depth provide for this build,

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -175,7 +175,11 @@ namespace Agent.Plugins.Repository
             string progress = reducedOutput ? string.Empty : "--progress";
 
             // insert prune-tags if knob is false to sync tags with the remote
-            string pruneTags = !EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) ? string.Empty : AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
+            string pruneTags = string.Empty;
+            if (EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) && !AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean())
+            {
+                pruneTags = "--prune-tags";
+            }
 
             // If shallow fetch add --depth arg
             // If the local repository is shallowed but there is no fetch depth provide for this build,

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 refSpec = refSpec.Where(r => !string.IsNullOrEmpty(r)).ToList();
             }
 
-            // insert prune-tags if knob is false to sync tags with the remote and Git version is above 2.17
+            // insert prune-tags if DisableFetchPruneTags knob is false and Git version is above 2.17
             string pruneTags = !EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) ? string.Empty : AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
 
             // If shallow fetch add --depth arg

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -233,8 +233,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
 
             // insert prune-tags if DisableFetchPruneTags knob is false and Git version is above 2.17
-            string pruneTags = !EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) ? string.Empty : AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
-
+            string pruneTags = string.Empty;
+            if (EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) && !AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean())
+            {
+                pruneTags = "--prune-tags";
+            }
+            
             // If shallow fetch add --depth arg
             // If the local repository is shallowed but there is no fetch depth provide for this build,
             // add --unshallow to convert the shallow repository to a complete repository

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -198,8 +198,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             Version minRequiredGitVersion = new Version(2, 0);
             EnsureGitVersion(minRequiredGitVersion, throwOnNotMatch: true);
 
-            // suggest user upgrade to 2.9 for better git experience
-            Version recommendGitVersion = new Version(2, 9);
+            // suggest user upgrade to 2.17 for better git experience
+            Version recommendGitVersion = new Version(2, 17);
             if (!EnsureGitVersion(recommendGitVersion, throwOnNotMatch: false))
             {
                 context.Output(StringUtil.Loc("UpgradeToLatestGit", recommendGitVersion, _gitVersion));
@@ -232,8 +232,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 refSpec = refSpec.Where(r => !string.IsNullOrEmpty(r)).ToList();
             }
 
-            // insert prune-tags if knob is false to sync tags with the remote
-            string pruneTags = AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
+            // insert prune-tags if knob is false to sync tags with the remote and Git version is above 2.17
+            string pruneTags = !EnsureGitVersion(new Version(2, 17), throwOnNotMatch: false) ? string.Empty : AgentKnobs.DisableFetchPruneTags.GetValue(context).AsBoolean() ? string.Empty : "--prune-tags";
 
             // If shallow fetch add --depth arg
             // If the local repository is shallowed but there is no fetch depth provide for this build,


### PR DESCRIPTION
Bump recommended Git version notification to 2.17.*
Fix --prune-tags for versions older than 2.17, since it's not supported
Related [issue](https://github.com/microsoft/azure-pipelines-agent/issues/3572)