### PR TITLE
Update info about legacy http handler

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -145,7 +145,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob UseLegacyHttpHandler = new DeprecatedKnob(
             nameof(UseLegacyHttpHandler),
             "Use the libcurl-based HTTP handler rather than .NET's native HTTP handler, as we did on .NET Core 2.1",
-            "The legacy http handler will go away when the agent migrates to .NET 6.0 (expected date: Apr - May), and we recommend you don't use it.",
+            "Legacy http handler will be removed in one of the next agent releases with migration to .Net Core 6. We are highly recommend to not use it.",
             new EnvironmentKnobSource(LegacyHttpVariableName),
             new BuiltInDefaultKnobSource("false"));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -145,6 +145,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob UseLegacyHttpHandler = new DeprecatedKnob(
             nameof(UseLegacyHttpHandler),
             "Use the libcurl-based HTTP handler rather than .NET's native HTTP handler, as we did on .NET Core 2.1",
+            "The legacy http handler will go away when the agent migrates to .NET 6.0 (expected date: Apr - May), and we recommend you don't use it.",
             new EnvironmentKnobSource(LegacyHttpVariableName),
             new BuiltInDefaultKnobSource("false"));
 

--- a/src/Agent.Sdk/Knob/Knob.cs
+++ b/src/Agent.Sdk/Knob/Knob.cs
@@ -11,8 +11,15 @@ namespace Agent.Sdk.Knob
     public class DeprecatedKnob : Knob
     {
         public override bool IsDeprecated => true;
+        public string DeprecationInfo;
         public DeprecatedKnob(string name, string description, params IKnobSource[] sources) : base(name, description, sources)
         {
+            DeprecationInfo = "";
+        }
+
+        public DeprecatedKnob(string name, string description, string deprecationInfo, params IKnobSource[] sources) : base(name, description, sources)
+        {
+            DeprecationInfo = deprecationInfo;
         }
     }
 

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -147,9 +147,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                 HostContext.SecretMasker.AddValue(stringValue, $"JobExtension_InitializeJob_{knob.Name}");
                             }
                             var outputLine = $"   Knob: {knob.Name} = {stringValue} Source: {value.Source.GetDisplayString()} {tag}";
+
                             if (knob.IsDeprecated)
                             {
                                 context.Warning(outputLine);
+                                context.Warning((knob as DeprecatedKnob).DeprecationInfo);
+
                             }
                             else
                             {

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -151,8 +151,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             if (knob.IsDeprecated)
                             {
                                 context.Warning(outputLine);
-                                context.Warning((knob as DeprecatedKnob).DeprecationInfo);
 
+                                string deprecationInfo = (knob as DeprecatedKnob).DeprecationInfo;
+                                if (!string.IsNullOrEmpty(deprecationInfo))
+                                {
+                                    context.Warning(deprecationInfo);
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
Added the "deprecationInfo" property for deprecated knobs. Updated the warning message about using legacy http handler.