### PR TITLE
Maintenance job - make maintenance operation for source provider independent on build directory clean up time interval

### DIFF
--- a/src/Agent.Worker/Build/WorkspaceMaintenanceProvider.cs
+++ b/src/Agent.Worker/Build/WorkspaceMaintenanceProvider.cs
@@ -87,17 +87,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 // scan unused build directories
                 executionContext.Output(StringUtil.Loc("DiscoverBuildDir", staleBuildDirThreshold));
                 trackingManager.MarkExpiredForGarbageCollection(executionContext, TimeSpan.FromDays(staleBuildDirThreshold));
+
+                executionContext.Output(StringUtil.Loc("GCBuildDir"));
+
+                // delete unused build directories
+                trackingManager.DisposeCollectedGarbage(executionContext);
             }
             else
             {
                 executionContext.Output(StringUtil.Loc("GCBuildDirNotEnabled"));
-                return false;
             }
-
-            executionContext.Output(StringUtil.Loc("GCBuildDir"));
-
-            // delete unused build directories
-            trackingManager.DisposeCollectedGarbage(executionContext);
 
             // give source provider a chance to run maintenance operation
             Trace.Info("Scan all SourceFolder tracking files.");


### PR DESCRIPTION
Currently maintenance operation is not being called if "Days to keep unused working directories" parameter is set as 0 (meaning that it should be kept forever)
Although removal of stale build directories and source folders maintenance are different routines - and maintenance of source folders should run even if removal of stale build directories is disabled.
Related issue - https://github.com/microsoft/azure-pipelines-agent/issues/3805

Testing/unit tests - in progress