### PR TITLE
Added gMSA accounts support 

### DIFF
--- a/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
+++ b/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
@@ -378,8 +378,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         {
             NTAccount ntaccount = new NTAccount(accountName);
             SecurityIdentifier sid = (SecurityIdentifier)ntaccount.Translate(typeof(SecurityIdentifier));
-            // Debug only
-            Trace.Info(sid.Value);
 
             SecurityIdentifier networkServiceSid = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null);
             SecurityIdentifier localServiceSid = new SecurityIdentifier(WellKnownSidType.LocalServiceSid, null);
@@ -461,7 +459,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
             if (IsManagedServiceAccount(logonAccount))
             {
-                logonAccount = SanitizeManagedServiceAccountName(logonAccount);
                 Trace.Info(logonAccount);
             }
 

--- a/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
+++ b/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
@@ -947,7 +947,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         {
             bool isServiceAccount = false;
             accountName = SanitizeManagedServiceAccountName(accountName);
-            var result = NetIsServiceAccount(null, accountName, ref isServiceAccount);
+            var result = this.CheckNetIsServiceAccount(null, accountName, ref isServiceAccount);
             if (result == 0)
             {
                 return isServiceAccount;
@@ -955,11 +955,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             else
             {
                 int lastErrorCode = (int)GetLastError();
-                Exception win32exception = new Win32Exception(lastErrorCode);
-                throw win32exception;
+                throw new Win32Exception(lastErrorCode);
             }
         }
 
+        /// <summary>
+        /// Checks if account is managed service
+        /// </summary>
+        /// <param name="ServerName"></param>
+        /// <param name="AccountName"></param>
+        /// <param name="isServiceAccount"></param>
+        /// <returns>Returns 0 if account is managed service, otherwise - returns non-zero code</returns>
+        /// <exception cref="Win32Exception">Throws exception if there's an error during check</exception>
+        public virtual uint CheckNetIsServiceAccount(string ServerName, string AccountName, ref bool isServiceAccount)
+        {
+            return NativeWindowsServiceHelper.NetIsServiceAccount(ServerName, AccountName, ref isServiceAccount);
+        }
 
         private bool IsValidCredentialInternal(string domain, string userName, string logonPassword, UInt32 logonType)
         {
@@ -1313,7 +1324,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         }
 
         [DllImport("Logoncli.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        public static extern uint NetIsServiceAccount(string ServerName, string AccountName, ref bool IsServiceAccount);
+        private static extern uint NetIsServiceAccount(string ServerName, string AccountName, ref bool IsServiceAccount);
 
 
         [DllImport("Netapi32.dll")]

--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -67,7 +67,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             Trace.Info("LogonAccount after transforming: {0}, user: {1}, domain: {2}", logonAccount, userName, domainName);
 
             string logonPassword = string.Empty;
-            if (!defaultServiceAccount.Equals(new NTAccount(logonAccount)) && !NativeWindowsServiceHelper.IsWellKnownIdentity(logonAccount))
+            if (!defaultServiceAccount.Equals(new NTAccount(logonAccount)) &&
+                !_windowsServiceHelper.IsWellKnownIdentity(logonAccount) &&
+                !_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
             {
                 while (true)
                 {

--- a/src/Test/L0/Listener/Configuration/Mocks/MockNativeWindowsServiceHelper.cs
+++ b/src/Test/L0/Listener/Configuration/Mocks/MockNativeWindowsServiceHelper.cs
@@ -13,7 +13,7 @@ namespace Test.L0.Listener.Configuration.Mocks
     {
         public bool ShouldAccountBeManagedService { get; set; }
         public bool ShouldErrorHappenDuringManagedServiceAccoutCheck { get; set; }
-        public override uint CheckNetIsServiceAccount(string ServerName, string AccountName, ref bool isServiceAccount)
+        public override uint CheckNetIsServiceAccount(string ServerName, string AccountName, out bool isServiceAccount)
         {
             isServiceAccount = this.ShouldAccountBeManagedService;
             if (ShouldErrorHappenDuringManagedServiceAccoutCheck)

--- a/src/Test/L0/Listener/Configuration/Mocks/MockNativeWindowsServiceHelper.cs
+++ b/src/Test/L0/Listener/Configuration/Mocks/MockNativeWindowsServiceHelper.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.Services.Agent.Listener.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Test.L0.Listener.Configuration.Mocks
+{
+    /// <summary>
+    /// Mock class for NativeWindowsServiceHelper
+    /// Use this to mock any functions of this class
+    /// </summary>
+    public class MockNativeWindowsServiceHelper : NativeWindowsServiceHelper
+    {
+        public bool ShouldAccountBeManagedService { get; set; }
+        public bool ShouldErrorHappenDuringManagedServiceAccoutCheck { get; set; }
+        public override uint CheckNetIsServiceAccount(string ServerName, string AccountName, ref bool isServiceAccount)
+        {
+            isServiceAccount = this.ShouldAccountBeManagedService;
+            if (ShouldErrorHappenDuringManagedServiceAccoutCheck)
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/src/Test/L0/Listener/Configuration/NativeWindowsServiceHelperL0.cs
+++ b/src/Test/L0/Listener/Configuration/NativeWindowsServiceHelperL0.cs
@@ -11,6 +11,8 @@ using Xunit;
 using System.Security.Principal;
 using Microsoft.VisualStudio.Services.Agent;
 using Microsoft.VisualStudio.Services.Agent.Tests;
+using Test.L0.Listener.Configuration.Mocks;
+using System.ComponentModel;
 
 namespace Test.L0.Listener.Configuration
 {
@@ -52,6 +54,60 @@ namespace Test.L0.Listener.Configuration
                 trace.Info("Trying to get the Default Service Account when a DeploymentAgent is being configured");
                 var defaultServiceAccount = windowsServiceHelper.GetDefaultAdminServiceAccount();
                 Assert.True(defaultServiceAccount.ToString().Equals(@"NT AUTHORITY\SYSTEM"), "If agent is getting configured as deployment agent, default service accout should be 'NT AUTHORITY\\SYSTEM'");
+            }
+        }
+
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "ConfigurationManagement")]
+        public void EnsureIsManagedServiceAccount_TrueForManagedAccount()
+        {
+            using (TestHostContext tc = new TestHostContext(this, "EnsureIsManagedServiceAccount_TrueForManagedAccount"))
+            {
+                Tracing trace = tc.GetTrace();
+
+                trace.Info("Creating an instance of the MockNativeWindowsServiceHelper class");
+                var windowsServiceHelper = new MockNativeWindowsServiceHelper();
+                windowsServiceHelper.ShouldAccountBeManagedService = true;
+                var isManagedServiceAccount = windowsServiceHelper.IsManagedServiceAccount("managedServiceAccount$");
+
+                Assert.True(isManagedServiceAccount, "Account should be properly determined as managed service");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "ConfigurationManagement")]
+        public void EnsureIsManagedServiceAccount_FalseForNonManagedAccount()
+        {
+            using (TestHostContext tc = new TestHostContext(this, "EnsureIsManagedServiceAccount_TrueForManagedAccount"))
+            {
+                Tracing trace = tc.GetTrace();
+
+                trace.Info("Creating an instance of the MockNativeWindowsServiceHelper class");
+                var windowsServiceHelper = new MockNativeWindowsServiceHelper();
+                windowsServiceHelper.ShouldAccountBeManagedService = false;
+                var isManagedServiceAccount = windowsServiceHelper.IsManagedServiceAccount("managedServiceAccount$");
+
+                Assert.True(!isManagedServiceAccount, "Account should be properly determined as not managed service");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "ConfigurationManagement")]
+        public void EnsureIsManagedServiceAccount_ThrowsExceptionDuringCheck()
+        {
+            using (TestHostContext tc = new TestHostContext(this, "EnsureIsManagedServiceAccount_TrueForManagedAccount"))
+            {
+                Tracing trace = tc.GetTrace();
+
+                trace.Info("Creating an instance of the MockNativeWindowsServiceHelper class");
+                var windowsServiceHelper = new MockNativeWindowsServiceHelper();
+                windowsServiceHelper.ShouldErrorHappenDuringManagedServiceAccoutCheck = true;
+
+                Assert.Throws<Win32Exception>(() => windowsServiceHelper.IsManagedServiceAccount("managedServiceAccount$"));
             }
         }
     }


### PR DESCRIPTION
Currently gMSA accounts are not supported by agent.
Recovered [changes](https://github.com/microsoft/azure-pipelines-agent/compare/a5d5e507ef0089917eef73b846372fd990a76a8c..85a5dad321410dafea9d25f5979954cb6a75de0e) made previously.
Issue: https://github.com/microsoft/azure-pipelines-agent/issues/1294
Testing: tested with gmsa account on a local machine with Active Directory account, prepared unit tests for NativeWindowsServiceHelper (IsManagedServiceAccount method)