### PR TITLE
Fix for "Azure DevOps Pipelines fails git with an HTTP 400 error"

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -441,7 +441,14 @@ namespace Agent.Plugins.Repository
             return exitcode == 0;
         }
 
-        // git config --get-all <key>
+        /// <summary>
+        /// Get the value of a git config key. Values of the key can be get from latest function parameter.
+        /// git config --get-all <key>
+        /// <param name="context">Execution context of the agent tasks</param>
+        /// <param name="repositoryPath">Local repository path on agent</param>
+        /// <param name="configKey">Git config key name</param>
+        /// <param name="values">Output array of values of the key</param>
+        /// </summary>
         public async Task<bool> GitConfigExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey, IList<string> existingConfigValues)
         {
             // git config --get-all {configKey} will return 0 and print the value if the config exist.

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -441,6 +441,22 @@ namespace Agent.Plugins.Repository
             return exitcode == 0;
         }
 
+        // git config --get-all <key>
+        public async Task<bool> GitConfigExist(AgentTaskPluginExecutionContext context, string repositoryPath, string configKey, IList<string> existingConfigValues)
+        {
+            // git config --get-all {configKey} will return 0 and print the value if the config exist.
+            context.Debug($"Checking git config {configKey} exist or not");
+
+            // ignore any outputs by redirect them into a string list, since the output might contains secrets.
+            if (existingConfigValues == null)
+            {
+                existingConfigValues = new List<string>();
+            }
+
+            int exitcode = await ExecuteGitCommandAsync(context, repositoryPath, "config", StringUtil.Format($"--get-all {configKey}"), existingConfigValues);
+            return exitcode == 0;
+        }
+
         /// <summary>
         /// Verify if git config contains config key with some regex pattern
         /// git config --get-regexp <configKeyPattern>

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -657,11 +657,17 @@ namespace Agent.Plugins.Repository
                 executionContext.Debug($"Remove http.{repositoryUrl.AbsoluteUri}.extraheader setting from git config.");
                 await RemoveGitConfig(executionContext, gitCommandManager, targetPath, $"http.{repositoryUrl.AbsoluteUri}.extraheader", string.Empty);
             }
-            if (await gitCommandManager.GitConfigExist(executionContext, targetPath, $"http.extraheader"))
+
+            var existingExtraheaders = new List<string>();
+            if (await gitCommandManager.GitConfigExist(executionContext, targetPath, $"http.extraheader", existingExtraheaders))
             {
                 executionContext.Debug("Remove http.extraheader setting from git config.");
-                await RemoveGitConfig(executionContext, gitCommandManager, targetPath, $"http.extraheader", string.Empty);
+                foreach(var configValue in existingExtraheaders)
+                {
+                    await RemoveGitConfig(executionContext, gitCommandManager, targetPath, $"http.extraheader", configValue);
+                }
             }
+
             if (await gitCommandManager.GitConfigRegexExist(executionContext, targetPath, ".*extraheader"))
             {
                 executionContext.Warning($"Git config still contains extraheader keys. It may cause errors.  To remove the credential, execute \"git config --unset-all key-name\" from the repository root");


### PR DESCRIPTION
Sometimes checkout task may fail with the following message:

```
fatal: unable to access 'https://.../': The requested URL returned error: 400
Git fetch failed with exit code: 128
```

The git configuration change caused the duplicate authentication header which in turn resulted in the Http 400 error across pipeline.
I was able to reproduce this issue on my local agent by setting "http.extraheader" key in local git config with invalid value. Then I ran the build and got the same error message.

Add ability to get values of pre-existing `extraheader` configs to be able to clean up them from git config file.
Link to the ICM: https://portal.microsofticm.com/imp/v3/incidents/details/275689076/home

Tested manually on self-hosted agent with additional logic to add manually several extraheaders.