### PR TITLE
Change release x86 build image back to windows-2019

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -89,7 +89,7 @@ stages:
         jobName: build_windows_x86
         displayName: Windows (x86)
         pool:
-          vmImage: windows-latest
+          vmImage: windows-2019
         os: win
         arch: x86
         branch: ${{ parameters.branch }}


### PR DESCRIPTION
Windows-latest breaks our x86 Windows builds. Recently windows-latest becama windows-2022. We need to fix the image to windows-2019.
X64 was fixed along with this PR: https://github.com/microsoft/azure-pipelines-agent/pull/3696.