### PR TITLE
Add retries to `docker login` to handle flakiness with docker container

### DIFF
--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -209,7 +209,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         retryCount++;
                         if (retryCount < maxRetries)
                         {
-                            var backOff = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
+                            TimeSpan backOff = BackoffTimerHelper.GetExponentialBackoff(retryCount, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(2));
                             executionContext.Warning($"Docker login failed with exit code {pullExitCode}, back off {backOff.TotalSeconds} seconds before retry.");
                             await Task.Delay(backOff);
                         }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                 }
 
-                if (retryCount == 3 && pullExitCode != 0)
+                if (retryCount == maxRetries && pullExitCode != 0)
                 {
                     throw new InvalidOperationException($"Docker login fail with exit code {loginExitCode}");
                 }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 ArgUtil.NotNullOrEmpty(password, nameof(password));
 
 
-                // Pull down docker image with retry up to 3 times
+                // login with retry up to 3 times
                 int retryCount = 0;
                 int loginExitCode = 0;
 

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -193,10 +193,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
 
                 // login with retry up to 3 times
+                int maxRetries = 3;
                 int retryCount = 0;
                 int loginExitCode = 0;
 
-                while (retryCount < 3)
+                while (retryCount < maxRetries)
                 {
                     loginExitCode = await _dockerManger.DockerLogin(executionContext, registryServer, username, password);
                     if (loginExitCode == 0)
@@ -206,7 +207,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     else
                     {
                         retryCount++;
-                        if (retryCount < 3)
+                        if (retryCount < maxRetries)
                         {
                             var backOff = BackoffTimerHelper.GetRandomBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10));
                             executionContext.Warning($"Docker login failed with exit code {pullExitCode}, back off {backOff.TotalSeconds} seconds before retry.");


### PR DESCRIPTION
Frequently we are seeing flakiness with our docker container host and it is unfortunately failing our pipelines.

We would really want to have this retry instead of failing the entire pipeline.


```
##[debug]Evaluating condition for step: 'Initialize containers'
##[debug]Evaluating: SucceededNode()
##[debug]Evaluating SucceededNode:
##[debug]=> True
##[debug]Result: True
Starting: Initialize containers
/usr/bin/docker version --format '{{.Server.APIVersion}}'
'1.41'
Docker daemon API version: '1.41'
/usr/bin/docker version --format '{{.Client.APIVersion}}'
'1.41'
Docker client API version: '1.41'
##[debug]Delete stale containers from previous jobs
/usr/bin/docker ps --all --quiet --no-trunc --filter "label=***"
##[debug]Delete stale container networks from previous jobs
/usr/bin/docker network prune --force --filter "label=***"
/usr/bin/docker login --username "***" --password-stdin ***
Error response from daemon: Get ***: dial tcp ***: connect: connection refused
##[error]Docker login fail with exit code 1
##[debug]System.InvalidOperationException: Docker login fail with exit code 1
```