### PR TITLE
Add correction of empty Matching pattern field to default value

### DIFF
--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -114,6 +114,9 @@ namespace Agent.Plugins.BuildArtifacts
 
             targetPath = Path.IsPathFullyQualified(targetPath) ? targetPath : Path.GetFullPath(Path.Combine(defaultWorkingDirectory, targetPath));
 
+            // Empty input field "Matching pattern" must be recognised as default value '**'
+            itemPattern = itemPattern.Length == 0 ? "**" : itemPattern;
+
             string[] minimatchPatterns = itemPattern.Split(
                 new[] { "\n" },
                 StringSplitOptions.RemoveEmptyEntries

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV1.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV1.cs
@@ -226,6 +226,9 @@ namespace Agent.Plugins.PipelineArtifact
             string tags = context.GetInput(ArtifactEventProperties.Tags, required: false);
             string userSpecifiedpipelineId = context.GetInput(PipelineId, required: false);
 
+            // Empty input field "Matching pattern" must be recognised as default value '**'
+            itemPattern = itemPattern.Length == 0 ? "**" : itemPattern;
+
             string[] minimatchPatterns = itemPattern.Split(
                 new[] { "\n" },
                 StringSplitOptions.RemoveEmptyEntries

--- a/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
+++ b/src/Agent.Plugins/PipelineArtifact/PipelineArtifactPluginV2.cs
@@ -108,6 +108,9 @@ namespace Agent.Plugins.PipelineArtifact
             }
             context.Debug($"ArtifactName: {artifactName}");
 
+            // Empty input field "Matching pattern" must be recognised as default value '**'
+            itemPattern = itemPattern.Length == 0 ? "**" : itemPattern;
+
             string[] minimatchPatterns = itemPattern.Split(
                 new[] { "\n" },
                 StringSplitOptions.RemoveEmptyEntries


### PR DESCRIPTION
Original version of DownloadBuildArtifact/DownloadPipelineArtifact tasks handles empty field Matching pattern as default pattern `**`. But new versions handle this just as pattern equals to empty string. The changes correct logic to recognize empty field Matching pattern as default value for the field `**`.

Checked cases:
- download all (like `**`)
- download all (like `**`) except 1or 2 file (like `!**/file.1.nupkg`)
- download all (like `**`) except group of files (like `!**/file.*.nupkg`)
- download all (like `**`) except directory (like `!**/folder1/**`)
- download directory (like `**/folder1/**`) except 1 file (like `!**/folder1/file.1.nupkg`)
- download group files (like `**/file.*.nupkg`) except 1 file (like `!**/file.1.nupkg`)
- download all (like `**`) except directory (like `!**/folder1/**`) but with downloading 1 file from the directory (like `!!**/folder1/file.1.nupkg`)
- using of whitespaces in start and end of pattern
- using of sharp (`#`) in pattern
- using of empty pattern
- using of pattern without asterisks (full path to file in artifact)
- **using of task without declaring itemPattern argument**
- **using of task with 1 pattern - empty string**
- **using of empty pattern on first place in lost of patterns**

The cases are checked for
- both tasks DownloadBuildArtifact and DownloadPipelineArtifact
- with using both BlobStorage and FileStorage as storage for artifact
- with Windows-based and Linux-based (BlobStorage only) agents