### PR TITLE
Add additional clean up command to delete all extraheader headers or warm

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -442,14 +442,14 @@ namespace Agent.Plugins.Repository
         }
 
         // git config --get-regexp <key>
-        public async Task<bool> GitConfigRegexExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey)
+        public async Task<bool> GitConfigRegexExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKeyPattern)
         {
-            // git config --get-all {configKey} will return 0 and print the value if the config exist.
-            context.Debug($"Checking git config {configKey} exist or not");
+            // git config --get-regexp {configKeyPattern} will return 0 and print the value if the config exist.
+            context.Debug($"Checking git config {configKeyPattern} exist or not");
 
             // ignore any outputs by redirect them into a string list, since the output might contains secrets.
             List<string> outputStrings = new List<string>();
-            int exitcode = await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--get-regexp {configKey}"), outputStrings);
+            int exitcode = await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--get-regexp {configKeyPattern}"), outputStrings);
 
             return exitcode == 0;
         }

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -441,7 +441,14 @@ namespace Agent.Plugins.Repository
             return exitcode == 0;
         }
 
-        // git config --get-regexp <key>
+        /// <summary>
+        /// Verify if git config contains config key with some regex pattern
+        /// git config --get-regexp <configKeyPattern>
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="repositoryPath"></param>
+        /// <param name="configKeyPattern"></param>
+        /// <returns></returns>
         public async Task<bool> GitConfigRegexExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKeyPattern)
         {
             // git config --get-regexp {configKeyPattern} will return 0 and print the value if the config exist.

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -445,10 +445,6 @@ namespace Agent.Plugins.Repository
         /// Verify if git config contains config key with some regex pattern
         /// git config --get-regexp <configKeyPattern>
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="repositoryPath"></param>
-        /// <param name="configKeyPattern"></param>
-        /// <returns></returns>
         public async Task<bool> GitConfigRegexExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKeyPattern)
         {
             // git config --get-regexp {configKeyPattern} will return 0 and print the value if the config exist.

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -441,6 +441,19 @@ namespace Agent.Plugins.Repository
             return exitcode == 0;
         }
 
+        // git config --get-regexp <key>
+        public async Task<bool> GitConfigRegexExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey)
+        {
+            // git config --get-all {configKey} will return 0 and print the value if the config exist.
+            context.Debug($"Checking git config {configKey} exist or not");
+
+            // ignore any outputs by redirect them into a string list, since the output might contains secrets.
+            List<string> outputStrings = new List<string>();
+            int exitcode = await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--get-regexp {configKey}"), outputStrings);
+
+            return exitcode == 0;
+        }
+
         // git config --unset-all <key>
         public async Task<int> GitConfigUnset(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey)
         {

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -654,8 +654,13 @@ namespace Agent.Plugins.Repository
             // always remove any possible left extraheader setting from git config.
             if (await gitCommandManager.GitConfigExist(executionContext, targetPath, $"http.{repositoryUrl.AbsoluteUri}.extraheader"))
             {
-                executionContext.Debug("Remove any extraheader setting from git config.");
+                executionContext.Debug($"Remove http.{repositoryUrl.AbsoluteUri}.extraheader setting from git config.");
                 await RemoveGitConfig(executionContext, gitCommandManager, targetPath, $"http.{repositoryUrl.AbsoluteUri}.extraheader", string.Empty);
+            }
+            if (await gitCommandManager.GitConfigExist(executionContext, targetPath, $"http.extraheader"))
+            {
+                executionContext.Debug("Remove http.extraheader setting from git config.");
+                await RemoveGitConfig(executionContext, gitCommandManager, targetPath, $"http.extraheader", string.Empty);
             }
 
             // always remove any possible left proxy setting from git config, the proxy setting may contains credential

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -662,6 +662,10 @@ namespace Agent.Plugins.Repository
                 executionContext.Debug("Remove http.extraheader setting from git config.");
                 await RemoveGitConfig(executionContext, gitCommandManager, targetPath, $"http.extraheader", string.Empty);
             }
+            if (await gitCommandManager.GitConfigRegexExist(executionContext, targetPath, ".*extraheader"))
+            {
+                executionContext.Warning($"Git config still contains extraheader keys. It may cause errors.  To remove the credential, execute \"git config --unset-all key-name\" from the repository root");
+            }
 
             // always remove any possible left proxy setting from git config, the proxy setting may contains credential
             if (await gitCommandManager.GitConfigExist(executionContext, targetPath, $"http.proxy"))


### PR DESCRIPTION
Sometimes checkout task may fail with the following message:
```
fatal: unable to access 'https://.../': The requested URL returned error: 400
Git fetch failed with exit code: 128
```
The git configuration change caused the duplicate authentication header which in turn resulted in the Http 400 error across pipeline.
I was able to reproduce this issue on my local agent by setting "`http.extraheader`" key in local git config with invalid value. Then I ran the build and got the same error message. This was caused by the fact that we had checked and removed only "`http.{repositoryUrl.AbsoluteUri}.extraheader`" and had not paid attention to other formats of the key.

To fix it:
- Add removal of `http.extraheader` from git config.
- Add additional verification on left "*.extraheader" keys after removal

Tested this change manually:
1. Run just common build on self-hosted agent - worked fine
2. Run build on self-hosted agent with pre-set git config extraheader keys - build worked as expected, keys were removed before `checkout`