### PR TITLE
Porting logic of handling negative patterns for DownloadBuildArtifacts task

### DIFF
--- a/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Agent.Sdk;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.BlobStore.Common;
+using Microsoft.VisualStudio.Services.Content.Common.Tracing;
+using Microsoft.VisualStudio.Services.FileContainer;
+using Microsoft.VisualStudio.Services.WebApi;
+using Minimatch;
+
+namespace Agent.Plugins
+{
+    class ArtifactItemFilters
+    {
+        private readonly VssConnection connection;
+        private readonly IAppTraceSource tracer;
+
+        public ArtifactItemFilters(VssConnection connection, IAppTraceSource tracer)
+        {
+            this.tracer = tracer;
+            this.connection = connection;
+        }
+
+        // Collects hashtable with items in accordance with patterns
+        public dynamic GetMapToFilterItems(List<string> paths, string[] minimatchPatterns, Options customMinimatchOptions)
+        {
+            // Hashtable to keep track of matches.
+            Hashtable map = new Hashtable();
+
+            foreach (string minimatchPattern in minimatchPatterns)
+            {
+                tracer.Info($"Pattern: {minimatchPattern}");
+
+                // Trim and skip empty.
+                string currentPattern = minimatchPattern.Trim();
+                if (String.IsNullOrEmpty(currentPattern))
+                {
+                    tracer.Info($"Skipping empty pattern.");
+                    continue;
+                }
+
+                // Clone match options.
+                Options matchOptions = CloneMiniMatchOptions(customMinimatchOptions);
+
+                // Skip comments.
+                if (!matchOptions.NoComment && currentPattern.StartsWith('#'))
+                {
+                    tracer.Info($"Skipping comment.");
+                    continue;
+                }
+
+                // Set NoComment. Brace expansion could result in a leading '#'.
+                matchOptions.NoComment = true;
+
+                // Determine whether pattern is include or exclude.
+                int negateCount = 0;
+                if (!matchOptions.NoNegate)
+                {
+                    while (negateCount < currentPattern.Length && currentPattern[negateCount] == '!')
+                    {
+                        negateCount++;
+                    }
+
+                    currentPattern = currentPattern.Substring(negateCount);
+                    if (negateCount > 0)
+                    {
+                        tracer.Info($"Trimmed leading '!'. Pattern: '{currentPattern}'");
+                    }
+                }
+
+                bool isIncludePattern = negateCount == 0 ||
+                    (negateCount % 2 == 0 && !matchOptions.FlipNegate) ||
+                    (negateCount % 2 == 1 && matchOptions.FlipNegate);
+
+                // Set NoNegate. Brace expansion could result in a leading '!'.
+                matchOptions.NoNegate = true;
+                matchOptions.FlipNegate = false;
+
+                // Trim and skip empty.
+                currentPattern = currentPattern.Trim();
+                if (String.IsNullOrEmpty(currentPattern))
+                {
+                    tracer.Info($"Skipping empty pattern.");
+                    continue;
+                }
+
+                // Expand braces - required to accurately interpret findPath.
+                string[] expandedPatterns;
+                string preExpandedPattern = currentPattern;
+                if (matchOptions.NoBrace)
+                {
+                    expandedPatterns = new string[] { currentPattern };
+                }
+                else
+                {
+                    expandedPatterns = ExpandBraces(currentPattern, matchOptions);
+                }
+
+                // Set NoBrace.
+                matchOptions.NoBrace = true;
+
+                foreach (string expandedPattern in expandedPatterns)
+                {
+                    if (expandedPattern != preExpandedPattern)
+                    {
+                        tracer.Info($"Pattern: {expandedPattern}");
+                    }
+
+                    // Trim and skip empty.
+                    currentPattern = expandedPattern.Trim();
+                    if (String.IsNullOrEmpty(currentPattern))
+                    {
+                        tracer.Info($"Skipping empty pattern.");
+                        continue;
+                    }
+
+                    string[] currentPatterns = new string[] { currentPattern };
+                    IEnumerable<Func<string, bool>> minimatcherFuncs = MinimatchHelper.GetMinimatchFuncs(
+                        currentPatterns,
+                        tracer,
+                        matchOptions
+                    );
+
+                    UpdatePatternsMap(isIncludePattern, paths, minimatcherFuncs, ref map);
+                }
+            }
+
+            return map;
+        }
+
+        private string[] ExpandBraces(string pattern, Options matchOptions)
+        {
+            // Convert slashes on Windows before calling braceExpand(). Unfortunately this means braces cannot
+            // be escaped on Windows, this limitation is consistent with current limitations of minimatch (3.0.3).
+            tracer.Info($"Expanding braces.");
+            string convertedPattern = pattern.Replace("\\", "/");
+            return Minimatcher.BraceExpand(convertedPattern, matchOptions).ToArray();
+        }
+
+        private void UpdatePatternsMap(bool isIncludePattern, List<string> paths, IEnumerable<Func<string, bool>> minimatcherFuncs, ref Hashtable map)
+        {
+            if (isIncludePattern)
+            {
+                // Apply the pattern.
+                tracer.Info($"Applying include pattern against original list.");
+                List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
+
+                // Union the results.
+                int matchCount = 0;
+                foreach (string matchResult in matchResults)
+                {
+                    matchCount++;
+                    map[matchResult] = Boolean.TrueString;
+                }
+
+                tracer.Info($"{matchCount} matches");
+            }
+            else
+            {
+                // Apply the pattern.
+                tracer.Info($"Applying exclude pattern against original list.");
+                List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
+
+                // Subtract the results.
+                int matchCount = 0;
+                foreach (string matchResult in matchResults)
+                {
+                    matchCount++;
+                    map.Remove(matchResult);
+                }
+
+                tracer.Info($"{matchCount} matches");
+            }
+        }
+
+        // Returns list of FileContainerItem items required to be downloaded. Used by FileContainerProvider.
+        public List<FileContainerItem> ApplyPatternsMapToContainerItems(List<FileContainerItem> items, Hashtable map)
+        {
+            List<FileContainerItem> resultItems = new List<FileContainerItem>();
+            foreach (FileContainerItem item in items)
+            {
+                if (Convert.ToBoolean(map[item.Path]))
+                {
+                    resultItems.Add(item);
+                }
+            }
+
+            return resultItems;
+        }
+
+        private List<string> FilterItemsByPatterns(List<string> paths, IEnumerable<Func<string, bool>> minimatchFuncs)
+        {
+            List<string> filteredItems = new List<string>();
+            foreach (string path in paths)
+            {
+                if (minimatchFuncs.Any(match => match(path)))
+                {
+                    filteredItems.Add(path);
+                }
+            }
+
+            return filteredItems;
+        }
+
+        // Clones MiniMatch options into separate object
+        private Options CloneMiniMatchOptions(Options currentMiniMatchOptions)
+        {
+            Options clonedMiniMatchOptions = new Options()
+            {
+                Dot = currentMiniMatchOptions.Dot,
+                FlipNegate = currentMiniMatchOptions.FlipNegate,
+                MatchBase = currentMiniMatchOptions.MatchBase,
+                NoBrace = currentMiniMatchOptions.NoBrace,
+                NoCase = currentMiniMatchOptions.NoCase,
+                NoComment = currentMiniMatchOptions.NoComment,
+                NoExt = currentMiniMatchOptions.NoExt,
+                NoGlobStar = currentMiniMatchOptions.NoGlobStar,
+                NoNegate = currentMiniMatchOptions.NoNegate,
+                NoNull = currentMiniMatchOptions.NoNull,
+                IgnoreCase = currentMiniMatchOptions.IgnoreCase,
+                AllowWindowsPaths = PlatformUtil.RunningOnWindows
+            };
+            return clonedMiniMatchOptions;
+        }
+    }
+}

--- a/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
@@ -26,7 +26,13 @@ namespace Agent.Plugins
             this.connection = connection;
         }
 
-        // Collects hashtable with items in accordance with patterns
+        /// <summary>
+        /// Collects hashtable with items in accordance with patterns
+        /// </summary>
+        /// <param name="paths">List of relative paths for items detected in artifact. The relative paths start from name of artifact.</param>
+        /// <param name="minimatchPatterns">Array of patterns used to filter items in artifact</param>
+        /// <param name="customMinimatchOptions">Download parameters from minimatcherFuncs</param>
+        /// <returns></returns>
         public dynamic GetMapToFilterItems(List<string> paths, string[] minimatchPatterns, Options customMinimatchOptions)
         {
             // Hashtable to keep track of matches.
@@ -133,6 +139,12 @@ namespace Agent.Plugins
             return map;
         }
 
+        /// <summary>
+        /// Expands braces in patterns if they are exist
+        /// </summary>
+        /// <param name="pattern">String of pattern</param>
+        /// <param name="matchOptions">Download parameters from minimatcherFuncs</param>
+        /// <returns></returns>
         private string[] ExpandBraces(string pattern, Options matchOptions)
         {
             // Convert slashes on Windows before calling braceExpand(). Unfortunately this means braces cannot
@@ -142,6 +154,13 @@ namespace Agent.Plugins
             return Minimatcher.BraceExpand(convertedPattern, matchOptions).ToArray();
         }
 
+        /// <summary>
+        /// Adds or removes items from map in accordance with patterns
+        /// </summary>
+        /// <param name="isIncludePattern">Defines if specific pattern possitive or negative</param>
+        /// <param name="paths">List of relative paths for items detected in artifact. The relative paths start from name of artifact.</param>
+        /// <param name="minimatcherFuncs">Functions of MinimatchHelper</param>
+        /// <param name="map">Map for items in artifact collected in accordance with patterns</param>
         private void UpdatePatternsMap(bool isIncludePattern, List<string> paths, IEnumerable<Func<string, bool>> minimatcherFuncs, ref Hashtable map)
         {
             string patternType = isIncludePattern ? "include" : "exclude";
@@ -168,7 +187,12 @@ namespace Agent.Plugins
             tracer.Info($"{matchCount} matches");
         }
 
-        // Returns list of FileContainerItem items required to be downloaded. Used by FileContainerProvider.
+        /// <summary>
+        /// Returns list of FileContainerItem items required to be downloaded. Used by FileContainerProvider.
+        /// </summary>
+        /// <param name="items">List of items detected in artifact</param>
+        /// <param name="map">Map for items in artifact collected in accordance with patterns</param>
+        /// <returns></returns>
         public List<FileContainerItem> ApplyPatternsMapToContainerItems(List<FileContainerItem> items, Hashtable map)
         {
             List<FileContainerItem> resultItems = new List<FileContainerItem>();
@@ -183,6 +207,12 @@ namespace Agent.Plugins
             return resultItems;
         }
 
+        /// <summary>
+        /// Collects list of items filtered by minimather in accordance with pattern
+        /// </summary>
+        /// <param name="paths">List of relative paths for items detected in artifact. The relative paths start from name of artifact.</param>
+        /// <param name="minimatchFuncs">Functions of MinimatchHelper</param>
+        /// <returns></returns>
         private List<string> FilterItemsByPatterns(List<string> paths, IEnumerable<Func<string, bool>> minimatchFuncs)
         {
             List<string> filteredItems = new List<string>();
@@ -198,6 +228,12 @@ namespace Agent.Plugins
         }
 
         // Clones MiniMatch options into separate object
+
+        /// <summary>
+        /// Creates copy of provided minimatcher options
+        /// </summary>
+        /// <param name="currentMiniMatchOptions">Existed minimatcher options for copying</param>
+        /// <returns></returns>
         private Options CloneMiniMatchOptions(Options currentMiniMatchOptions)
         {
             Options clonedMiniMatchOptions = new Options()

--- a/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
@@ -160,7 +160,7 @@ namespace Agent.Plugins
         /// <param name="isIncludePattern">Defines if specific pattern possitive or negative</param>
         /// <param name="paths">List of relative paths for items detected in artifact. The relative paths start from name of artifact.</param>
         /// <param name="minimatcherFuncs">Functions of MinimatchHelper</param>
-        /// <param name="map">Map for items in artifact collected in accordance with patterns</param>
+        /// <param name="map">Map for items in artifact collected in accordance with patterns. The map is hashtable, key is string path to item in artifact, value is bool true for all items. Item with path from the hashtable is considered as required to be in list after filtering.</param>
         private void UpdatePatternsMap(bool isIncludePattern, List<string> paths, IEnumerable<Func<string, bool>> minimatcherFuncs, ref Hashtable map)
         {
             string patternType = isIncludePattern ? "include" : "exclude";
@@ -191,7 +191,7 @@ namespace Agent.Plugins
         /// Returns list of FileContainerItem items required to be downloaded. Used by FileContainerProvider.
         /// </summary>
         /// <param name="items">List of items detected in artifact</param>
-        /// <param name="map">Map for items in artifact collected in accordance with patterns</param>
+        /// <param name="map">Map for items in artifact collected in accordance with patterns. The map is hashtable, key is string path to item in artifact, value is bool true for all items. Item with path from the hashtable is considered as required to be in list after filtering.</param>
         /// <returns></returns>
         public List<FileContainerItem> ApplyPatternsMapToContainerItems(List<FileContainerItem> items, Hashtable map)
         {

--- a/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
@@ -144,38 +144,28 @@ namespace Agent.Plugins
 
         private void UpdatePatternsMap(bool isIncludePattern, List<string> paths, IEnumerable<Func<string, bool>> minimatcherFuncs, ref Hashtable map)
         {
-            if (isIncludePattern)
-            {
-                // Apply the pattern.
-                tracer.Info($"Applying include pattern against original list.");
-                List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
+            string patternType = isIncludePattern ? "include" : "exclude";
+            tracer.Info($"Applying { patternType } pattern against original list.");
 
-                // Union the results.
-                int matchCount = 0;
-                foreach (string matchResult in matchResults)
+            List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
+            int matchCount = 0;
+
+            foreach (string matchResult in matchResults)
+            {
+                matchCount++;
+                if (isIncludePattern)
                 {
-                    matchCount++;
+                    // Union the results.
                     map[matchResult] = Boolean.TrueString;
                 }
-
-                tracer.Info($"{matchCount} matches");
-            }
-            else
-            {
-                // Apply the pattern.
-                tracer.Info($"Applying exclude pattern against original list.");
-                List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
-
-                // Subtract the results.
-                int matchCount = 0;
-                foreach (string matchResult in matchResults)
+                else
                 {
-                    matchCount++;
+                    // Subtract the results.
                     map.Remove(matchResult);
                 }
-
-                tracer.Info($"{matchCount} matches");
             }
+
+            tracer.Info($"{matchCount} matches");
         }
 
         // Returns list of FileContainerItem items required to be downloaded. Used by FileContainerProvider.


### PR DESCRIPTION
Ported logic of pre-handling minimatch patterns from azure-pipelines-task-lib ([PS version](https://github.com/microsoft/azure-pipelines-task-lib/blob/21dac986b4c7478eb2ed8ffbd60e4fad62904438/powershell/VstsTaskSdk/FindFunctions.ps1#L306) / [TS version](https://github.com/microsoft/azure-pipelines-task-lib/blob/0bbb9f8f133f8052aa1cb602c2408470c1fe4afe/node/task.ts#L1406)). 
The logic allows to handle negative minimatch patterns correctly.
Also reporting of excluded items was moved from GetFilteredItems to GetArtifactItems.

Checked cases:
- download all (like `**`)
- download all (like `**`) except 1or 2 file (like `!**/file.1.nupkg`)
- download all (like `**`) except group of files (like `!**/file.*.nupkg`)
- download all (like `**`) except directory (like `!**/folder1/**`)
- download directory (like `**/folder1/**`) except 1 file (like `!**/folder1/file.1.nupkg`)
- download group files (like `**/file.*.nupkg`) except 1 file (like `!**/file.1.nupkg`)
- download all (like `**`) except directory (like `!**/folder1/**`) but with downloading 1 file from the directory (like `!!**/folder1/file.1.nupkg`)
- using of whitespaces in start and end of pattern
- using of sharp (`#`) in pattern
- using of empty pattern
- using of pattern without asterisks (full path to file in artifact)

Checklist:
- There’s no risky dependency updates
   - Corrected function is used by 2 tasks. And both these tasks work correctly with the changes.

- Changes has been tested
   - Yes. The changes are tested by 22 cases (2 affected tasks, 11 cases for each task) by build in prepared pipeline. Also test with 7 cases was added in these PR to cover corrected function.

- Enough test coverage for changes, and current test coverage for task doesn't look poor
   - Yes, test with 7 cases was added in these PR to cover corrected function. Most cases of using the function are covered.

- We understand how tasks is working, how changes affect task behavior
   - Yes. The changes allow to collect list of files which should be downloaded from artifact. Previously all files are downloaded.

- There is no breaking changes
   - No breaking changes.

- There is no any other concerns
   - No concerns. Corrected function is used by 2 tasks. And both these tasks work correctly with the changes.

- I have not discovered any new uncovered test/use cases
   - Yes, I don't uncovered test/use cases for corrected function.