### PR TITLE
Added message - in case when account is not managed, but WindowsLogon…

### DIFF
--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -71,11 +71,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 !_windowsServiceHelper.IsWellKnownIdentity(logonAccount) &&
                 !_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
             {
-               if (!_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
-                {
                     while (true)
                     {
-                        logonPassword = command.GetWindowsLogonPassword(logonAccount);
+                        try
+                        {
+                            logonPassword = command.GetWindowsLogonPassword(logonAccount);
+                        }
+                        catch (ArgumentException e)
+                        {
+                            Trace.Warning("LogonAccount {0} is not managed service account, although you did not specify WindowsLogonPassword - maybe you wanted to use managed service account? Please see https://aka.ms/gmsa for guidelines to set up sMSA/gMSA account.", logonAccount, userName, domainName);
+                            throw;
+                        }
+
                         if (_windowsServiceHelper.IsValidCredential(domainName, userName, logonPassword))
                         {
                             Trace.Info("Credential validation succeed");
@@ -94,10 +101,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                             }
                         }
                     }
-                } else
-                {
-                    Trace.Info("LogonAccount {0} is not managed service account, although you did not specify WindowsLogonPassword - maybe you wanted to use managed service account? Please see https://aka.ms/gmsa for guidelines to set up sMSA/gMSA account.", logonAccount, userName, domainName);
-                }
             }
 
             string serviceName;

--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -71,36 +71,36 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 !_windowsServiceHelper.IsWellKnownIdentity(logonAccount) &&
                 !_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
             {
-                    while (true)
+                while (true)
+                {
+                    try
                     {
-                        try
-                        {
-                            logonPassword = command.GetWindowsLogonPassword(logonAccount);
-                        }
-                        catch (ArgumentException e)
-                        {
-                            Trace.Warning("LogonAccount {0} is not managed service account, although you did not specify WindowsLogonPassword - maybe you wanted to use managed service account? Please see https://aka.ms/gmsa for guidelines to set up sMSA/gMSA account.", logonAccount, userName, domainName);
-                            throw;
-                        }
+                        logonPassword = command.GetWindowsLogonPassword(logonAccount);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        Trace.Warning("LogonAccount {0} is not managed service account, although you did not specify WindowsLogonPassword - maybe you wanted to use managed service account? Please see https://aka.ms/gmsa for guidelines to set up sMSA/gMSA account.", logonAccount, userName, domainName);
+                        throw;
+                    }
 
-                        if (_windowsServiceHelper.IsValidCredential(domainName, userName, logonPassword))
+                    if (_windowsServiceHelper.IsValidCredential(domainName, userName, logonPassword))
+                    {
+                        Trace.Info("Credential validation succeed");
+                        break;
+                    }
+                    else
+                    {
+                        if (!command.Unattended())
                         {
-                            Trace.Info("Credential validation succeed");
-                            break;
+                            Trace.Info("Invalid credential entered");
+                            _term.WriteLine(StringUtil.Loc("InvalidWindowsCredential"));
                         }
                         else
                         {
-                            if (!command.Unattended())
-                            {
-                                Trace.Info("Invalid credential entered");
-                                _term.WriteLine(StringUtil.Loc("InvalidWindowsCredential"));
-                            }
-                            else
-                            {
-                                throw new SecurityException(StringUtil.Loc("InvalidWindowsCredential"));
-                            }
+                            throw new SecurityException(StringUtil.Loc("InvalidWindowsCredential"));
                         }
                     }
+                }
             }
 
             string serviceName;

--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -71,26 +71,32 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 !_windowsServiceHelper.IsWellKnownIdentity(logonAccount) &&
                 !_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
             {
-                while (true)
+               if (!_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
                 {
-                    logonPassword = command.GetWindowsLogonPassword(logonAccount);
-                    if (_windowsServiceHelper.IsValidCredential(domainName, userName, logonPassword))
+                    while (true)
                     {
-                        Trace.Info("Credential validation succeed");
-                        break;
-                    }
-                    else
-                    {
-                        if (!command.Unattended())
+                        logonPassword = command.GetWindowsLogonPassword(logonAccount);
+                        if (_windowsServiceHelper.IsValidCredential(domainName, userName, logonPassword))
                         {
-                            Trace.Info("Invalid credential entered");
-                            _term.WriteLine(StringUtil.Loc("InvalidWindowsCredential"));
+                            Trace.Info("Credential validation succeed");
+                            break;
                         }
                         else
                         {
-                            throw new SecurityException(StringUtil.Loc("InvalidWindowsCredential"));
+                            if (!command.Unattended())
+                            {
+                                Trace.Info("Invalid credential entered");
+                                _term.WriteLine(StringUtil.Loc("InvalidWindowsCredential"));
+                            }
+                            else
+                            {
+                                throw new SecurityException(StringUtil.Loc("InvalidWindowsCredential"));
+                            }
                         }
                     }
+                } else
+                {
+                    Trace.Info("LogonAccount {0} is not managed service account, although you did not specify WindowsLogonPassword - maybe you wanted to use managed service account? Please see https://aka.ms/gmsa for guidelines to set up sMSA/gMSA account.", logonAccount, userName, domainName);
                 }
             }
 


### PR DESCRIPTION
Added message with link to the managed account set up [guidelines](https://aka.ms/gmsa) for the case when there is a user name specified during configuration (via `windowslogonaccount`), but password is omitted.
Testing - checked that warning message appears for not managed account if password is not specified, and does not appear for other cases.