### PR TITLE
Added knob to disable Node 6 deprecation warnings

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -272,7 +272,9 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("DISABLE_OVERRIDE_TFVC_BUILD_DIRECTORY"),
             new EnvironmentKnobSource("DISABLE_OVERRIDE_TFVC_BUILD_DIRECTORY"),
             new BuiltInDefaultKnobSource("false"));
-
+        /**
+         * We need to remove this knob - once Node 6 handler is dropped
+         */
         public static readonly Knob DisableNode6DeprecationWarning = new Knob(
             nameof(DisableNode6DeprecationWarning),
             "Disables Node 6 deprecation warnings.",

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -272,5 +272,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("DISABLE_OVERRIDE_TFVC_BUILD_DIRECTORY"),
             new EnvironmentKnobSource("DISABLE_OVERRIDE_TFVC_BUILD_DIRECTORY"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob DisableNode6DeprecationWarning = new Knob(
+            nameof(DisableNode6DeprecationWarning),
+            "Disables Node 6 deprecation warnings.",
+            new RuntimeKnobSource("DISABLE_NODE6_DEPRECATION_WARNING"),
+            new EnvironmentKnobSource("DISABLE_NODE6_DEPRECATION_WARNING"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/Handlers/HandlerFactory.cs
+++ b/src/Agent.Worker/Handlers/HandlerFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (data is BaseNodeHandlerData)
             {
                 // Node 6
-                if (data is NodeHandlerData && AgentKnobs.DisableNode6DeprecationWarning.GetValue(executionContext).AsBoolean()) {       
+                if (data is NodeHandlerData && !AgentKnobs.DisableNode6DeprecationWarning.GetValue(executionContext).AsBoolean()) {       
                     executionContext.Warning(StringUtil.Loc("DeprecatedNode6"));
                 }
                 // Node 6 and 10.

--- a/src/Agent.Worker/Handlers/HandlerFactory.cs
+++ b/src/Agent.Worker/Handlers/HandlerFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Agent.Sdk.Knob;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
@@ -56,7 +57,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (data is BaseNodeHandlerData)
             {
                 // Node 6
-                if (data is NodeHandlerData) {       
+                if (data is NodeHandlerData && AgentKnobs.DisableNode6DeprecationWarning.GetValue(executionContext).AsBoolean()) {       
                     executionContext.Warning(StringUtil.Loc("DeprecatedNode6"));
                 }
                 // Node 6 and 10.

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -254,7 +254,7 @@
   "DeploymentMachineWithSameNameAlreadyExistInDeploymentGroup": "DeploymentGroup {0} already contains a machine with name {1}.",
   "DeploymentPoolName": "Deployment Pool name",
   "DeploymentPoolNotFound": "Deployment pool not found: '{0}'",
-  "DeprecatedNode6": "This task uses Node 6 execution handler, which will be removed March 31st 2022. If you are the developer of the task - please consider the migration guideline to Node 10 handler - https://aka.ms/migrateTaskNode10. If you are the user - feel free to reach out to the owners of this task to proceed on migration.",
+  "DeprecatedNode6": "This task uses Node 6 execution handler, which will be removed March 31st 2022. If you are the developer of the task - please consider the migration guideline to Node 10 handler - https://aka.ms/migrateTaskNode10 (check this page also if you would like to disable Node 6 deprecation warnings). If you are the user - feel free to reach out to the owners of this task to proceed on migration.",
   "DirectoryHierarchyUnauthorized": "Permission to read the directory contents is required for '{0}' and each directory up the hierarchy. {1}",
   "DirectoryIsEmptyForArtifact": "Directory '{0}' is empty. Nothing will be added to build artifact '{1}'.",
   "DirectoryNotFound": "Directory not found: '{0}'",


### PR DESCRIPTION
Added knob to disable Node 6 deprecation warnings. 
Testing: checked, works as expected - warnings are being disabled if knob is turned on.