### PR TITLE
Add some logging to the ProcessInvoker

### DIFF
--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -210,6 +210,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 var payloadJson = JsonUtility.ToString(payload);
                 redirectStandardIn.Enqueue(payloadJson);
                 HostContext.GetTrace(nameof(ContainerStepHost)).Info($"Payload: {payloadJson}");
+
+                if (environment.TryGetValue("VSTS_AGENT_TRACE_PROCESSINVOKER", out string addTracing))
+                {
+                    System.Environment.SetEnvironmentVariable("VSTS_AGENT_TRACE_PROCESSINVOKER", addTracing.ToLower());
+                }
+                else
+                {
+                    System.Environment.SetEnvironmentVariable("VSTS_AGENT_TRACE_PROCESSINVOKER", "false");
+                }
+                
                 return await processInvoker.ExecuteAsync(workingDirectory: HostContext.GetDirectory(WellKnownDirectory.Work),
                                                          fileName: containerEnginePath,
                                                          arguments: containerExecutionArgs,

--- a/src/Misc/layoutbin/containerHandlerInvoker.js.template
+++ b/src/Misc/layoutbin/containerHandlerInvoker.js.template
@@ -55,10 +55,19 @@ process.stdin.on('end', function () {
     process.env['TF_BUILD'] = 'True';
     console.log("##vso[task.debug]Handler Setup Complete");
     var launch = spawn(handler, [handlerArg], options);
+    try
+    {
+        console.log("##vso[task.debug]Handler process has started: " + launch.pid);
+    }
+    catch (error)
+    {
+        console.log("##vso[task.debug]Handler process fails to spawn due to errors: " + error);
+    }
     launch.on('exit', function (code) {
         console.log("##vso[task.debug]Handler exit code: " + code);
         if (code != 0) {
             process.exit(code);
         }
     });
+    console.log("##vso[task.debug]Current process with containerHandlerInvoker does not exit");
 });


### PR DESCRIPTION
We faced with the problem when multiple jobs stalling when finalizing some tasks during execution on OneBranch pool.
From logs it is not clear where the problem happens. So it was decided to add additional tracing messages to figure out the place where execution is stopped. 

I have added additional tracing messages around processes that execute task and handles stdio streams.
