### PR TITLE
Add getting SqlPackage capability from Visual Studio 2022

### DIFF
--- a/src/Misc/layoutbin/powershell/Add-SqlPackageCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-SqlPackageCapabilities.ps1
@@ -77,36 +77,17 @@ function Get-MaxInfoFromSqlServerDtaf {
     }
 }
 
-function Get-MaxInfoFromVisualStudio_15_0 {
+function Get-MaxInfoFromVisualStudioByVersion {
     [CmdletBinding()]
-    param()
+    param([int] $VersionNumber)
 
-    $vs15 = Get-VisualStudio -MajorVersion 15
-    if ($vs15 -and $vs15.installationPath) {
+    $vs = Get-VisualStudio -MajorVersion $VersionNumber
+    if ($vs -and $vs.installationPath) {
         # End with "\" for consistency with old ShellFolder values.
-        $shellFolder15 = $vs15.installationPath.TrimEnd('\'[0]) + "\"
+        $shellFolder = $vs.installationPath.TrimEnd('\'[0]) + "\"
 
         # Test for the DAC directory.
-        $dacDirectory = [System.IO.Path]::Combine($shellFolder15, 'Common7', 'IDE', 'Extensions', 'Microsoft', 'SQLDB', 'DAC')
-        $sqlPacakgeInfo = Get-SqlPacakgeFromDacDirectory -dacDirectory $dacDirectory
-
-        if($sqlPacakgeInfo -and $sqlPacakgeInfo.File) {
-            return $sqlPacakgeInfo
-        }
-    }
-}
-
-function Get-MaxInfoFromVisualStudio_16_0 {
-    [CmdletBinding()]
-    param()
-
-    $vs16 = Get-VisualStudio -MajorVersion 16
-    if ($vs16 -and $vs16.installationPath) {
-        # End with "\" for consistency with old ShellFolder values.
-        $shellFolder16 = $vs16.installationPath.TrimEnd('\'[0]) + "\"
-
-        # Test for the DAC directory.
-        $dacDirectory = [System.IO.Path]::Combine($shellFolder16, 'Common7', 'IDE', 'Extensions', 'Microsoft', 'SQLDB', 'DAC')
+        $dacDirectory = [System.IO.Path]::Combine($shellFolder, 'Common7', 'IDE', 'Extensions', 'Microsoft', 'SQLDB', 'DAC')
         $sqlPacakgeInfo = Get-SqlPacakgeFromDacDirectory -dacDirectory $dacDirectory
 
         if($sqlPacakgeInfo -and $sqlPacakgeInfo.File) {
@@ -190,8 +171,8 @@ $sqlPackageInfo = @( )
 $sqlPackageInfo += (Get-MaxInfoFromSqlServer)
 $sqlPackageInfo += (Get-MaxInfoFromSqlServerDtaf)
 $sqlPackageInfo += (Get-MaxInfoFromVisualStudio)
-$sqlPackageInfo += (Get-MaxInfoFromVisualStudio_15_0)
-$sqlPackageInfo += (Get-MaxInfoFromVisualStudio_16_0)
+$sqlPackageInfo += (Get-MaxInfoFromVisualStudioByVersion -VersionNumber 15)
+$sqlPackageInfo += (Get-MaxInfoFromVisualStudioByVersion -VersionNumber 16)
 $sqlPackageInfo |
     Sort-Object -Property Version -Descending |
     Select -First 1 |

--- a/src/Misc/layoutbin/powershell/Add-SqlPackageCapabilities.ps1
+++ b/src/Misc/layoutbin/powershell/Add-SqlPackageCapabilities.ps1
@@ -173,6 +173,7 @@ $sqlPackageInfo += (Get-MaxInfoFromSqlServerDtaf)
 $sqlPackageInfo += (Get-MaxInfoFromVisualStudio)
 $sqlPackageInfo += (Get-MaxInfoFromVisualStudioByVersion -VersionNumber 15)
 $sqlPackageInfo += (Get-MaxInfoFromVisualStudioByVersion -VersionNumber 16)
+$sqlPackageInfo += (Get-MaxInfoFromVisualStudioByVersion -VersionNumber 17)
 $sqlPackageInfo |
     Sort-Object -Property Version -Descending |
     Select -First 1 |


### PR DESCRIPTION
*Description*:
Added getting VS 17 (2022) capabilities to `Add-SqlPackageCapabilities` script

Changes:
- Reduced `Get-MaxInfoFromVisualStudio_15` and `Get-MaxInfoFromVisualStudio_15` to one generic
- Added Get VS Info function call for VS 17

Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3852

Testing in progress