### PR TITLE
Changed image for stage Windows (x86) to windows-2019

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -89,7 +89,7 @@ stages:
         jobName: build_windows_x86
         displayName: Windows (x86)
         pool:
-          vmImage: windows-latest
+          vmImage: windows-2019
         os: win
         arch: x86
         branch: ${{ parameters.branch }}


### PR DESCRIPTION
Changed image for stage Windows (x86) to windows-2019. It's required because of windows-latest image had had some changes several days ago. And the changes don't allow to have successful build of this version of agent.