### PR TITLE
Improve retry logic for downloading tasks

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -164,14 +164,14 @@ namespace Agent.Sdk.Knob
         public static readonly Knob TaskDownloadTimeout = new Knob(
             nameof(TaskDownloadTimeout),
             "Amount of time in seconds to wait for the agent to download a task when starting a job",
-            new RuntimeKnobSource("vstsTaskDownloadTimeout"),
+            // new RuntimeKnobSource("vstsTaskDownloadTimeout"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_TIMEOUT"),
             new BuiltInDefaultKnobSource("1200")); // 20*60
 
         public static readonly Knob TaskDownloadRetryLimit = new Knob(
             nameof(TaskDownloadRetryLimit),
             "Attempts to download a task when starting a job",
-            new RuntimeKnobSource("vstsTaskDownloadRetryCount"),
+            // new RuntimeKnobSource("vstsTaskDownloadRetryCount"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_RETRY_LIMIT"),
             new BuiltInDefaultKnobSource("3"));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -164,14 +164,14 @@ namespace Agent.Sdk.Knob
         public static readonly Knob TaskDownloadTimeout = new Knob(
             nameof(TaskDownloadTimeout),
             "Amount of time in seconds to wait for the agent to download a task when starting a job",
-            // new RuntimeKnobSource("vstsTaskDownloadTimeout"),
+            new RuntimeKnobSource("vstsTaskDownloadTimeout"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_TIMEOUT"),
             new BuiltInDefaultKnobSource("1200")); // 20*60
 
         public static readonly Knob TaskDownloadRetryLimit = new Knob(
             nameof(TaskDownloadRetryLimit),
             "Attempts to download a task when starting a job",
-            // new RuntimeKnobSource("vstsTaskDownloadRetryCount"),
+            new RuntimeKnobSource("vstsTaskDownloadRetryCount"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_RETRY_LIMIT"),
             new BuiltInDefaultKnobSource("3"));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -164,14 +164,12 @@ namespace Agent.Sdk.Knob
         public static readonly Knob TaskDownloadTimeout = new Knob(
             nameof(TaskDownloadTimeout),
             "Amount of time in seconds to wait for the agent to download a task when starting a job",
-            new RuntimeKnobSource("vstsTaskDownloadTimeout"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_TIMEOUT"),
             new BuiltInDefaultKnobSource("1200")); // 20*60
 
         public static readonly Knob TaskDownloadRetryLimit = new Knob(
             nameof(TaskDownloadRetryLimit),
             "Attempts to download a task when starting a job",
-            new RuntimeKnobSource("vstsTaskDownloadRetryCount"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_RETRY_LIMIT"),
             new BuiltInDefaultKnobSource("3"));
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -164,8 +164,16 @@ namespace Agent.Sdk.Knob
         public static readonly Knob TaskDownloadTimeout = new Knob(
             nameof(TaskDownloadTimeout),
             "Amount of time in seconds to wait for the agent to download a task when starting a job",
+            new RuntimeKnobSource("vstsTaskDownloadTimeout"),
             new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_TIMEOUT"),
             new BuiltInDefaultKnobSource("1200")); // 20*60
+
+        public static readonly Knob TaskDownloadRetryLimit = new Knob(
+            nameof(TaskDownloadRetryLimit),
+            "Attempts to download a task when starting a job",
+            new RuntimeKnobSource("vstsTaskDownloadRetryCount"),
+            new EnvironmentKnobSource("VSTS_TASK_DOWNLOAD_RETRY_LIMIT"),
+            new BuiltInDefaultKnobSource("3"));
 
         // HTTP
         public const string LegacyHttpVariableName = "AZP_AGENT_USE_LEGACY_HTTP";

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                             if (retryCount == retryLimit)
                             {
-                                throw ex;
+                                throw;
                             }
                         }
                     }

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -188,7 +188,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             //download and extract task in a temp folder and rename it on success
             string tempDirectory = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Tasks), "_temp_" + Guid.NewGuid());
-            System.Diagnostics.Debugger.Launch();
             try
             {
                 Directory.CreateDirectory(tempDirectory);

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -196,8 +196,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Allow up to 20 * 60s for any task to be downloaded from service.
                 // Base on Kusto, the longest we have on the service today is over 850 seconds.
                 // Timeout limit can be overwrite by environment variable
-                int timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(executionContext).AsInt();
-                int retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(executionContext).AsInt();
+                var timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(executionContext).AsInt();
+                var retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(executionContext).AsInt();
 
                 while (true)
                 {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -196,8 +196,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Allow up to 20 * 60s for any task to be downloaded from service.
                 // Base on Kusto, the longest we have on the service today is over 850 seconds.
                 // Timeout limit can be overwrite by environment variable
-                int timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(executionContext).AsInt();
-                int retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(executionContext).AsInt();
+                int timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(UtilKnobValueContext.Instance()).AsInt();
+                int retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(UtilKnobValueContext.Instance()).AsInt();
 
                 while (true)
                 {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -196,8 +196,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Allow up to 20 * 60s for any task to be downloaded from service.
                 // Base on Kusto, the longest we have on the service today is over 850 seconds.
                 // Timeout limit can be overwrite by environment variable
-                int timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(UtilKnobValueContext.Instance()).AsInt();
-                int retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(UtilKnobValueContext.Instance()).AsInt();
+                int timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(executionContext).AsInt();
+                int retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(executionContext).AsInt();
 
                 while (true)
                 {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -212,7 +212,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             using (FileStream fs = new FileStream(zipFile, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: _defaultFileStreamBufferSize, useAsync: true))
                             using (Stream result = await taskServer.GetTaskContentZipAsync(task.Id, version, taskDownloadCancellation.Token))
                             {
+                                Trace.Info($"The '{task.Name}' task downloading started.");
                                 await result.CopyToAsync(fs, _defaultCopyBufferSize, taskDownloadCancellation.Token);
+                                Trace.Info($"The '{task.Name}' task downloading finished.");
                                 await fs.FlushAsync(taskDownloadCancellation.Token);
 
                                 // download succeed, break out the retry loop.
@@ -253,7 +255,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                 Trace.Info($"Zip file '{zipFile}' can not be found.");
                             }
 
-                            if (retryCount == retryLimit)
+                            if (retryCount >= retryLimit)
                             {
                                 Trace.Info($"Retry limit to download the '{task.Name}' task reached.");
                                 throw;

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -196,8 +196,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Allow up to 20 * 60s for any task to be downloaded from service.
                 // Base on Kusto, the longest we have on the service today is over 850 seconds.
                 // Timeout limit can be overwrite by environment variable
-                var timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(UtilKnobValueContext.Instance()).AsInt();
-                var retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(UtilKnobValueContext.Instance()).AsInt();
+                int timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(UtilKnobValueContext.Instance()).AsInt();
+                int retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(UtilKnobValueContext.Instance()).AsInt();
 
                 while (true)
                 {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -196,8 +196,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Allow up to 20 * 60s for any task to be downloaded from service.
                 // Base on Kusto, the longest we have on the service today is over 850 seconds.
                 // Timeout limit can be overwrite by environment variable
-                var timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(executionContext).AsInt();
-                var retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(executionContext).AsInt();
+                var timeoutSeconds = AgentKnobs.TaskDownloadTimeout.GetValue(UtilKnobValueContext.Instance()).AsInt();
+                var retryLimit = AgentKnobs.TaskDownloadRetryLimit.GetValue(UtilKnobValueContext.Instance()).AsInt();
 
                 while (true)
                 {


### PR DESCRIPTION
This PR improves logging for downloading tasks during job initialization.

[Related issue](https://github.com/microsoft/build-task-team/issues/2698)

Agent logs example:
```log
[2022-06-06 13:03:37Z INFO TaskManager] The 'CodeQL3000Init' task downloading started.
[2022-06-06 13:03:39Z ERR  TaskManager] Fail to download task 'c450a110-caea-4ea9-8299-297eecc70633 (CodeQL3000Init/0.1.76)' -- Attempt: 1
[2022-06-06 13:03:40Z ERR  TaskManager] System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
<Exception Stack Trace>

[2022-06-06 13:03:40Z INFO TaskManager] Zip file 'D:\agent\_cloud\x2\_work\_tasks\_temp_e15c1cd9-ca4d-4194-9b14-4d2a5794d15a\46becf97-219c-4b9b-9006-1e84fb75a9d1.zip' exists; its size in bytes: 5304320
. . .

[2022-06-06 13:04:04Z INFO TaskManager] The 'CodeQL3000Init' task downloading started.
[2022-06-06 13:04:07Z ERR  TaskManager] Fail to download task 'c450a110-caea-4ea9-8299-297eecc70633 (CodeQL3000Init/0.1.76)' -- Attempt: 2
[2022-06-06 13:04:07Z ERR  TaskManager] System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
<Exception Stack Trace>

[2022-06-06 13:04:07Z INFO TaskManager] Zip file 'D:\agent\_cloud\x2\_work\_tasks\_temp_e15c1cd9-ca4d-4194-9b14-4d2a5794d15a\1922b180-26dc-4168-bc62-91419a1f4900.zip' exists; its size in bytes: 294912
. . .

[2022-06-06 13:04:23Z INFO TaskManager] The 'CodeQL3000Init' task downloading started.
[2022-06-06 13:04:25Z ERR  TaskManager] Fail to download task 'c450a110-caea-4ea9-8299-297eecc70633 (CodeQL3000Init/0.1.76)' -- Attempt: 3
[2022-06-06 13:04:25Z ERR  TaskManager] System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
<Exception Stack Trace>

[2022-06-06 13:04:25Z INFO TaskManager] Zip file 'D:\agent\_cloud\x2\_work\_tasks\_temp_e15c1cd9-ca4d-4194-9b14-4d2a5794d15a\829b4b19-338d-4472-9961-6dc98c84b01f.zip' exists; its size in bytes: 512000
[2022-06-06 13:04:25Z INFO TaskManager] Retry limit to download the 'CodeQL3000Init' task reached.
```

Pipeline logs example:
```log
Set build variables.
Download all required tasks.
Downloading task: CodeQL3000Init (0.1.76)
##[warning]Task 'CodeQL3000Init' didn't finish download within 3 seconds.
##[warning]Back off 24.052 seconds before retry.
##[warning]Task 'CodeQL3000Init' didn't finish download within 3 seconds.
##[warning]Back off 15.567 seconds before retry.
##[warning]Task 'CodeQL3000Init' didn't finish download within 3 seconds.
##[error]The operation was canceled.
##[debug]System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
<Exception Stack Trace>
```

Full size of the zip file can not be determined via the [result.Length](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.length?view=net-6.0) property, and the [result.CanSeek](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.canseek?view=net-6.0) property is `false`:

![image](https://user-images.githubusercontent.com/61472718/172263227-588e551e-f3f4-4efb-9913-fd8a272e6069.png)

`GetTaskContentZipAsync` is located in `Microsoft.TeamFoundation.DistributedTask.WebApi.TaskAgentHttpClient` (metadata).
During its execution, a `GET` request is sent to Azure DevOps, to get a stream, but not a zip archive with a task, before downloading the zip archive with the task itself. So, the 200 status code in the response does not mean that the task is downloaded successfully, it means that the agent got the stream from the server.