### PR TITLE
Control ServiceNamePattern for more control

### DIFF
--- a/src/Agent.Listener/CommandLine/ConfigureAgent.cs
+++ b/src/Agent.Listener/CommandLine/ConfigureAgent.cs
@@ -90,6 +90,12 @@ namespace Agent.Listener.CommandLine
         [Option(Constants.Agent.CommandLine.Args.ProxyPassword)]
         public string ProxyPassword { get; set; }
 
+        [Option(Constants.Agent.CommandLine.Args.ServiceDisplayNamePattern)]
+        public string ServiceDisplayNamePattern { get; set; }
+
+        [Option(Constants.Agent.CommandLine.Args.ServiceNamePattern)]
+        public string ServiceNamePattern { get; set; }
+
         [Option(Constants.Agent.CommandLine.Args.ProxyUserName)]
         public string ProxyUserName { get; set; }
 

--- a/src/Agent.Listener/CommandSettings.cs
+++ b/src/Agent.Listener/CommandSettings.cs
@@ -452,6 +452,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         {
             return GetArg(Configure?.ProxyPassword, Constants.Agent.CommandLine.Args.ProxyPassword);
         }
+        public string GetServiceDisplayNamePattern()
+        {
+            return GetArg(Configure?.ServiceDisplayNamePattern, Constants.Agent.CommandLine.Args.ServiceDisplayNamePattern);
+        }
+
+        public string GetServiceNamePattern()
+        {
+            return GetArg(Configure?.ServiceNamePattern, Constants.Agent.CommandLine.Args.ServiceNamePattern);
+        }
 
         public bool GetSkipCertificateValidation()
         {

--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -94,7 +94,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
             string serviceName;
             string serviceDisplayName;
-            CalculateServiceName(settings, ServiceNamePattern, ServiceDisplayNamePattern, out serviceName, out serviceDisplayName);
+
+            string serviceNamePattern = command.GetServiceNamePattern() ?? ServiceNamePattern;
+            string serviceDisplayNamePattern = command.GetServiceDisplayNamePattern() ?? ServiceDisplayNamePattern;
+
+            CalculateServiceName(settings, serviceNamePattern, serviceDisplayNamePattern, out serviceName, out serviceDisplayName);
             if (_windowsServiceHelper.IsServiceExists(serviceName))
             {
                 _term.WriteLine(StringUtil.Loc("ServiceAlreadyExists", serviceName));

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -97,6 +97,8 @@ namespace Microsoft.VisualStudio.Services.Agent
                     public const string ProjectName = "projectname";
                     public const string ProxyUrl = "proxyurl";
                     public const string ProxyUserName = "proxyusername";
+                    public const string ServiceDisplayNamePattern = "servicedisplaynamepattern";
+                    public const string ServiceNamePattern = "servicenamepattern";
                     public const string SslCACert = "sslcacert";
                     public const string SslClientCert = "sslclientcert";
                     public const string SslClientCertKey = "sslclientcertkey";
@@ -472,6 +474,8 @@ namespace Microsoft.VisualStudio.Services.Agent
                 Agent.RootDirectory,
                 Agent.RunMode,
                 Agent.ServerOMDirectory,
+                Agent.ServiceDisplayNamePattern,
+                Agent.ServiceNamePattern,
                 Agent.ServicePortPrefix,
                 Agent.SslCAInfo,
                 Agent.SslClientCert,


### PR DESCRIPTION
Current `CalculateServiceName` method truncates long service names to meet 80 character limit, but does not give users much control over how this truncation happens.

Our organisation has a long collection name (24 chars), long pool/environment names (25+ characters), and the agent name conveys meaning (typically server name and another discriminator). Unfortunately we can't shorten the collection name, and project teams are in control of their own pool/environment names and have little concern for pipeline agents.

As such, we frequently run into issues whereby multiple agents on the same machine end up with the same truncated service names, meaning the install fails. 

This PR allows us to better control the Service name, by (for example) using a short prefix instead of full collection name (by using, for example, `VSTS_AGENT_INPUT_ServiceNamePattern = 'vstsagent.ACRONYM.{1}{2}'`, i.e. skipping collection name for a hardcoded value), or completely overriding it on a case-by-case basis.
