### PR TITLE
Dump Agent Azure VM extension logs

### DIFF
--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -244,11 +244,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 string pathToExtensionVersions = ExtensionPaths.WindowsPathToExtensionVersions;
                 if (!Directory.Exists(pathToExtensionVersions))
                 {
+                    executionContext.Debug("Path to subfolders with Agent Azure VM Windows extension logs (of its different versions) does not exist.");
+                    executionContext.Debug($"(directory \"{pathToExtensionVersions}\" not found)");
                     return false;
                 }
                 string[] subDirs = Directory.GetDirectories(pathToExtensionVersions).Select(dir => Path.GetFileName(dir)).ToArray();
                 if (subDirs.Length == 0)
                 {
+                    executionContext.Debug("Path to Agent Azure VM Windows extension logs (of its different versions) does not contain subfolders.");
+                    executionContext.Debug($"(directory \"{pathToExtensionVersions}\" does not contain subdirectories with logs)");
                     return false;
                 }
                 Version[] versions = subDirs.Select(dir => new Version(dir)).ToArray();
@@ -262,6 +266,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 pathToLogs = ExtensionPaths.LinuxPathToExtensionLogs;
                 if (!Directory.Exists(pathToLogs))
                 {
+                    executionContext.Debug("Path to Agent Azure VM Linux extension logs does not exist.");
+                    executionContext.Debug($"(directory \"{pathToLogs}\" not found)");
                     return false;
                 }
                 archiveName = $"AgentLinuxExtensionLogs-{timestamp}-utc.zip";


### PR DESCRIPTION
**Description:**
This pull request adds archived Agent Azure VM extension logs to the `_diag` folder and to the build (pipeline run) logs.

**Changelog:**
* `src\Agent.Worker\DiagnosticLogManager.cs` — the `DumpAgentExtensionLogs` method implemented
  and used in the `UploadDiagnosticLogsAsync` method

Changes have been tested manually end-to-end.

For this purpose, the `agent.diagnostic` variable was set to `true`, and several folders have been created inside the directory
`C:\WindowsAzure\Logs\Plugins\Microsoft.VisualStudio.Services.TeamServicesAgent`:

![image](https://user-images.githubusercontent.com/61472718/150828635-ddd98589-84c1-456b-861e-dec495f286c3.png)

Here is the archive with the Agent Azure VM extension logs inside the `<agent>\_diag` folder (after the pipeline has been run):

![image](https://user-images.githubusercontent.com/61472718/150827587-e83d2a87-72d5-402f-881a-87c86876af7e.png)

This is the same archive inside the downloaded build (pipeline run) logs:

![image](https://user-images.githubusercontent.com/61472718/150827052-f471a050-1cd1-4d40-ad51-05047a90a391.png)

The content was uploaded successfully from the extension logs folder to the agent diagnostic logs folder and to the build logs.