### PR TITLE
Added L0 tests for TrackingManager - MergeTrackingConfigs method

### DIFF
--- a/src/Agent.Worker/Build/BuildDirectoryManager.cs
+++ b/src/Agent.Worker/Build/BuildDirectoryManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Agent.Sdk.Knob;
 using Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.VisualStudio.Services.Agent.Util;
 
@@ -64,7 +65,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             // If there aren't any major changes, merge the configurations and use the same workspace
             if (trackingManager.AreTrackingConfigsCompatible(executionContext, newConfig, existingConfig))
             {
-                newConfig = trackingManager.MergeTrackingConfigs(executionContext, newConfig, existingConfig, shouldOverrideBuildDirectory);
+                bool disableOverrideTfvcBuildDirectoryKnob = AgentKnobs.DisableOverrideTfvcBuildDirectory.GetValue(executionContext).AsBoolean();
+                newConfig = trackingManager.MergeTrackingConfigs(executionContext, newConfig, existingConfig, shouldOverrideBuildDirectory && !disableOverrideTfvcBuildDirectoryKnob);
             }
             else if (existingConfig != null)
             {

--- a/src/Agent.Worker/Build/TrackingManager.cs
+++ b/src/Agent.Worker/Build/TrackingManager.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 mergedConfig.SourcesDirectory = newConfig.SourcesDirectory;
             }
 
-            if (overrideBuildDirectory && !AgentKnobs.DisableOverrideTfvcBuildDirectory.GetValue(executionContext).AsBoolean())
+            if (overrideBuildDirectory)
             {
                 mergedConfig.BuildDirectory = newConfig.BuildDirectory;
             }

--- a/src/Test/L0/Worker/Build/TrackingManagerL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingManagerL0.cs
@@ -630,6 +630,49 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MergeTrackingConfig_CheckIfReturnsValidConfig()
+        {
+            using (TestHostContext hc = Setup())
+            {
+                var config1 = GetTestConfig(1);
+                var config2 = GetTestConfig(2);
+
+                var mergedConfig = _trackingManager.MergeTrackingConfigs(_ec.Object, config2, config1, true);
+                Assert.Equal("BuildDirectory2", mergedConfig.BuildDirectory);
+                Assert.Equal("SourcesDirectory1", mergedConfig.SourcesDirectory);
+                Assert.Equal("RepositoryType1", mergedConfig.RepositoryType);
+                Assert.Equal("CollectionUrl1", mergedConfig.CollectionUrl);
+                Assert.Equal("ArtifactsDirectory1", mergedConfig.ArtifactsDirectory);
+                Assert.Equal("CollectionId1", mergedConfig.CollectionId);
+                Assert.Equal("FileLocation1", mergedConfig.FileLocation);
+                Assert.Equal("DefinitionId1", mergedConfig.DefinitionId);
+                Assert.Equal("DefinitionName1", mergedConfig.DefinitionName);
+                Assert.Equal("System1", mergedConfig.System);
+                Assert.Equal("TestResultsDirectory1", mergedConfig.TestResultsDirectory);
+            }
+        }
+
+        private TrackingConfig GetTestConfig(int index)
+        {
+            TrackingConfig config = new TrackingConfig();
+            config.BuildDirectory = $"BuildDirectory{index}";
+            config.ArtifactsDirectory = $"ArtifactsDirectory{index}";
+            config.CollectionId = $"CollectionId{index}";
+            config.CollectionUrl = $"CollectionUrl{index}";
+            config.FileLocation = $"FileLocation{index}";
+            config.DefinitionId = $"DefinitionId{index}";
+            config.DefinitionName = $"DefinitionName{index}";
+            config.SourcesDirectory = $"SourcesDirectory{index}";
+            config.System = $"System{index}";
+            config.RepositoryType = $"RepositoryType{index}";
+            config.TestResultsDirectory = $"TestResultsDirectory{index}";
+
+            return config;
+        }
+
         private void WriteConfigFile(string contents)
         {
             string filePath = Path.Combine(

--- a/src/Test/L0/Worker/Build/TrackingManagerL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingManagerL0.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Xunit;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
 {
@@ -645,6 +646,109 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 Assert.Equal("SourcesDirectory1", mergedConfig.SourcesDirectory);
                 Assert.Equal("RepositoryType1", mergedConfig.RepositoryType);
                 Assert.Equal("CollectionUrl1", mergedConfig.CollectionUrl);
+                Assert.Equal("ArtifactsDirectory1", mergedConfig.ArtifactsDirectory);
+                Assert.Equal("CollectionId1", mergedConfig.CollectionId);
+                Assert.Equal("FileLocation1", mergedConfig.FileLocation);
+                Assert.Equal("DefinitionId1", mergedConfig.DefinitionId);
+                Assert.Equal("DefinitionName1", mergedConfig.DefinitionName);
+                Assert.Equal("System1", mergedConfig.System);
+                Assert.Equal("TestResultsDirectory1", mergedConfig.TestResultsDirectory);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MergeTrackingConfig_CheckIfReturnsValidConfigIfBuildOverrideIsFalse()
+        {
+            using (TestHostContext hc = Setup())
+            {
+                var config1 = GetTestConfig(1);
+                var config2 = GetTestConfig(2);
+
+                var mergedConfig = _trackingManager.MergeTrackingConfigs(_ec.Object, config2, config1, false);
+                Assert.Equal("BuildDirectory1", mergedConfig.BuildDirectory);
+                Assert.Equal("SourcesDirectory1", mergedConfig.SourcesDirectory);
+                Assert.Equal("RepositoryType1", mergedConfig.RepositoryType);
+                Assert.Equal("CollectionUrl1", mergedConfig.CollectionUrl);
+                Assert.Equal("ArtifactsDirectory1", mergedConfig.ArtifactsDirectory);
+                Assert.Equal("CollectionId1", mergedConfig.CollectionId);
+                Assert.Equal("FileLocation1", mergedConfig.FileLocation);
+                Assert.Equal("DefinitionId1", mergedConfig.DefinitionId);
+                Assert.Equal("DefinitionName1", mergedConfig.DefinitionName);
+                Assert.Equal("System1", mergedConfig.System);
+                Assert.Equal("TestResultsDirectory1", mergedConfig.TestResultsDirectory);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MergeTrackingConfig_EmptySourcesDirectoryOfPreviousConfig()
+        {
+            using (TestHostContext hc = Setup())
+            {
+                var config1 = GetTestConfig(1);
+                var config2 = GetTestConfig(2);
+                config1.SourcesDirectory = "";
+
+                var mergedConfig = _trackingManager.MergeTrackingConfigs(_ec.Object, config2, config1, false);
+                Assert.Equal("BuildDirectory1", mergedConfig.BuildDirectory);
+                Assert.Equal("SourcesDirectory2", mergedConfig.SourcesDirectory);
+                Assert.Equal("RepositoryType1", mergedConfig.RepositoryType);
+                Assert.Equal("CollectionUrl1", mergedConfig.CollectionUrl);
+                Assert.Equal("ArtifactsDirectory1", mergedConfig.ArtifactsDirectory);
+                Assert.Equal("CollectionId1", mergedConfig.CollectionId);
+                Assert.Equal("FileLocation1", mergedConfig.FileLocation);
+                Assert.Equal("DefinitionId1", mergedConfig.DefinitionId);
+                Assert.Equal("DefinitionName1", mergedConfig.DefinitionName);
+                Assert.Equal("System1", mergedConfig.System);
+                Assert.Equal("TestResultsDirectory1", mergedConfig.TestResultsDirectory);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MergeTrackingConfig_EmptyRepositoryTypeOfPreviousConfig()
+        {
+            using (TestHostContext hc = Setup())
+            {
+                var config1 = GetTestConfig(1);
+                var config2 = GetTestConfig(2);
+                config1.RepositoryType = "";
+
+                var mergedConfig = _trackingManager.MergeTrackingConfigs(_ec.Object, config2, config1, false);
+                Assert.Equal("BuildDirectory1", mergedConfig.BuildDirectory);
+                Assert.Equal("SourcesDirectory1", mergedConfig.SourcesDirectory);
+                Assert.Equal("RepositoryType2", mergedConfig.RepositoryType);
+                Assert.Equal("CollectionUrl1", mergedConfig.CollectionUrl);
+                Assert.Equal("ArtifactsDirectory1", mergedConfig.ArtifactsDirectory);
+                Assert.Equal("CollectionId1", mergedConfig.CollectionId);
+                Assert.Equal("FileLocation1", mergedConfig.FileLocation);
+                Assert.Equal("DefinitionId1", mergedConfig.DefinitionId);
+                Assert.Equal("DefinitionName1", mergedConfig.DefinitionName);
+                Assert.Equal("System1", mergedConfig.System);
+                Assert.Equal("TestResultsDirectory1", mergedConfig.TestResultsDirectory);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void MergeTrackingConfig_EmptyCollectionUrlOfPreviousConfig()
+        {
+            using (TestHostContext hc = Setup())
+            {
+                var config1 = GetTestConfig(1);
+                var config2 = GetTestConfig(2);
+                config1.CollectionUrl = "";
+
+                var mergedConfig = _trackingManager.MergeTrackingConfigs(_ec.Object, config2, config1, false);
+                Assert.Equal("BuildDirectory1", mergedConfig.BuildDirectory);
+                Assert.Equal("SourcesDirectory1", mergedConfig.SourcesDirectory);
+                Assert.Equal("RepositoryType1", mergedConfig.RepositoryType);
+                Assert.Equal("CollectionUrl2", mergedConfig.CollectionUrl);
                 Assert.Equal("ArtifactsDirectory1", mergedConfig.ArtifactsDirectory);
                 Assert.Equal("CollectionId1", mergedConfig.CollectionId);
                 Assert.Equal("FileLocation1", mergedConfig.FileLocation);


### PR DESCRIPTION
- Increased test coverage for TrackingManager.MergeTrackingConfigs method.
- Moved agent knob out of this method - to make it testable.