### PR TITLE
Users/flsaplac/diag folder location customisable

### DIFF
--- a/src/Agent.Listener/Program.cs
+++ b/src/Agent.Listener/Program.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
             }
 
-            using (HostContext context = new HostContext("Agent"))
+            using (HostContext context = new HostContext(HostType.Agent))
             {
                 return MainAsync(context, args).GetAwaiter().GetResult();
             }

--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -556,7 +556,7 @@ You can skip checksum validation for the agent package by setting the environmen
         private string GenerateUpdateScript(bool restartInteractiveAgent)
         {
             int processId = Process.GetCurrentProcess().Id;
-            string updateLog = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Diag), $"SelfUpdate-{DateTime.UtcNow.ToString("yyyyMMdd-HHmmss")}.log");
+            string updateLog = Path.Combine(HostContext.GetDiagDirectory(), $"SelfUpdate-{DateTime.UtcNow.ToString("yyyyMMdd-HHmmss")}.log");
             string agentRoot = HostContext.GetDirectory(WellKnownDirectory.Root);
 
             string templateName = "update.sh.template";

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -144,7 +144,7 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob WorkerDiagLogPath = new Knob(
             nameof(WorkerDiagLogPath),
-            "If set to anything, the _diag folder containing the agent diag log will be created here.",
+            "If set to anything, the folder containing the agent worker diag log will be created here.",
             new EnvironmentKnobSource("WORKER_DIAGLOGPATH"),
             new BuiltInDefaultKnobSource(string.Empty));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -135,6 +135,19 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOGS"),
             new BuiltInDefaultKnobSource("false"));
 
+        // Diag logging
+        public static readonly Knob AgentDiagLogPath = new Knob(
+            nameof(AgentDiagLogPath),
+            "If set to anything, the _diag folder containing the agent diag log will be created here.",
+            new EnvironmentKnobSource("AGENT_DIAGLOGPATH"),
+            new BuiltInDefaultKnobSource(string.Empty));
+
+        public static readonly Knob WorkerDiagLogPath = new Knob(
+            nameof(WorkerDiagLogPath),
+            "If set to anything, the _diag folder containing the agent diag log will be created here.",
+            new EnvironmentKnobSource("WORKER_DIAGLOGPATH"),
+            new BuiltInDefaultKnobSource(string.Empty));
+
         // Timeouts
         public static readonly Knob AgentChannelTimeout = new Knob(
             nameof(AgentChannelTimeout),

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -138,7 +138,7 @@ namespace Agent.Sdk.Knob
         // Diag logging
         public static readonly Knob AgentDiagLogPath = new Knob(
             nameof(AgentDiagLogPath),
-            "If set to anything, the _diag folder containing the agent diag log will be created here.",
+            "If set to anything, the folder containing the agent diag log will be created here.",
             new EnvironmentKnobSource("AGENT_DIAGLOGPATH"),
             new BuiltInDefaultKnobSource(string.Empty));
 

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -83,8 +83,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             File.WriteAllText(capabilitiesFile, capabilitiesContent);
 
             // Copy worker diag log files
-            List<string> workerDiagLogFiles = GetWorkerDiagLogFiles(HostContext.GetDirectory(WellKnownDirectory.Diag), jobStartTimeUtc);
-            executionContext.Debug($"Copying {workerDiagLogFiles.Count()} worker diag logs from {HostContext.GetDirectory(WellKnownDirectory.Diag)}.");
+            List<string> workerDiagLogFiles = GetWorkerDiagLogFiles(HostContext.GetDiagDirectory(), jobStartTimeUtc);
+            executionContext.Debug($"Copying {workerDiagLogFiles.Count()} worker diag logs from {HostContext.GetDiagDirectory()}.");
 
             foreach (string workerLogFile in workerDiagLogFiles)
             {
@@ -94,9 +94,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 File.Copy(workerLogFile, destination);
             }
 
-            // Copy agent diag log files
-            List<string> agentDiagLogFiles = GetAgentDiagLogFiles(jobStartTimeUtc);
-            executionContext.Debug($"Copying {agentDiagLogFiles.Count()} agent diag logs.");
+            // Copy agent diag log files - we are using the worker Host Context and we need the diag folder form the Agent.
+            List<string> agentDiagLogFiles = GetAgentDiagLogFiles(HostContext.GetDiagDirectory(HostType.Agent), jobStartTimeUtc);
+            executionContext.Debug($"Copying {agentDiagLogFiles.Count()} agent diag logs from {HostContext.GetDiagDirectory(HostType.Agent)}.");
 
             foreach (string agentLogFile in agentDiagLogFiles)
             {
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 executionContext.Debug("Dumping cloud-init logs.");
 
-                string logsFilePath = $"{HostContext.GetDirectory(WellKnownDirectory.Diag)}/cloudinit-{jobStartTimeUtc.ToString("yyyyMMdd-HHmmss")}-logs.tar.gz";
+                string logsFilePath = $"{HostContext.GetDiagDirectory()}/cloudinit-{jobStartTimeUtc.ToString("yyyyMMdd-HHmmss")}-logs.tar.gz";
                 string resultLogs = await DumpCloudInitLogs(logsFilePath);
                 executionContext.Debug(resultLogs);
 
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 try
                 {
-                    string eventLogsFile = $"{HostContext.GetDirectory(WellKnownDirectory.Diag)}/EventViewer-{ jobStartTimeUtc.ToString("yyyyMMdd-HHmmss") }.csv";
+                    string eventLogsFile = $"{HostContext.GetDiagDirectory()}/EventViewer-{ jobStartTimeUtc.ToString("yyyyMMdd-HHmmss") }.csv";
                     await DumpCurrentJobEventLogs(executionContext, eventLogsFile, jobStartTimeUtc);
 
                     string destination = Path.Combine(supportFilesFolder, Path.GetFileName(eventLogsFile));
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             .Split("\n")
                             .Where((line) => !String.IsNullOrEmpty(line) && !line.EndsWith("OK"));
 
-                        string brokenPackagesLogsPath = $"{HostContext.GetDirectory(WellKnownDirectory.Diag)}/BrokenPackages-{ jobStartTimeUtc.ToString("yyyyMMdd-HHmmss") }.log";
+                        string brokenPackagesLogsPath = $"{HostContext.GetDiagDirectory()}/BrokenPackages-{ jobStartTimeUtc.ToString("yyyyMMdd-HHmmss") }.log";
                         File.AppendAllLines(brokenPackagesLogsPath, brokenPackagesInfo);
 
                         string destination = Path.Combine(supportFilesFolder, Path.GetFileName(brokenPackagesLogsPath));
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             executionContext.Debug($"Path to agent extension logs: {pathToLogs}");
 
-            string archivePath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Diag), archiveName);
+            string archivePath = Path.Combine(HostContext.GetDiagDirectory(), archiveName);
             executionContext.Debug($"Archiving agent extension logs to: {archivePath}");
             ZipFile.CreateFromDirectory(pathToLogs, archivePath);
 
@@ -416,7 +416,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             int bufferInSeconds = -30;
             DateTime searchTimeUtc = jobStartTimeUtc.AddSeconds(bufferInSeconds);
 
-            foreach (FileInfo file in directoryInfo.GetFiles().Where(f => f.Name.StartsWith("Worker_")))
+            foreach (FileInfo file in directoryInfo.GetFiles().Where(f => f.Name.StartsWith($"{HostType.Worker}_")))
             {
                 // The format of the logs is:
                 // Worker_20171003-143110-utc.log
@@ -431,18 +431,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return workerLogFiles;
         }
 
-        private List<string> GetAgentDiagLogFiles(DateTime jobStartTimeUtc)
+        private List<string> GetAgentDiagLogFiles(string diagFolder, DateTime jobStartTimeUtc)
         {
-            // Since this is the Worker context, we still want to fetch the Agent _diag folder.
-            // This might have been overriden by the envrionment variable.
-            // TODO: this is a hacky way to do it, maybe it should be a config value
-            var diagFolder = Environment.GetEnvironmentVariable($"AGENT_DIAGLOGPATH");
-            if (string.IsNullOrEmpty(diagFolder))
-            {
-                diagFolder = HostContext.GetDirectory(WellKnownDirectory.Root);
-            }
-            diagFolder = Path.Join(diagFolder, Constants.Path.DiagDirectory);
-
             // Get the newest agent log file that created just before the start of the job
             var agentLogFiles = new List<string>();
             var directoryInfo = new DirectoryInfo(diagFolder);
@@ -454,7 +444,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             String recentLog = null;
             DateTime recentTimeUtc = DateTime.MinValue;
 
-            foreach (FileInfo file in directoryInfo.GetFiles().Where(f => f.Name.StartsWith("Agent_")))
+            foreach (FileInfo file in directoryInfo.GetFiles().Where(f => f.Name.StartsWith($"{HostType.Agent}_")))
             {
                 // The format of the logs is:
                 // Agent_20171003-143110-utc.log

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             // Copy worker diag log files
             List<string> workerDiagLogFiles = GetWorkerDiagLogFiles(HostContext.GetDirectory(WellKnownDirectory.Diag), jobStartTimeUtc);
-            executionContext.Debug($"Copying {workerDiagLogFiles.Count()} from {HostContext.GetDirectory(WellKnownDirectory.Diag)} worker diag logs.");
+            executionContext.Debug($"Copying {workerDiagLogFiles.Count()} worker diag logs from {HostContext.GetDirectory(WellKnownDirectory.Diag)}.");
 
             foreach (string workerLogFile in workerDiagLogFiles)
             {

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (_disableLogUploads)
             {
-                _buildLogsFolderPath = Path.Combine(hostContext.GetDirectory(WellKnownDirectory.Diag), _buildLogsFolderName);
+                _buildLogsFolderPath = Path.Combine(hostContext.GetDiagDirectory(), _buildLogsFolderName);
                 Directory.CreateDirectory(_buildLogsFolderPath);
             }
 

--- a/src/Agent.Worker/Program.cs
+++ b/src/Agent.Worker/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 AppContext.SetSwitch("System.Net.Http.UseSocketsHttpHandler", false);
             }
 
-            using (HostContext context = new HostContext("Worker"))
+            using (HostContext context = new HostContext(HostType.Worker))
             {
                 return MainAsync(context, args).GetAwaiter().GetResult();
             }

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.Services.Agent
     public enum WellKnownDirectory
     {
         Bin,
-        Diag,
         Externals,
         LegacyPSHost,
         Root,

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -115,8 +115,13 @@ namespace Microsoft.VisualStudio.Services.Agent
                     logRetentionDays = _defaultLogRetentionDays;
                 }
 
-                // this should give us _diag folder under agent root directory
+                // this should give us _diag folder under agent root directory as default value for diagLogDirctory
                 string diagLogDirectory = Path.Combine(new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)).Parent.FullName, Constants.Path.DiagDirectory);
+                string diagLogDirectoryEnv = Environment.GetEnvironmentVariable($"{hostType.ToUpperInvariant()}_DIAGLOGPATH");
+                if (!string.IsNullOrEmpty(diagLogDirectoryEnv))
+                {
+                    diagLogDirectory = Path.Combine(diagLogDirectoryEnv, Constants.Path.DiagDirectory);
+                }
                 _traceManager = new TraceManager(new HostTraceListener(diagLogDirectory, hostType, logPageSize, logRetentionDays), this.SecretMasker);
             }
             else

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -127,6 +127,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             }
             else
             {
+                _diagLogPath = Path.GetDirectoryName(logFile);
                 _traceManager = new TraceManager(new HostTraceListener(logFile), this.SecretMasker);
             }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -73,6 +73,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         private IDisposable _diagListenerSubscription;
         private StartupType _startupType;
         private string _perfFile;
+        private string _diagLogPath;
         public event EventHandler Unloading;
         public CancellationToken AgentShutdownToken => _agentShutdownTokenSource.Token;
         public ShutdownReason AgentShutdownReason { get; private set; }
@@ -116,13 +117,13 @@ namespace Microsoft.VisualStudio.Services.Agent
                 }
 
                 // this should give us _diag folder under agent root directory as default value for diagLogDirctory
-                string diagLogDirectory = Path.Combine(new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)).Parent.FullName, Constants.Path.DiagDirectory);
+                _diagLogPath = Path.Combine(new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)).Parent.FullName, Constants.Path.DiagDirectory);
                 string diagLogDirectoryEnv = Environment.GetEnvironmentVariable($"{hostType.ToUpperInvariant()}_DIAGLOGPATH");
                 if (!string.IsNullOrEmpty(diagLogDirectoryEnv))
                 {
-                    diagLogDirectory = Path.Combine(diagLogDirectoryEnv, Constants.Path.DiagDirectory);
+                    _diagLogPath = Path.Combine(diagLogDirectoryEnv, Constants.Path.DiagDirectory);
                 }
-                _traceManager = new TraceManager(new HostTraceListener(diagLogDirectory, hostType, logPageSize, logRetentionDays), this.SecretMasker);
+                _traceManager = new TraceManager(new HostTraceListener(_diagLogPath, hostType, logPageSize, logRetentionDays), this.SecretMasker);
             }
             else
             {
@@ -174,9 +175,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                     break;
 
                 case WellKnownDirectory.Diag:
-                    path = Path.Combine(
-                        GetDirectory(WellKnownDirectory.Root),
-                        Constants.Path.DiagDirectory);
+                    path = _diagLogPath;
                     break;
 
                 case WellKnownDirectory.Externals:

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -281,11 +281,14 @@ namespace Microsoft.VisualStudio.Services.Agent
 
         private string GetDiagOrDefault(string diagFolder)
         {
-            if (string.IsNullOrEmpty(diagFolder))
+            if (!string.IsNullOrEmpty(diagFolder))
             {
-                diagFolder = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)).Parent.FullName;
-            } 
-            return Path.Combine(diagFolder, Constants.Path.DiagDirectory);
+                return diagFolder;
+            }
+           
+            return Path.Combine(
+                new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)).Parent.FullName,
+                Constants.Path.DiagDirectory);          
         }
 
         public string GetConfigFile(WellKnownConfigFile configFile)

--- a/src/Microsoft.VisualStudio.Services.Agent/Logging.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Logging.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             base.Initialize(hostContext);
             _totalLines = 0;
             _pageId = Guid.NewGuid().ToString();
-            _pagesFolder = Path.Combine(hostContext.GetDirectory(WellKnownDirectory.Diag), PagingFolder);
+            _pagesFolder = Path.Combine(hostContext.GetDiagDirectory(), PagingFolder);
             _jobServerQueue = HostContext.GetService<IJobServerQueue>();
             Directory.CreateDirectory(_pagesFolder);
         }

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -124,12 +124,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             try
             {
                 var newPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "logs");
-                Environment.SetEnvironmentVariable("L0TEST_DIAGLOGPATH", newPath);
+                Environment.SetEnvironmentVariable("AGENT_DIAGLOGPATH", newPath);
 
-                using (var _hc = new HostContext("L0Test"))
+                using (var _hc = new HostContext(HostType.Agent))
                 {
                     // Act.
-                    var diagFolder = _hc.GetDirectory(WellKnownDirectory.Diag);
+                    var diagFolder = _hc.GetDiagDirectory();
 
                     // Assert
                     Assert.Equal(Path.Combine(newPath, Constants.Path.DiagDirectory), diagFolder);
@@ -138,14 +138,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
             finally
             {
-                Environment.SetEnvironmentVariable("L0TEST_DIAGLOGPATH", null);
+                Environment.SetEnvironmentVariable("AGENT_DIAGLOGPATH", null);
             }
         }
 
         public HostContext Setup([CallerMemberName] string testName = "")
         {
             return new HostContext(
-                hostType: "L0Test",
+                hostType: HostType.Agent,
                 logFile: Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), $"trace_{nameof(HostContextL0)}_{testName}.log"));
         }
     }

--- a/src/Test/L0/HostContextL0.cs
+++ b/src/Test/L0/HostContextL0.cs
@@ -118,6 +118,30 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
         }
 
+        [Fact]
+        public void LogFileChangedAccordingToEnvVariable()
+        {
+            try
+            {
+                var newPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "logs");
+                Environment.SetEnvironmentVariable("L0TEST_DIAGLOGPATH", newPath);
+
+                using (var _hc = new HostContext("L0Test"))
+                {
+                    // Act.
+                    var diagFolder = _hc.GetDirectory(WellKnownDirectory.Diag);
+
+                    // Assert
+                    Assert.Equal(Path.Combine(newPath, Constants.Path.DiagDirectory), diagFolder);
+                    Directory.Exists(diagFolder);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("L0TEST_DIAGLOGPATH", null);
+            }
+        }
+
         public HostContext Setup([CallerMemberName] string testName = "")
         {
             return new HostContext(

--- a/src/Test/L0/PagingLoggerL0.cs
+++ b/src/Test/L0/PagingLoggerL0.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
             using (TestHostContext hc = new TestHostContext(this))
             {
                 //clean test data if any old test forgot
-                string pagesFolder = Path.Combine(hc.GetDirectory(WellKnownDirectory.Diag), PagingLogger.PagingFolder);
+                string pagesFolder = Path.Combine(hc.GetDiagDirectory(), PagingLogger.PagingFolder);
                 if (Directory.Exists(pagesFolder))
                 {
                     Directory.Delete(pagesFolder, true);

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -179,12 +179,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
                     break;
 
-                case WellKnownDirectory.Diag:
-                    path = Path.Combine(
-                        GetDirectory(WellKnownDirectory.Root),
-                        Constants.Path.DiagDirectory);
-                    break;
-
                 case WellKnownDirectory.Externals:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Root),
@@ -265,6 +259,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
 
             _trace.Info($"Well known directory '{directory}': '{path}'");
             return path;
+        }
+
+        public string GetDiagDirectory(HostType hostType = HostType.Undefined)
+        {
+            return Path.Combine(
+                        GetDirectory(WellKnownDirectory.Root),
+                        Constants.Path.DiagDirectory);
         }
 
         public string GetConfigFile(WellKnownConfigFile configFile)

--- a/src/Test/L1/L1HostContext.cs
+++ b/src/Test/L1/L1HostContext.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
 {
     public class L1HostContext : HostContext
     {
-        public L1HostContext(string hostType, string logFile = null)
+        public L1HostContext(HostType hostType, string logFile = null)
             : base(hostType, logFile)
         {
         }

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             var stringFile = Path.Combine(assemblyLocation, "en-US", "strings.json");
             StringUtil.LoadExternalLocalization(stringFile);
 
-            _l1HostContext = new L1HostContext("Agent", GetLogFile(this, testName));
+            _l1HostContext = new L1HostContext(HostType.Agent, GetLogFile(this, testName));
             SetupMocks(_l1HostContext);
 
             // Use different working directories for each test


### PR DESCRIPTION
Use one of the following environement variables
AGENT_LOGDIAGPATH 
WORKER_LOGDIAGPATH

To customize the location of the _diag folder path. By default the location of this folder will be in the agent directory. By overriding this in an environment variable it will be placed in a _diag folder in the specified folder.
 