### PR TITLE
Added RepoType telemetry for checkout task

### DIFF
--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -118,6 +118,11 @@ namespace Agent.Plugins.Repository
             var repoAlias = executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.Repository, true);
             var repo = executionContext.Repositories.Single(x => string.Equals(x.Alias, repoAlias, StringComparison.OrdinalIgnoreCase));
 
+            executionContext.PublishTelemetry(area: "AzurePipelinesAgent", feature: "Checkout", properties: new Dictionary<string, string>
+            {
+                { "RepoType", $"{repo.Type}" }
+            });
+
             MergeCheckoutOptions(executionContext, repo);
 
             var currentRepoPath = repo.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);

--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -120,7 +120,8 @@ namespace Agent.Plugins.Repository
 
             executionContext.PublishTelemetry(area: "AzurePipelinesAgent", feature: "Checkout", properties: new Dictionary<string, string>
             {
-                { "RepoType", $"{repo.Type}" }
+                { "RepoType", $"{repo.Type}" },
+                { "HostOS", $"{PlatformUtil.HostOS}" }
             });
 
             MergeCheckoutOptions(executionContext, repo);


### PR DESCRIPTION
We need this to check which percentage of users works with TFVC repos on Linux and Macos agents.