### PR TITLE
[Agent CI] Update signing pipeline to respect the new MinGit layout

### DIFF
--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -149,6 +149,8 @@ steps:
         bin\**\*.exe
         externals\**\*.exe
         externals\**\*.dll
+        externals\**\*.py
+        externals\**\*.pyd
       UseMinimatch: true
       signConfigType: inlineSignParams
       inlineOperation: |

--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -149,7 +149,6 @@ steps:
         bin\**\*.exe
         externals\**\*.exe
         externals\**\*.dll
-        externals\**\*.py
         externals\**\*.pyd
       UseMinimatch: true
       signConfigType: inlineSignParams


### PR DESCRIPTION
**Issue Description**:

Recently our release pipeline failed with the following error on Verify Codesign Report pipeline step:

```Console
externals/git/mingw64/lib/python3.9/site-packages/libxml2mod.pyd(File,): error CI0001:  : The file is unsigned.
```

From the report, we can see that issue comes from the `libxml2mod.pyd` file that can be found by the following path `externals/git/mingw64/lib/python3.9/site-packages`

<details>
  <summary>From Codesign Report</summary>

  ```Console
    FileName         : libxml2mod.pyd
    Ext              : PYD
    Path             : externals/git/mingw64/lib/python3.9/site-packages/libxml2mod.pyd
    OriginalFileName : 
    Version          : 
    Description      : 
    Product          : 
    Hash             : EA284B1DC6839A3D41DC1DB2DBFD1B237DAA77ECE4E20DBA0532D8271EFC13C3
    UserMode         : True
    Status           : Unsigned
  ```
  
</details>

The MinGW distribution comes from the Mingit distribution which we ship with the pipeline agent. Recently we have updated the Mingit version in this pull request:

- #3839

The Mingit distribution layout was changed between versions `2.30.2` and `2.36.1` and now contains `*.pyd` files. In the Windows ecosystem, the `*.pyd` file is a dynamic link library (aka DLL) that contains a Python module or set of modules, to be called by other Python code.

**Fix description**:

Since `*.pyd` is a DLL file we need to sign it as well as other `*.dll` files which means that we have to update a list of patterns for the Sign Agent Assemblies (3rd Party Assemblies Signing) pipeline step to respect `*.pyd` files. 

_Changelog_:
- `signing.yml`: Add pattern to sing the `*.pyd` files

