### PR TITLE
Add null check for _jobServerQueue

### DIFF
--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -343,7 +343,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         {
             if (message.PostLinesFrequencyMillis.HasValue)
             {
-                _jobServerQueue.UpdateWebConsoleLineRate(message.PostLinesFrequencyMillis.Value);
+                if (_jobServerQueue != null)
+                {
+                    _jobServerQueue.UpdateWebConsoleLineRate(message.PostLinesFrequencyMillis.Value);
+                }
             }
         }
 


### PR DESCRIPTION
Added null check for the job server queue in the UpadteMetadata method.

In rare cases, the agent receives a Metadata update message from the server when the job completes and the _jobServerQueue has already been [set](https://github.com/microsoft/azure-pipelines-agent/blob/b54fc601f9bd194b92e02d12b1a24869600a8657/src/Agent.Worker/JobRunner.cs#L469) to null. So the user can see the null refference exception in the pipeline logs:

<img width="842" alt="Снимок экрана 2022-01-21 в 19 45 37" src="https://user-images.githubusercontent.com/16704239/150566436-31a7c4be-b831-45a0-ac55-28dbaa94a419.png">

In the worker logs we can see the following:
```
[2022-01-19 00:54:54Z INFO JobRunner] Shutting down the job server queue.
...
[2022-01-19 00:55:08Z INFO JobServerQueue] All queue process tasks have been stopped, and all queues are drained.
...
[2022-01-19 00:55:08Z INFO JobRunner] Raising job completed event.
[2022-01-19 00:55:08Z INFO Worker] Metadata update message received.
[2022-01-19 00:55:08Z ERR  Program] System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.VisualStudio.Services.Agent.Worker.JobRunner.UpdateMetadata(JobMetadataMessage message)
   at Microsoft.VisualStudio.Services.Agent.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at Microsoft.VisualStudio.Services.Agent.Worker.Program.MainAsync(IHostContext context, String[] args)
```

This PR should fix this issue


