### PR TITLE
Try to delete the workspace instead of fail

### DIFF
--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -253,7 +253,6 @@ namespace Agent.Plugins.Repository
                 tfWorkspaces = await tf.WorkspacesAsync(matchWorkspaceNameOnAnyComputer: true);
                 foreach (ITfsVCWorkspace tfWorkspace in tfWorkspaces ?? new ITfsVCWorkspace[0])
                 {
-
                     await tf.TryWorkspaceDeleteAsync(tfWorkspace);
                 }
 

--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -253,7 +253,8 @@ namespace Agent.Plugins.Repository
                 tfWorkspaces = await tf.WorkspacesAsync(matchWorkspaceNameOnAnyComputer: true);
                 foreach (ITfsVCWorkspace tfWorkspace in tfWorkspaces ?? new ITfsVCWorkspace[0])
                 {
-                    await tf.WorkspaceDeleteAsync(tfWorkspace);
+
+                    await tf.TryWorkspaceDeleteAsync(tfWorkspace);
                 }
 
                 // Recreate the sources directory.


### PR DESCRIPTION
Creation of the new workspace will fail anyway if it still exists.
But 2 agents may delete the same workspace at the exact same time.

Fixes: #3588