### PR TITLE
Turned on x86 pool for ci checks

### DIFF
--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -6,7 +6,7 @@ parameters:
 - name: win_x86
   type: boolean
   displayName: Windows (x86)
-  default: false
+  default: true
 - name: linux_x64
   type: boolean
   displayName: Linux (x64)


### PR DESCRIPTION
Since currently there is a hosted pool used for x86 architecture - included it into ci checks by default.