### PR TITLE
Added tests for ported logic of handling negative patterns for DownloadBuildArtifacts task

### DIFF
--- a/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Agent.Sdk;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.BlobStore.Common;
+using Microsoft.VisualStudio.Services.Content.Common.Tracing;
+using Microsoft.VisualStudio.Services.FileContainer;
+using Microsoft.VisualStudio.Services.WebApi;
+using Minimatch;
+
+namespace Agent.Plugins
+{
+    class ArtifactItemFilters
+    {
+        private readonly VssConnection connection;
+        private readonly IAppTraceSource tracer;
+
+        public ArtifactItemFilters(VssConnection connection, IAppTraceSource tracer)
+        {
+            this.tracer = tracer;
+            this.connection = connection;
+        }
+
+        // Collects hashtable with items in accordance with patterns
+        public dynamic GetMapToFilterItems(List<string> paths, string[] minimatchPatterns, Options customMinimatchOptions)
+        {
+            // Hashtable to keep track of matches.
+            Hashtable map = new Hashtable();
+
+            foreach (string minimatchPattern in minimatchPatterns)
+            {
+                tracer.Info($"Pattern: {minimatchPattern}");
+
+                // Trim and skip empty.
+                string currentPattern = minimatchPattern.Trim();
+                if (String.IsNullOrEmpty(currentPattern))
+                {
+                    tracer.Info($"Skipping empty pattern.");
+                    continue;
+                }
+
+                // Clone match options.
+                Options matchOptions = CloneMiniMatchOptions(customMinimatchOptions);
+
+                // Skip comments.
+                if (!matchOptions.NoComment && currentPattern.StartsWith('#'))
+                {
+                    tracer.Info($"Skipping comment.");
+                    continue;
+                }
+
+                // Set NoComment. Brace expansion could result in a leading '#'.
+                matchOptions.NoComment = true;
+
+                // Determine whether pattern is include or exclude.
+                int negateCount = 0;
+                if (!matchOptions.NoNegate)
+                {
+                    while (negateCount < currentPattern.Length && currentPattern[negateCount] == '!')
+                    {
+                        negateCount++;
+                    }
+
+                    currentPattern = currentPattern.Substring(negateCount);
+                    if (negateCount > 0)
+                    {
+                        tracer.Info($"Trimmed leading '!'. Pattern: '{currentPattern}'");
+                    }
+                }
+
+                bool isIncludePattern = negateCount == 0 ||
+                    (negateCount % 2 == 0 && !matchOptions.FlipNegate) ||
+                    (negateCount % 2 == 1 && matchOptions.FlipNegate);
+
+                // Set NoNegate. Brace expansion could result in a leading '!'.
+                matchOptions.NoNegate = true;
+                matchOptions.FlipNegate = false;
+
+                // Trim and skip empty.
+                currentPattern = currentPattern.Trim();
+                if (String.IsNullOrEmpty(currentPattern))
+                {
+                    tracer.Info($"Skipping empty pattern.");
+                    continue;
+                }
+
+                // Expand braces - required to accurately interpret findPath.
+                string[] expandedPatterns;
+                string preExpandedPattern = currentPattern;
+                if (matchOptions.NoBrace)
+                {
+                    expandedPatterns = new string[] { currentPattern };
+                }
+                else
+                {
+                    expandedPatterns = ExpandBraces(currentPattern, matchOptions);
+                }
+
+                // Set NoBrace.
+                matchOptions.NoBrace = true;
+
+                foreach (string expandedPattern in expandedPatterns)
+                {
+                    if (expandedPattern != preExpandedPattern)
+                    {
+                        tracer.Info($"Pattern: {expandedPattern}");
+                    }
+
+                    // Trim and skip empty.
+                    currentPattern = expandedPattern.Trim();
+                    if (String.IsNullOrEmpty(currentPattern))
+                    {
+                        tracer.Info($"Skipping empty pattern.");
+                        continue;
+                    }
+
+                    string[] currentPatterns = new string[] { currentPattern };
+                    IEnumerable<Func<string, bool>> minimatcherFuncs = MinimatchHelper.GetMinimatchFuncs(
+                        currentPatterns,
+                        tracer,
+                        matchOptions
+                    );
+
+                    UpdatePatternsMap(isIncludePattern, paths, minimatcherFuncs, ref map);
+                }
+            }
+
+            return map;
+        }
+
+        private string[] ExpandBraces(string pattern, Options matchOptions)
+        {
+            // Convert slashes on Windows before calling braceExpand(). Unfortunately this means braces cannot
+            // be escaped on Windows, this limitation is consistent with current limitations of minimatch (3.0.3).
+            tracer.Info($"Expanding braces.");
+            string convertedPattern = pattern.Replace("\\", "/");
+            return Minimatcher.BraceExpand(convertedPattern, matchOptions).ToArray();
+        }
+
+        private void UpdatePatternsMap(bool isIncludePattern, List<string> paths, IEnumerable<Func<string, bool>> minimatcherFuncs, ref Hashtable map)
+        {
+            if (isIncludePattern)
+            {
+                // Apply the pattern.
+                tracer.Info($"Applying include pattern against original list.");
+                List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
+
+                // Union the results.
+                int matchCount = 0;
+                foreach (string matchResult in matchResults)
+                {
+                    matchCount++;
+                    map[matchResult] = Boolean.TrueString;
+                }
+
+                tracer.Info($"{matchCount} matches");
+            }
+            else
+            {
+                // Apply the pattern.
+                tracer.Info($"Applying exclude pattern against original list.");
+                List<string> matchResults = this.FilterItemsByPatterns(paths, minimatcherFuncs);
+
+                // Subtract the results.
+                int matchCount = 0;
+                foreach (string matchResult in matchResults)
+                {
+                    matchCount++;
+                    map.Remove(matchResult);
+                }
+
+                tracer.Info($"{matchCount} matches");
+            }
+        }
+
+        // Returns list of FileContainerItem items required to be downloaded. Used by FileContainerProvider.
+        public List<FileContainerItem> ApplyPatternsMapToContainerItems(List<FileContainerItem> items, Hashtable map)
+        {
+            List<FileContainerItem> resultItems = new List<FileContainerItem>();
+            foreach (FileContainerItem item in items)
+            {
+                if (Convert.ToBoolean(map[item.Path]))
+                {
+                    resultItems.Add(item);
+                }
+            }
+
+            return resultItems;
+        }
+
+        private List<string> FilterItemsByPatterns(List<string> paths, IEnumerable<Func<string, bool>> minimatchFuncs)
+        {
+            List<string> filteredItems = new List<string>();
+            foreach (string path in paths)
+            {
+                if (minimatchFuncs.Any(match => match(path)))
+                {
+                    filteredItems.Add(path);
+                }
+            }
+
+            return filteredItems;
+        }
+
+        // Clones MiniMatch options into separate object
+        private Options CloneMiniMatchOptions(Options currentMiniMatchOptions)
+        {
+            Options clonedMiniMatchOptions = new Options()
+            {
+                Dot = currentMiniMatchOptions.Dot,
+                FlipNegate = currentMiniMatchOptions.FlipNegate,
+                MatchBase = currentMiniMatchOptions.MatchBase,
+                NoBrace = currentMiniMatchOptions.NoBrace,
+                NoCase = currentMiniMatchOptions.NoCase,
+                NoComment = currentMiniMatchOptions.NoComment,
+                NoExt = currentMiniMatchOptions.NoExt,
+                NoGlobStar = currentMiniMatchOptions.NoGlobStar,
+                NoNegate = currentMiniMatchOptions.NoNegate,
+                NoNull = currentMiniMatchOptions.NoNull,
+                IgnoreCase = currentMiniMatchOptions.IgnoreCase,
+                AllowWindowsPaths = PlatformUtil.RunningOnWindows
+            };
+            return clonedMiniMatchOptions;
+        }
+    }
+}

--- a/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
+++ b/src/Agent.Plugins/Artifact/ArtifactItemFilters.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Test/L0/Plugin/TestFileContainerProvider/TestFileContainerProviderL0.cs
+++ b/src/Test/L0/Plugin/TestFileContainerProvider/TestFileContainerProviderL0.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Agent.Plugins;
+using Agent.Sdk;
+using Microsoft.VisualStudio.Services.FileContainer;
+using Minimatch;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests
+{
+    public class TestFileContainerProviderL0
+    {
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Plugin")]
+        [InlineData(new string[] { "**" }, 7,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/File2.txt",
+                "ArtifactForTest/Folder1/File21.txt", "ArtifactForTest/Folder1/Folder2", "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "**", "!**/File2.txt" }, 6,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/File21.txt",
+                "ArtifactForTest/Folder1/Folder2", "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "**", "!**/File2*" }, 5,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/Folder2",
+                "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "**", "!**/Folder2/**" }, 6,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/File2.txt",
+                "ArtifactForTest/Folder1/File21.txt", "ArtifactForTest/Folder1/Folder2" })]
+        [InlineData(new string[] { "**/Folder1/**", "!**/File3.txt" }, 3,
+            new string[] { "ArtifactForTest/Folder1/File2.txt", "ArtifactForTest/Folder1/File21.txt", "ArtifactForTest/Folder1/Folder2" })]
+        [InlineData(new string[] { "**/File*.txt", "!**/File3.txt" }, 3,
+            new string[] { "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1/File2.txt", "ArtifactForTest/Folder1/File21.txt" })]
+        [InlineData(new string[] { "**", "!**/Folder1/**", "!!**/File3.txt" }, 4,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "**", "   !**/Folder1/**  ", "!!**/File3.txt" }, 4,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "**", "!**/Folder1/**", "#!**/Folder2/**", "!!**/File3.txt" }, 4,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "**", "!**/Folder1/**", " ", "!!**/File3.txt" }, 4,
+            new string[] { "ArtifactForTest", "ArtifactForTest/File1.txt", "ArtifactForTest/Folder1", "ArtifactForTest/Folder1/Folder2/File3.txt" })]
+        [InlineData(new string[] { "ArtifactForTest/File1.txt" }, 1, new string[] { "ArtifactForTest/File1.txt" })]
+        public void TestGettingArtifactItemsWithMinimatchPattern(string[] pttrn, int count, string[] expectedPaths)
+        {
+            using (TestHostContext hostContext = new TestHostContext(this))
+            {
+                AgentTaskPluginExecutionContext context = new AgentTaskPluginExecutionContext(hostContext.GetTrace());
+                ArtifactItemFilters filters = new ArtifactItemFilters(null, context.CreateArtifactsTracer());
+
+                List<FileContainerItem> items = new List<FileContainerItem>
+                {
+                    new FileContainerItem() { ItemType = ContainerItemType.Folder, Path = "ArtifactForTest" },
+                    new FileContainerItem() { ItemType = ContainerItemType.File, Path = "ArtifactForTest/File1.txt" },
+                    new FileContainerItem() { ItemType = ContainerItemType.Folder, Path = "ArtifactForTest/Folder1" },
+                    new FileContainerItem() { ItemType = ContainerItemType.File, Path = "ArtifactForTest/Folder1/File2.txt" },
+                    new FileContainerItem() { ItemType = ContainerItemType.File, Path = "ArtifactForTest/Folder1/File21.txt" },
+                    new FileContainerItem() { ItemType = ContainerItemType.Folder, Path = "ArtifactForTest/Folder1/Folder2" },
+                    new FileContainerItem() { ItemType = ContainerItemType.File, Path = "ArtifactForTest/Folder1/Folder2/File3.txt" }
+                };
+
+                List<string> paths = new List<string>();
+                foreach (FileContainerItem item in items)
+                {
+                    paths.Add(item.Path);
+                }
+
+                string[] minimatchPatterns = pttrn;
+
+                Options customMinimatchOptions = new Options()
+                {
+                    Dot = true,
+                    NoBrace = true,
+                    AllowWindowsPaths = PlatformUtil.RunningOnWindows
+                };
+
+                Hashtable map = filters.GetMapToFilterItems(paths, minimatchPatterns, customMinimatchOptions);
+                List<FileContainerItem> resultItems = filters.ApplyPatternsMapToContainerItems(items, map);
+
+                Assert.Equal(count, resultItems.Count);
+
+                string listPaths = string.Join(", ", expectedPaths);
+                List<string> resultPathsList = new List<string>();
+                foreach (FileContainerItem item in resultItems)
+                {
+                    resultPathsList.Add(item.Path);
+                }
+                string resultPaths = string.Join(", ", resultPathsList);
+
+                Assert.Equal(listPaths, resultPaths);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added tests for ported logic of handling negative patterns for DownloadBuildArtifacts task.

Checklist:
- There’s no risky dependency updates
   - Corrected function is used by 2 tasks. And both these tasks work correctly with the changes.

- Changes has been tested
   - Yes. The changes are tested by 22 cases (2 affected tasks, 11 cases for each task) by build in prepared pipeline. Also test with 7 cases was added in these PR to cover corrected function.

- Enough test coverage for changes, and current test coverage for task doesn't look poor
   - Yes, test with 7 cases was added in these PR to cover corrected function. Most cases of using the function are covered.

- We understand how tasks is working, how changes affect task behavior
   - Yes. The changes allow to collect list of files which should be downloaded from artifact. Previously all files are downloaded.

- There is no breaking changes
   - No breaking changes.

- There is no any other concerns
   - No concerns. Corrected function is used by 2 tasks. And both these tasks work correctly with the changes.

- I have not discovered any new uncovered test/use cases
   - Yes, I don't uncovered test/use cases for corrected function.