### PR TITLE
Enabling validation of checksum for online agent update for ADO OnPrem

### DIFF
--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -42,7 +42,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         private VssCredentials _creds;
         private ILocationServer _locationServer;
         private bool _hashValidationDisabled;
-        private ServerUtil _serverUtil;
 
         public override void Initialize(IHostContext hostContext)
         {
@@ -60,7 +59,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             _creds = credManager.LoadCredentials();
             _locationServer = HostContext.GetService<ILocationServer>();
             _hashValidationDisabled = AgentKnobs.DisableHashValidation.GetValue(_knobContext).AsBoolean();
-            _serverUtil = new ServerUtil(Trace);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA2000:Dispose objects before losing scope", MessageId = "invokeScript")]
@@ -170,15 +168,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             return false;
         }
 
-        private async Task<bool> HashValidation(string archiveFile)
+        private bool HashValidation(string archiveFile)
         {
             if (_hashValidationDisabled)
             {
                 Trace.Info($"Agent package hash validation disabled, so skipping it");
                 return true;
             }
-
-            await _serverUtil.DetermineDeploymentType(_serverUrl, _creds, _locationServer);
 
             // DownloadUrl for offline agent update is started from Url of ADO On-Premises
             // DownloadUrl for online agent update is started from Url of feed with agent packages
@@ -304,7 +300,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                             Trace.Info($"Download agent: finished download");
 
                             downloadSucceeded = true;
-                            validationSucceeded = await HashValidation(archiveFile);
+                            validationSucceeded = HashValidation(archiveFile);
                         }
                         catch (OperationCanceledException) when (token.IsCancellationRequested)
                         {

--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -178,21 +178,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 return true;
             }
 
-            bool isHostedServer;
             await _serverUtil.DetermineDeploymentType(_serverUrl, _creds, _locationServer);
-            if (!_serverUtil.TryGetDeploymentType(out isHostedServer))
-            {
-                throw new DeploymentTypeNotDeterminedException(@"Deployment type determination has been failed.
-This exception was thrown during checksum validation when performing the agent self-update process.
-Most likely you are using On-Premises DevOps solution and the deployment type determination was not implemented for your server version.
-Checksum validation implemented for Cloud DevOps solutions only.
-You can skip checksum validation for the agent package by setting the environment variable DISABLE_HASH_VALIDATION=true");
-            }
 
-            if (!isHostedServer)
+            bool isOfflineUpdate = _targetPackage.DownloadUrl.StartsWith(_serverUrl);
+            if (isOfflineUpdate)
             {
-                Trace.Info($"Checksum validation for On-Premises solution");
-                // return true;
+                Trace.Info($"Skipping checksum validation for offline agent update");
+                return true;
             }
 
             if (string.IsNullOrEmpty(_targetPackage.HashValue))

--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -191,8 +191,8 @@ You can skip checksum validation for the agent package by setting the environmen
 
             if (!isHostedServer)
             {
-                Trace.Info($"Skipping checksum validation for On-Premises solution");
-                return true;
+                Trace.Info($"Checksum validation for On-Premises solution");
+                // return true;
             }
 
             if (string.IsNullOrEmpty(_targetPackage.HashValue))
@@ -202,7 +202,9 @@ You can skip checksum validation for the agent package by setting the environmen
             }
 
             string expectedHash = _targetPackage.HashValue;
+            Trace.Info($"Expected hash - { expectedHash }");
             string actualHash = IOUtil.GetFileHash(archiveFile);
+            Trace.Info($"Actual hash - { actualHash }");
             bool hashesMatch = StringUtil.AreHashesEqual(actualHash, expectedHash);
 
             if (hashesMatch)

--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -180,6 +180,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
             await _serverUtil.DetermineDeploymentType(_serverUrl, _creds, _locationServer);
 
+            // DownloadUrl for offline agent update is started from Url of ADO On-Premises
+            // DownloadUrl for online agent update is started from Url of feed with agent packages
             bool isOfflineUpdate = _targetPackage.DownloadUrl.StartsWith(_serverUrl);
             if (isOfflineUpdate)
             {
@@ -194,9 +196,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             }
 
             string expectedHash = _targetPackage.HashValue;
-            Trace.Info($"Expected hash - { expectedHash }");
             string actualHash = IOUtil.GetFileHash(archiveFile);
-            Trace.Info($"Actual hash - { actualHash }");
             bool hashesMatch = StringUtil.AreHashesEqual(actualHash, expectedHash);
 
             if (hashesMatch)


### PR DESCRIPTION
Enabled validation of checksum for online agent update for ADO OnPrem. Previously the validation was actual for Hosted ADO versions.
Validation of checksum is left as disabled for offline agent update (https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/agents?view=azure-devops-2019&tabs=browser#can-i-update-my-v2-agents-that-are-part-of-an-azure-devops-server-pool).

Changes are tested by following cases:
- ADO On-Premises:
  - Update by button "Update all agents" with **enabled network** and **without package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was successful
  - Update by start new task on agent with **enabled network** and **without package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was successful
  - Update by button "Update all agents" with **enabled network** and **with package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was skipped
  - Update by start new task on agent with **enabled network** and **with package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was skipped
  - Update by button "Update all agents" with **disabled network** and **with package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was skipped
  - Update by start new task on agent with **disabled network** and **with package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was skipped
- Hosted ADO:
  - Update by button "Update all agents" with **enabled network** and **without package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was successful
  - Update by start new task on agent with **enabled network** and **without package** in %ProgramData%\Microsoft\Azure DevOps\Agents - Checksum was successful