### PR TITLE
Added masking for environment variables containing credentials in diagnostic logs

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -172,13 +172,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("http_proxy"),
             new BuiltInDefaultKnobSource(string.Empty));
 
-        public static readonly Knob ProxyPassword = new Knob(
+        public static readonly Knob ProxyPassword = new SecretKnob(
             nameof(ProxyPassword),
             "Proxy password if one exists",
             new EnvironmentKnobSource("VSTS_HTTP_PROXY_PASSWORD"),
             new BuiltInDefaultKnobSource(string.Empty));
 
-        public static readonly Knob ProxyUsername = new Knob(
+        public static readonly Knob ProxyUsername = new SecretKnob(
             nameof(ProxyUsername),
             "Proxy username if one exists",
             new EnvironmentKnobSource("VSTS_HTTP_PROXY_USERNAME"),

--- a/src/Agent.Sdk/Knob/CompositeKnobSource.cs
+++ b/src/Agent.Sdk/Knob/CompositeKnobSource.cs
@@ -39,14 +39,18 @@ namespace Agent.Sdk.Knob
             return string.Join(", ", strings);
         }
 
-        public bool hasEnvironmentSourceWithName(string name)
+        /// <summary>
+        /// Returns true if object has source with type EnvironmentKnobSource and provided name
+        /// </summary>
+        /// <param name="name">Name to check</param>
+        /// <returns>Returns true if source exists with this type and name</returns>
+        public bool hasSourceWithTypeEnvironmentByName(string name)
         {
             foreach (var source in _sources)
             {
-                var isEnvironmentSource = source is EnvironmentKnobSource;
-                if (isEnvironmentSource)
+                if (source is EnvironmentKnobSource)
                 {
-                    var envName = (source as IEnvironmentKnobSource).GetOriginalName();
+                    var envName = (source as IEnvironmentKnobSource).GetEnvironmentVariableName();
                     if (String.Equals(envName, name, StringComparison.OrdinalIgnoreCase))
                     {
                         return true;

--- a/src/Agent.Sdk/Knob/CompositeKnobSource.cs
+++ b/src/Agent.Sdk/Knob/CompositeKnobSource.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Agent.Sdk.Knob
 {
 
-    public class CompositeKnobSource : IKnobSource
+    public class CompositeKnobSource : ICompositeKnobSource
     {
         private IKnobSource[] _sources;
 
@@ -27,6 +28,7 @@ namespace Agent.Sdk.Knob
             }
             return null;
         }
+
         public string GetDisplayString()
         {
             var strings = new List<string>();
@@ -35,6 +37,24 @@ namespace Agent.Sdk.Knob
                 strings.Add(source.GetDisplayString());
             }
             return string.Join(", ", strings);
+        }
+
+        public bool hasEnvironmentSourceWithName(string name)
+        {
+            foreach (var source in _sources)
+            {
+                var isEnvironmentSource = source is EnvironmentKnobSource;
+                if (isEnvironmentSource)
+                {
+                    var envName = (source as IEnvironmentKnobSource).GetOriginalName();
+                    if (String.Equals(envName, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 

--- a/src/Agent.Sdk/Knob/CompositeKnobSource.cs
+++ b/src/Agent.Sdk/Knob/CompositeKnobSource.cs
@@ -44,7 +44,7 @@ namespace Agent.Sdk.Knob
         /// </summary>
         /// <param name="name">Name to check</param>
         /// <returns>Returns true if source exists with this type and name</returns>
-        public bool hasSourceWithTypeEnvironmentByName(string name)
+        public bool HasSourceWithTypeEnvironmentByName(string name)
         {
             foreach (var source in _sources)
             {

--- a/src/Agent.Sdk/Knob/EnvironmentKnobSource.cs
+++ b/src/Agent.Sdk/Knob/EnvironmentKnobSource.cs
@@ -31,7 +31,7 @@ namespace Agent.Sdk.Knob
             return $"${{{_envVar}}}";
         }
 
-        public string GetOriginalName()
+        public string GetEnvironmentVariableName()
         {
             return _envVar;
         }

--- a/src/Agent.Sdk/Knob/EnvironmentKnobSource.cs
+++ b/src/Agent.Sdk/Knob/EnvironmentKnobSource.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 namespace Agent.Sdk.Knob
 {
 
-    public class EnvironmentKnobSource : IKnobSource
+    public class EnvironmentKnobSource : IEnvironmentKnobSource
     {
         private string _envVar;
 
@@ -29,6 +29,11 @@ namespace Agent.Sdk.Knob
         public string GetDisplayString()
         {
             return $"${{{_envVar}}}";
+        }
+
+        public string GetOriginalName()
+        {
+            return _envVar;
         }
     }
 

--- a/src/Agent.Sdk/Knob/ICompositeKnobSource.cs
+++ b/src/Agent.Sdk/Knob/ICompositeKnobSource.cs
@@ -5,6 +5,6 @@ namespace Agent.Sdk.Knob
 {
     public interface ICompositeKnobSource : IKnobSource
     {
-        bool hasEnvironmentSourceWithName(string name);
+        bool hasSourceWithTypeEnvironmentByName(string name);
     }
 }

--- a/src/Agent.Sdk/Knob/ICompositeKnobSource.cs
+++ b/src/Agent.Sdk/Knob/ICompositeKnobSource.cs
@@ -5,6 +5,6 @@ namespace Agent.Sdk.Knob
 {
     public interface ICompositeKnobSource : IKnobSource
     {
-        bool hasSourceWithTypeEnvironmentByName(string name);
+        bool HasSourceWithTypeEnvironmentByName(string name);
     }
 }

--- a/src/Agent.Sdk/Knob/ICompositeKnobSource.cs
+++ b/src/Agent.Sdk/Knob/ICompositeKnobSource.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Agent.Sdk.Knob
+{
+    public interface ICompositeKnobSource : IKnobSource
+    {
+        bool hasEnvironmentSourceWithName(string name);
+    }
+}

--- a/src/Agent.Sdk/Knob/IEnvironmentKnobSource.cs
+++ b/src/Agent.Sdk/Knob/IEnvironmentKnobSource.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Agent.Sdk.Knob
+{
+    public interface IEnvironmentKnobSource : IKnobSource
+    {
+        string GetOriginalName();
+    }
+}

--- a/src/Agent.Sdk/Knob/IEnvironmentKnobSource.cs
+++ b/src/Agent.Sdk/Knob/IEnvironmentKnobSource.cs
@@ -5,6 +5,6 @@ namespace Agent.Sdk.Knob
 {
     public interface IEnvironmentKnobSource : IKnobSource
     {
-        string GetOriginalName();
+        string GetEnvironmentVariableName();
     }
 }

--- a/src/Agent.Sdk/Knob/Knob.cs
+++ b/src/Agent.Sdk/Knob/Knob.cs
@@ -27,7 +27,7 @@ namespace Agent.Sdk.Knob
     public class Knob
     {
         public string Name { get; private set; }
-        public IKnobSource Source { get; private set;}
+        public ICompositeKnobSource Source { get; private set;}
         public string Description { get; private set; }
         public virtual bool IsDeprecated => false;  // is going away at a future date
         public virtual bool IsExperimental => false; // may go away at a future date

--- a/src/Agent.Sdk/Knob/Knob.cs
+++ b/src/Agent.Sdk/Knob/Knob.cs
@@ -26,9 +26,7 @@ namespace Agent.Sdk.Knob
 
     public class SecretKnob : Knob
     {
-        public override bool isSecret => true;
-
-         public SecretKnob(string name, string description, params IKnobSource[] sources) : base(name, description, sources)
+        public SecretKnob(string name, string description, params IKnobSource[] sources) : base(name, description, sources)
         {
         }
     }
@@ -40,8 +38,6 @@ namespace Agent.Sdk.Knob
         public string Description { get; private set; }
         public virtual bool IsDeprecated => false;  // is going away at a future date
         public virtual bool IsExperimental => false; // may go away at a future date
-
-        public virtual bool isSecret => false;
 
         public Knob(string name, string description, params IKnobSource[] sources)
         {

--- a/src/Agent.Sdk/Knob/Knob.cs
+++ b/src/Agent.Sdk/Knob/Knob.cs
@@ -24,6 +24,15 @@ namespace Agent.Sdk.Knob
         }
     }
 
+    public class SecretKnob : Knob
+    {
+        public override bool isSecret => true;
+
+         public SecretKnob(string name, string description, params IKnobSource[] sources) : base(name, description, sources)
+        {
+        }
+    }
+
     public class Knob
     {
         public string Name { get; private set; }
@@ -31,6 +40,8 @@ namespace Agent.Sdk.Knob
         public string Description { get; private set; }
         public virtual bool IsDeprecated => false;  // is going away at a future date
         public virtual bool IsExperimental => false; // may go away at a future date
+
+        public virtual bool isSecret => false;
 
         public Knob(string name, string description, params IKnobSource[] sources)
         {

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -142,10 +142,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                 tag = "(EXPERIMENTAL)";
                             }
                             var stringValue = value.AsString();
-                            if (knob.isSecret)
+                            if (knob is SecretKnob)
                             {
                                 HostContext.SecretMasker.AddValue(stringValue);
-                                HostContext.SecretMasker.MaskSecrets(stringValue);
                             }
                             var outputLine = $"   Knob: {knob.Name} = {stringValue} Source: {value.Source.GetDisplayString()} {tag}";
                             if (knob.IsDeprecated)

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -141,7 +141,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             {
                                 tag = "(EXPERIMENTAL)";
                             }
-                            var outputLine = $"   Knob: {knob.Name} = {value.AsString()} Source: {value.Source.GetDisplayString()} {tag}";
+                            var stringValue = value.AsString();
+                            if (knob.isSecret)
+                            {
+                                HostContext.SecretMasker.AddValue(stringValue);
+                                HostContext.SecretMasker.MaskSecrets(stringValue);
+                            }
+                            var outputLine = $"   Knob: {knob.Name} = {stringValue} Source: {value.Source.GetDisplayString()} {tag}";
                             if (knob.IsDeprecated)
                             {
                                 context.Warning(outputLine);

--- a/src/Microsoft.VisualStudio.Services.Agent/Capabilities/EnvironmentCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Capabilities/EnvironmentCapabilitiesProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
                 }
             }
 
-            var secretKnobs = Knob.GetAllKnobsFor<AgentKnobs>().Where(k => k.isSecret);
+            var secretKnobs = Knob.GetAllKnobsFor<AgentKnobs>().Where(k => k is SecretKnob);
 
             // Get filtered env vars.
             IEnumerable<string> names =
@@ -87,29 +87,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
                     continue;
                 }
 
-                if (isKeySecretEnvironmentVariable(name, secretKnobs))
+                if (secretKnobs.Any(k => k.Source.hasSourceWithTypeEnvironmentByName(name)))
                 {
                     HostContext.SecretMasker.AddValue(value);
-                    HostContext.SecretMasker.MaskSecrets(value);
                 }
                 Trace.Info($"Adding '{name}': '{value}'");
                 capabilities.Add(new Capability(name, value));
             }
 
             return Task.FromResult(capabilities);
-        }
-
-        private bool isKeySecretEnvironmentVariable(string name, IEnumerable<Knob> secretKnobs)
-        {
-            foreach (var knob in secretKnobs)
-            {
-                if (knob.Source.hasEnvironmentSourceWithName(name))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/Capabilities/EnvironmentCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Capabilities/EnvironmentCapabilitiesProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
                     continue;
                 }
 
-                if (secretKnobs.Any(k => k.Source.hasSourceWithTypeEnvironmentByName(name)))
+                if (secretKnobs.Any(k => k.Source.HasSourceWithTypeEnvironmentByName(name)))
                 {
                     HostContext.SecretMasker.AddValue(value);
                 }


### PR DESCRIPTION
Sensitive data (passwords, usernames) that user can set through environment variables and used by self-hosted agents need to be masked before they will be uploaded on Azure DevOps servers.
By default, all environment variables are scanned as agent capabilities except specified in the [ignoring list](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Microsoft.VisualStudio.Services.Agent/Capabilities/EnvironmentCapabilitiesProvider.cs#L21). If users want to ignore some additional variable - they could specify it in VSO_AGENT_IGNORE environment variable as described in [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=browser#capabilities).

You can test this PR by setting environment variables `VSTS_HTTP_PROXY_USERNAME` and `VSTS_HTTP_PROXY_PASSWORD`.

The value of the environment variable must be masked in both agent and worker logs. Start and check the content of the logs by running the pipeline in [diagnostic mode](https://docs.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/review-logs?view=azure-devops#configure-verbose-logs) 
```
[2021-12-27 06:58:27Z INFO EnvironmentCapabilitiesProvider] Adding 'VSTS_HTTP_PROXY_PASSWORD': '***'
[2021-12-27 06:58:27Z INFO EnvironmentCapabilitiesProvider] Adding 'VSTS_HTTP_PROXY_USERNAME': '***'
```
```
[2021-12-27 06:24:53Z VERB JobServerQueue] Enqueue web console line queue:    Knob: ProxyPassword = *** Source: ${VSTS_HTTP_PROXY_PASSWORD} 
[2021-12-27 06:24:53Z VERB JobServerQueue] Enqueue web console line queue:    Knob: ProxyUsername = *** Source: ${VSTS_HTTP_PROXY_USERNAME}
```

Tested locally