### PR TITLE
Issue 3638 - Fixed the change source directory and workspace if a similar tracking config is existing

### DIFF
--- a/src/Agent.Worker/Build/TrackingManager.cs
+++ b/src/Agent.Worker/Build/TrackingManager.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             TrackingConfig mergedConfig = previousConfig.Clone();
 
             // Update the sources directory if we don't have one
-            if (!string.IsNullOrEmpty(mergedConfig.SourcesDirectory))
+            if (string.IsNullOrEmpty(mergedConfig.SourcesDirectory))
             {
                 mergedConfig.SourcesDirectory = newConfig.SourcesDirectory;
             }


### PR DESCRIPTION
I've fixed the change source directory and workspace if a similar tracking config is existing. The problem occurs after certain actions, for example: 
1) List of repositories of the pipeline is changed;
2) The pipeline created a new workspace when the pipeline run;
3) Reverted list of repositories to the original (before the first point);
The pipeline will incorrectly use workspace is created earlier (source directory will be created in the new workspace).

Seems like this bug exists in this component from its creation, but due to the bug in Tracking Manager (the bug that was fixed by this [PR](https://github.com/microsoft/azure-pipelines-agent/pull/3586)) current issue was hidden.

Related issue: [#3638](https://github.com/microsoft/azure-pipelines-agent/issues/3638)

Checked cases:
- Case from the example above;
- Cases with initializing new workspace in the pipeline:
    - The pipeline hasn't other workspaces;
    - The pipeline has other workspaces (select new list of repositories unused before);
- Case with using existing workspace in the pipeline (use earlier config of a pipeline);