### PR TITLE
Switched macos pool to 10.15

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -185,7 +185,7 @@ stages:
         jobName: build_osx
         displayName: macOS (x64)
         pool:
-          vmImage: macOS-10.14
+          vmImage: macOS-10.15
         os: osx
         arch: x64
         branch: ${{ parameters.branch }}


### PR DESCRIPTION
Updated release pipeline to use macos-10.15 image instead of 10.14 - since the last one is deprecated.