### PR TITLE
Run maintenance operations for all repos in RepositoryTrackingInfo

### DIFF
--- a/src/Agent.Worker/Build/WorkspaceMaintenanceProvider.cs
+++ b/src/Agent.Worker/Build/WorkspaceMaintenanceProvider.cs
@@ -49,7 +49,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             // Sort the all tracking file ASC by last maintenance attempted time
             foreach (var trackingConfig in trackingConfigs.OrderBy(x => x.LastMaintenanceAttemptedOn))
             {
-                System.Diagnostics.Debugger.Launch();
                 // Check for cancellation.
                 executionContext.CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Agent.Worker/Build/WorkspaceMaintenanceProvider.cs
+++ b/src/Agent.Worker/Build/WorkspaceMaintenanceProvider.cs
@@ -49,6 +49,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             // Sort the all tracking file ASC by last maintenance attempted time
             foreach (var trackingConfig in trackingConfigs.OrderBy(x => x.LastMaintenanceAttemptedOn))
             {
+                System.Diagnostics.Debugger.Launch();
                 // Check for cancellation.
                 executionContext.CancellationToken.ThrowIfCancellationRequested();
 
@@ -167,8 +168,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 try
                 {
                     trackingManager.MaintenanceStarted(trackingConfig);
-                    string repositoryPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), trackingConfig.SourcesDirectory);
-                    await sourceProvider.RunMaintenanceOperations(executionContext, repositoryPath);
+                    foreach(var repository in trackingConfig.RepositoryTrackingInfo)
+                    {
+                        string repositoryPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), repository.SourcesDirectory);
+                        await sourceProvider.RunMaintenanceOperations(executionContext, repositoryPath);
+                    }
                     trackingManager.MaintenanceCompleted(trackingConfig);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
SourceFolder.json has `RepositoryTrackingInfo` property where all fetched repos are listed.
Previously, we only ran maintenance operations for `build_sourcesdirectory`
Fixed this to run for sources directories from `RepositoryTrackingInfo`

<pre>
{
  "build_artifactstagingdirectory": "2\\a",
  "agent_builddirectory": "2",
  "collectionUrl": "https://dev.azure.com/org/",
  "definitionName": "multi-stage-with-resources",
  "repositoryTrackingInfo": [
    {
      "identifier": "self",
      "repositoryType": "Git",
      "repositoryUrl": "https://org@dev.azure.com/proj/test/_git/test",
      <b>"sourcesDirectory": "2\\Projects\\Cores\\test"</b>
    },
    {
      "identifier": "test2",
      "repositoryType": "git",
      "repositoryUrl": "https://org@dev.azure.com/proj/test/_git/test2",
      <b>"sourcesDirectory": "2\\Projects\\Cores\\test2"</b>
    }
  ],
  "fileFormatVersion": 3,
  "lastRunOn": "04/19/2022 11:19:12 +03:00",
  "repositoryType": "Git",
  "lastMaintenanceAttemptedOn": "04/21/2022 17:32:06 +03:00",
  "lastMaintenanceCompletedOn": "04/21/2022 17:32:11 +03:00",
  <b>"build_sourcesdirectory": "2\\s",</b>
  "common_testresultsdirectory": "2\\TestResults",
  "collectionId": "240741e6-a501-4c02-b604-5a6394254a7e",
  "definitionId": "11",
}
<pre>