### PR TITLE
Added knob for debsums verification

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -315,5 +315,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("TEE_PLUGIN_DOWNLOAD_RETRY_COUNT"),
             new EnvironmentKnobSource("TEE_PLUGIN_DOWNLOAD_RETRY_COUNT"),
             new BuiltInDefaultKnobSource("3"));
+
+        public static readonly Knob DumpPackagesVerificationResult = new Knob(
+            nameof(DumpPackagesVerificationResult),
+            "If true, dump packages verification results",
+            new RuntimeKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
+            new EnvironmentKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -182,7 +182,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
             }
 
-            if (PlatformUtil.RunningOnLinux && !PlatformUtil.RunningOnRHEL6) {
+            bool dumpPackagesVerificationResult = AgentKnobs.DumpPackagesVerificationResult.GetValue(executionContext).AsBoolean();
+            if (dumpPackagesVerificationResult && PlatformUtil.RunningOnLinux && !PlatformUtil.RunningOnRHEL6) {
                 executionContext.Debug("Dumping info about invalid MD5 sums of installed packages.");
 
                 var debsums = WhichUtil.Which("debsums");


### PR DESCRIPTION
If VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS environment or runtime variable is set to true, debsums verification is executed.

Tested manually in diagnostic mode with enabled and disabled values on Ubuntu 16.04.