### PR TITLE
Add simple support of Mariner OS distribution to installdependencies.sh

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -57,8 +57,8 @@ then
         echo "--------Debian Version--------"
         cat /etc/debian_version
         echo "------------------------------"
-
-        # prefer apt over apt-get
+        
+        # prefer apt over apt-get        
         command -v apt
         if [ $? -eq 0 ]
         then
@@ -177,7 +177,7 @@ then
                         print_errormessage
                         exit 1
                     fi
-                fi
+                fi       
 
                 dnf install -y lttng-ust krb5-libs zlib libicu
                 if [ $? -ne 0 ]
@@ -197,7 +197,7 @@ then
             then
                 yum install -y openssl-libs krb5-libs zlib libicu
                 if [ $? -ne 0 ]
-                then 
+                then                    
                     echo "'yum' failed with exit code '$?'"
                     print_errormessage
                     exit 1
@@ -257,7 +257,6 @@ then
                 exit 1
             fi
         elif [ -e /etc/mariner-release ]
-        # RHEL6 doesn't have an os-release file defined, read redhat-release instead
         then
             echo "The current OS is Mariner based"
             echo "--------Mariner Version--------"

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -11,6 +11,7 @@ fi
 # Debian based OS (Debian, Ubuntu, Linux Mint) has /etc/debian_version
 # Fedora based OS (Fedora, Redhat, Centos, Oracle Linux 7) has /etc/redhat-release
 # SUSE based OS (OpenSUSE, SUSE Enterprise) has ID_LIKE=suse in /etc/os-release
+# Mariner based OS (CBL-Mariner) has /etc/mariner-release
 
 function print_repositories_and_deps_warning()
 {

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -57,8 +57,8 @@ then
         echo "--------Debian Version--------"
         cat /etc/debian_version
         echo "------------------------------"
-        
-        # prefer apt over apt-get        
+
+        # prefer apt over apt-get
         command -v apt
         if [ $? -eq 0 ]
         then
@@ -177,7 +177,7 @@ then
                         print_errormessage
                         exit 1
                     fi
-                fi       
+                fi
 
                 dnf install -y lttng-ust krb5-libs zlib libicu
                 if [ $? -ne 0 ]
@@ -197,7 +197,7 @@ then
             then
                 yum install -y openssl-libs krb5-libs zlib libicu
                 if [ $? -ne 0 ]
-                then                    
+                then 
                     echo "'yum' failed with exit code '$?'"
                     print_errormessage
                     exit 1
@@ -221,7 +221,6 @@ then
             fi
         fi
     else
-
         # we might on OpenSUSE
         OSTYPE=$(grep ^ID_LIKE /etc/os-release | cut -f2 -d=)
         if [ -z $OSTYPE ]
@@ -254,6 +253,29 @@ then
                 fi
             else
                 echo "Can not find 'zypper'"
+                print_errormessage
+                exit 1
+            fi
+        elif [ -e /etc/mariner-release ]
+        # RHEL6 doesn't have an os-release file defined, read redhat-release instead
+        then
+            echo "The current OS is Mariner based"
+            echo "--------Mariner Version--------"
+            cat /etc/mariner-release
+            echo "------------------------------"
+
+            command -v yum
+            if [ $? -eq 0 ]
+                then
+                yum install -y icu
+                if [ $? -ne 0 ]
+                then                    
+                    echo "'yum' failed with exit code '$?'"
+                    print_errormessage
+                    exit 1
+                fi
+            else
+                echo "Can not find 'yum'"
                 print_errormessage
                 exit 1
             fi
@@ -293,29 +315,6 @@ then
         exit 1
     else
         echo "Unknown RHEL OS version"
-        print_errormessage
-        exit 1
-    fi
-elif [ -e /etc/mariner-release ]
-# RHEL6 doesn't have an os-release file defined, read redhat-release instead
-then
-    echo "The current OS is Mariner based"
-    echo "--------Mariner Version--------"
-    cat /etc/mariner-release
-    echo "------------------------------"
-
-    command -v yum
-    if [ $? -eq 0 ]
-        then
-        yum install -y icu
-        if [ $? -ne 0 ]
-        then                    
-            echo "'yum' failed with exit code '$?'"
-            print_errormessage
-            exit 1
-        fi
-    else
-        echo "Can not find 'yum'"
         print_errormessage
         exit 1
     fi

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -296,6 +296,29 @@ then
         print_errormessage
         exit 1
     fi
+elif [ -e /etc/mariner-release ]
+# RHEL6 doesn't have an os-release file defined, read redhat-release instead
+then
+    echo "The current OS is Mariner based"
+    echo "--------Mariner Version--------"
+    cat /etc/mariner-release
+    echo "------------------------------"
+
+    command -v yum
+    if [ $? -eq 0 ]
+        then
+        yum install -y icu
+        if [ $? -ne 0 ]
+        then                    
+            echo "'yum' failed with exit code '$?'"
+            print_errormessage
+            exit 1
+        fi
+    else
+        echo "Can not find 'yum'"
+        print_errormessage
+        exit 1
+    fi
 else
     echo "Unknown OS version"
     print_errormessage


### PR DESCRIPTION
This PR is adding simple support of Mariner OS distribution to installdependencies.sh script.
To execute agent on Mariner OS distribution requires additional installation of _icu_ package, so it was added step for installing this lib for the case when Mariner OS was detected as host OS.

Tested changes on a local installation of Mariner OS. It was tested case of agent setup on a clean OS. With updated installdependencies.sh script agent was successfully set up and was able to connect to the ADO organization. 
Instruction for an installation could be found [here](https://github.com/microsoft/CBL-Mariner/blob/1.0/toolkit/docs/quick_start/quickstart.md#prepare-vm)
ISO image of OS is [here](https://aka.ms/mariner-1.0-x86_64-iso)