### PR TITLE
Fix adding cloud-init logs to diagnostics archive

### DIFF
--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -146,8 +146,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 string resultLogs = await DumpCloudInitLogs(logsFilePath);
                 executionContext.Debug(resultLogs);
 
-                string destination = Path.Combine(supportFilesFolder, Path.GetFileName(logsFilePath));
-                File.Copy(logsFilePath, destination);
+                if (File.Exists(logsFilePath))
+                {
+                    string destination = Path.Combine(supportFilesFolder, Path.GetFileName(logsFilePath));
+                    File.Copy(logsFilePath, destination);
+                }
 
                 executionContext.Debug("Dumping cloud-init logs is ended.");
             }

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -150,6 +150,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 {
                     string destination = Path.Combine(supportFilesFolder, Path.GetFileName(logsFilePath));
                     File.Copy(logsFilePath, destination);
+                    executionContext.Debug("Cloud-init logs added to the diagnostics archive.");
+                }
+                else
+                {
+                    executionContext.Debug("Cloud-init logs were not found.");
                 }
 
                 executionContext.Debug("Dumping cloud-init logs is ended.");


### PR DESCRIPTION
Fix adding cloud-init logs to diagnostics archive. Added check for the existence cloud-init logs file before copying it.

Checked cases:
- On linux with installed cloud-init
- On linux without installed cloud-init
- On windows (without cloud-init)