### PR TITLE
Fix check for hosted agent

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ConfigurationStore.cs
@@ -39,13 +39,16 @@ namespace Microsoft.VisualStudio.Services.Agent
         public int AgentId { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
+        public string AgentCloudId { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
         public string AgentName { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public bool AlwaysExtractTask { get; set; }
 
         [IgnoreDataMember]
-        public bool IsHosted => !string.IsNullOrEmpty(NotificationPipeName) || !string.IsNullOrEmpty(NotificationSocketAddress);
+        public bool IsHosted => AgentCloudId != null;
 
         [DataMember(EmitDefaultValue = false)]
         public string Fingerprint


### PR DESCRIPTION
This PR should fix the check of the ms-hosted agent.

The old approach was based on an obsolete method and doesn't work on all agent pools. The new approach is based on a check of AgentCloudId which is presented in the agent configuration file for the agent that is provisioned by the agent pool provider. This property doesn't exist on a self-hosted agent which is provisioned using config.sh/.cmd scripts, it is only passed by the pool provider during provisioning hosted agents.

What was tested:
1) Checked that AgentCloudId exists ms-hosted agents (this setting is stored in .agent file).
2) Checked locally that agent with provided changes will properly use AgentCloudId property from .agent file.

Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3632