### PR TITLE
Update links in installdependencies.sh

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -24,7 +24,7 @@ function print_errormessage()
     echo "Can't install dotnet core dependencies."
     print_repositories_and_deps_warning
     echo "You can manually install all required dependencies based on following documentation"
-    echo "https://docs.microsoft.com/en-us/dotnet/core/dependencies?pivots=os-linux&tabs=netcore31"
+    echo "https://docs.microsoft.com/dotnet/core/install/linux"
 }
 
 function print_rhel6message() 
@@ -33,7 +33,7 @@ function print_rhel6message()
     echo "However, there are some dependencies which require manual installation"
     print_repositories_and_deps_warning
     echo "You can install all remaining required dependencies based on the following documentation"
-    echo "https://github.com/dotnet/core/blob/master/Documentation/build-and-install-rhel6-prerequisites.md"
+    echo "https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md"
 }
 
 function print_rhel6errormessage() 
@@ -41,9 +41,9 @@ function print_rhel6errormessage()
     echo "We couldn't install dotnet core dependencies"
     print_repositories_and_deps_warning
     echo "You can manually install all required dependencies based on following documentation"
-    echo "https://docs.microsoft.com/en-us/dotnet/core/dependencies?pivots=os-linux&tabs=netcore31"
+    echo "https://docs.microsoft.com/dotnet/core/install/linux"
     echo "In addition, there are some dependencies which require manual installation. Please follow this documentation" 
-    echo "https://github.com/dotnet/core/blob/master/Documentation/build-and-install-rhel6-prerequisites.md"
+    echo "https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md"
 }
 
 if [ -e /etc/os-release ]


### PR DESCRIPTION
Updated links to dotnet core prereqs to match the documentation ([prereqs.md](https://github.com/dotnet/core/blob/main/Documentation/prereqs.md) and [build-and-install-rhel6-prerequisites.md](https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md))

Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3801