### PR TITLE
Removed NPM module and executable which comes with NodeJS fox non windows distribution

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -211,6 +211,13 @@ if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-arm64.tar.gz" node10 fix_nested_dir
 fi
 
+if [[ "$PACKAGERUNTIME" != "win-x64" || "$PACKAGERUNTIME" != "win-x86" ]]; then
+    rm -rf "$LAYOUT_DIR/externals/node/lib/node_modules/npm"
+    rm "$LAYOUT_DIR/externals/node/bin/npm"
+    rm -rf "$LAYOUT_DIR/externals/node10/lib/node_modules/npm"
+    rm "$LAYOUT_DIR/externals/node10/bin/npm"
+fi
+
 if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then
     # cmdline task
     acquireExternalTool "$CONTAINER_URL/l1Tasks/d9bafed4-0b18-4f58-968d-86655b4d2ce9.zip" "Tasks" false dont_uncompress

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -211,7 +211,7 @@ if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-arm64.tar.gz" node10 fix_nested_dir
 fi
 
-if [[ "$PACKAGERUNTIME" != "win-x64" || "$PACKAGERUNTIME" != "win-x86" ]]; then
+if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
     rm -rf "$LAYOUT_DIR/externals/node/lib/node_modules/npm"
     rm "$LAYOUT_DIR/externals/node/bin/npm"
     rm -rf "$LAYOUT_DIR/externals/node10/lib/node_modules/npm"


### PR DESCRIPTION
The NPM and its dependencies, which are bundled with NodeJS 6 and 10, have a lot of vulnerabilities and had generated a lot of component governance bugs recently. When we layout the agent we copy NodeJS the files from https://nodejs.org/dist/v6.17.1 and put them into _externals folder. Along with NodeJS executable we copy node package manager (NPM).

The NPM resides in the _externals/node/bin  folder and its dependies are in inside _external/node/lib/node_modules folder. The NPM is not being used by the agent and can be removed. The agent version for  windows doesn't include the NPM in the current version. By removing the NPM and it's node modules, not only we will make versions to be more consistent, but also fix potential component governance bugs in the future.