### PR TITLE
Sync send timeout of dedup client to VssConnection timeout settings

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/DedupManifestArtifactClientFactory.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/DedupManifestArtifactClientFactory.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
                 {
                     ArtifactHttpClientFactory factory = new ArtifactHttpClientFactory(
                         connection.Credentials,
-                        TimeSpan.FromSeconds(50),
+                        connection.Settings.SendTimeout,
                         tracer,
                         cancellationToken);
 
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
                 {
                     ArtifactHttpClientFactory factory = new ArtifactHttpClientFactory(
                         connection.Credentials,
-                        TimeSpan.FromSeconds(50),
+                        connection.Settings.SendTimeout, // copy timeout settings from connection provided by agent
                         tracer,
                         cancellationToken);
 


### PR DESCRIPTION
Currently send timeout for artifact client is hard coded to 50 seconds in the agent.  Instead of hard coding copy the timeout from the VssConnection in the plugin context so that it can be manipulated by AgentKnobs.