### PR TITLE
Add DumpJobEventLogs knob

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -124,6 +124,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob DumpJobEventLogs = new Knob(
             nameof(DumpJobEventLogs),
             "If set to anything, dump event viewer logs",
+            new RuntimeKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOG"),
             new EnvironmentKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOGS"),
             new BuiltInDefaultKnobSource(string.Empty));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -123,10 +123,10 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob DumpJobEventLogs = new Knob(
             nameof(DumpJobEventLogs),
-            "If set to anything, dump event viewer logs",
-            new RuntimeKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOG"),
+            "If true, dump event viewer logs",
+            new RuntimeKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOGS"),
             new EnvironmentKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOGS"),
-            new BuiltInDefaultKnobSource(string.Empty));
+            new BuiltInDefaultKnobSource("false"));
 
         // Timeouts
         public static readonly Knob AgentChannelTimeout = new Knob(

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -121,6 +121,12 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTSAGENT_TRACE"),
             new BuiltInDefaultKnobSource(string.Empty));
 
+        public static readonly Knob DumpJobEventLogs = new Knob(
+            nameof(DumpJobEventLogs),
+            "If set to anything, dump event viewer logs",
+            new EnvironmentKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOGS"),
+            new BuiltInDefaultKnobSource(string.Empty));
+
         // Timeouts
         public static readonly Knob AgentChannelTimeout = new Knob(
             nameof(AgentChannelTimeout),

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Agent.Sdk.Knob;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
@@ -161,7 +162,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
 
             // Copy event logs for windows machines
-            if (PlatformUtil.RunningOnWindows)
+            string DumpJobEventLogs = AgentKnobs.DumpJobEventLogs.GetValue(HostContext).AsString();
+            if (!string.IsNullOrEmpty(DumpJobEventLogs) && PlatformUtil.RunningOnWindows)
             {
                 executionContext.Debug("Dumping event viewer logs for current job.");
 

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -162,8 +162,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
 
             // Copy event logs for windows machines
-            string DumpJobEventLogs = AgentKnobs.DumpJobEventLogs.GetValue(HostContext).AsString();
-            if (!string.IsNullOrEmpty(DumpJobEventLogs) && PlatformUtil.RunningOnWindows)
+            bool dumpJobEventLogs = AgentKnobs.DumpJobEventLogs.GetValue(executionContext).AsBoolean();
+            if (dumpJobEventLogs && PlatformUtil.RunningOnWindows)
             {
                 executionContext.Debug("Dumping event viewer logs for current job.");
 


### PR DESCRIPTION
Added `DumpJobEventLogs` agent knob to disable dumping event logs by default
If set to true, dump event viewer logs

Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3792