### PR TITLE
Bump git to version 2.34.1

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -10,7 +10,7 @@ CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
 NODE10_VERSION="10.24.1"
-MINGIT_VERSION="2.30.2"
+MINGIT_VERSION="2.34.1"
 LFS_VERSION="2.13.3"
 
 get_abs_path() {


### PR DESCRIPTION
Update git client to version 2.34.1 but it is unclear to me how to make the latest version available at https://vstsagenttools.blob.core.windows.net/tools/mingit

fix #3668