### PR TITLE
Update dumping waagent.conf file logic not to write waning on missed "waagent.conf"

### DIFF
--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                     else
                     {
-                        executionContext.Warning("waagent.conf file wasn't found. Dumping was not done.");
+                        executionContext.Debug("waagent.conf file wasn't found. Dumping was not done.");
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Replace
`Update dumping waagent.conf file logic not to write waning on missed "waagent.conf"`
with 
` executionContext.Debug("waagent.conf file wasn't found. Dumping was not done.");`