### PR TITLE
Fix TEE download error when agent and work directory are located on different mounts

### DIFF
--- a/src/Agent.Sdk/Util/TeeUtil.cs
+++ b/src/Agent.Sdk/Util/TeeUtil.cs
@@ -83,14 +83,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             string extractedTeePath = Path.Combine(tempDirectory, $"{Guid.NewGuid().ToString()}");
             ZipFile.ExtractToDirectory(zipPath, extractedTeePath);
 
-            debug($"Extracted {zipPath} to ${extractedTeePath}");
+            debug($"Extracted {zipPath} to {extractedTeePath}");
 
             string extractedTeeDestinationPath = GetTeePath();
-            Directory.Move(Path.Combine(extractedTeePath, TeePluginName), extractedTeeDestinationPath);
+            IOUtil.CopyDirectory(Path.Combine(extractedTeePath, TeePluginName), extractedTeeDestinationPath, cancellationToken);
 
-            debug($"Moved to ${extractedTeeDestinationPath}");
+            debug($"Copied TEE to {extractedTeeDestinationPath}");
 
             IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
+            IOUtil.DeleteDirectory(extractedTeePath, CancellationToken.None);
 
             // We have to set these files as executable because ZipFile.ExtractToDirectory does not set file permissions
             SetPermissions(Path.Combine(extractedTeeDestinationPath, "tf"), "a+x");

--- a/src/Agent.Sdk/Util/TeeUtil.cs
+++ b/src/Agent.Sdk/Util/TeeUtil.cs
@@ -91,7 +91,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             debug($"Copied TEE to {extractedTeeDestinationPath}");
 
             IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
-            IOUtil.DeleteDirectory(extractedTeePath, CancellationToken.None);
 
             // We have to set these files as executable because ZipFile.ExtractToDirectory does not set file permissions
             SetPermissions(Path.Combine(extractedTeeDestinationPath, "tf"), "a+x");


### PR DESCRIPTION
`Directory.Move` fails when trying to move directory between mounts. This is a known and documented issue in dotnet: https://github.com/dotnet/runtime/issues/31149
This PR replaces `Directory.Move` call with a recursive copy (`IOUtil.CopyDirectory`). This should prevent failures for this case.
Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3761