### PR TITLE
[TEE download and removal logic] Fix permissions setting on MacOS

### DIFF
--- a/src/Agent.Sdk/Util/TeeUtil.cs
+++ b/src/Agent.Sdk/Util/TeeUtil.cs
@@ -61,7 +61,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                 }
                 catch (Exception ex) when (downloadAttempt != downloadRetryCount)
                 {
-                    debug($"Failed to download TEE. Error: {ex.ToString()}");
+                    debug($"Failed to download and extract TEE. Error: {ex.ToString()}");
+                    DeleteTee(); // Clean up files before next attempt
                 }
             }
         }

--- a/src/Agent.Sdk/Util/TeeUtil.cs
+++ b/src/Agent.Sdk/Util/TeeUtil.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         {
             var chmodProcessInfo = new ProcessStartInfo("chmod")
             {
-                Arguments = $"{permissions} {(recursive ? "-R" : "")} {path}",
+                Arguments = $"{(recursive ? "-R" : "")} {permissions} {path}",
                 UseShellExecute = false,
                 RedirectStandardError = true
             };


### PR DESCRIPTION
We've encountered a couple of issues with TEE downloading on macos:
1. `chmod` command doesn't accept current argument order on macos
2. TEE folders don't get cleaned up when something is already extracted but permission setting fails
This PR should fix them

Initial PR: https://github.com/microsoft/azure-pipelines-agent/pull/3684