### PR TITLE
[Passive validations] Check `debsums` output on Debian

### DIFF
--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     executionContext.Debug($"Error message: {ex}");
                 }
             } else {
-                executionContext.Debug("The platform is not Linux or RHEL6 - skipping debsums check.");
+                executionContext.Debug("The platform is not based on Debian - skipping debsums check.");
             }
 
             try

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 try
                 {
-                    string packageVerificationResults = await GetPackageVerificationResult(executionContext);
+                    string packageVerificationResults = await GetPackageVerificationResult();
                     IEnumerable<string> brokenPackagesInfo = packageVerificationResults
                         .Split("\n")
                         .Where((line) => !String.IsNullOrEmpty(line) && !line.EndsWith("OK"));
@@ -607,7 +607,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        private async Task<string> GetPackageVerificationResult(IExecutionContext executionContext)
+        /// <summary>
+        ///  Git package verification result using the "debsums" utility.
+        /// </summary>
+        /// <returns>String with the "debsums" output</returns>
+        private async Task<string> GetPackageVerificationResult()
         {
             var debsums = WhichUtil.Which("debsums");
             var stringBuilder = new StringBuilder();

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     string packageVerificationResults = await GetPackageVerificationResult(executionContext);
                     IEnumerable<string> brokenPackagesInfo = packageVerificationResults
                         .Split("\n")
-                        .Where((line) => !line.EndsWith("OK"));
+                        .Where((line) => !String.IsNullOrEmpty(line) && !line.EndsWith("OK"));
 
                     string brokenPackagesLogsPath = $"{HostContext.GetDirectory(WellKnownDirectory.Diag)}/BrokenPackages-{ jobStartTimeUtc.ToString("yyyyMMdd-HHmmss") }.log";
                     File.AppendAllLines(brokenPackagesLogsPath, brokenPackagesInfo);

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -201,6 +201,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     executionContext.Debug("Failed to dump broken packages logs. Skipping.");
                     executionContext.Debug($"Error message: {ex}");
                 }
+            } else {
+                executionContext.Debug("The platform is not Linux or RHEL6 - skipping debsums check.");
             }
 
             try

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -90,6 +90,14 @@ then
                 print_errormessage
                 exit 1
             fi
+
+            # Try to install debsums package for logs gathering diagnostic info about broken packages
+            apt install debsums
+            if [ $? -ne 0 ]
+            then
+                # Since this is only for diagnostics, we don't have to fail the entire script if this installation fails
+                echo "Failed to install debsum package for diagnostics using 'apt'."
+            fi
         else
             command -v apt-get
             if [ $? -eq 0 ]
@@ -127,7 +135,7 @@ then
                 if [ $? -ne 0 ]
                 then
                     # Since this is only for diagnostics, we don't have to fail the entire script if this installation fails
-                    echo "Failed to install debsum package for diagnostics."
+                    echo "Failed to install debsum package for diagnostics using 'apt-get'."
                 fi
             else
                 echo "Can not find 'apt' or 'apt-get'"

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -120,6 +120,14 @@ then
                     print_errormessage
                     exit 1
                 fi
+
+                # Try to install debsums package for logs gathering diagnostic info about broken packages
+                apt-get install debsums
+                if [ $? -ne 0 ]
+                then
+                    # Since this is only for diagnostics, we don't have to fail the entire script if this installation fails
+                    echo "Failed to install debsum package for diagnostics."
+                fi
             else
                 echo "Can not find 'apt' or 'apt-get'"
                 print_errormessage


### PR DESCRIPTION
`debsums` is a utility that can verify all installed packages on Debian system.
This PR allows the agent to read `debsums` output and check for any issues.
Also we've added `debsums` installation to the `installdependencies.sh` script.

**NOTE**: `installdependencies.sh` script is never run automatically by the agent. So in most cases, this package will not be installed by the agent. This is ok since `debsums` an optional dependency. If it's absent, the agent will just skip this validation.