### PR TITLE
[Agent CI] Improve release pipeline stability

### DIFF
--- a/.azure-pipelines/build-jobs.yml
+++ b/.azure-pipelines/build-jobs.yml
@@ -15,7 +15,7 @@ parameters:
 
 - name: timeoutInMinutes
   type: number
-  default: 60
+  default: 120
 
 - name: branch
   type: string

--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -199,3 +199,4 @@ steps:
       SourceFolder: '${{ parameters.layoutRoot }}'
       Contents: '**\CodeSignSummary-*.md'
     displayName: Delete CodeSignSummary.md
+    retryCountOnTaskFailure: 4


### PR DESCRIPTION
**Issue description**:
Recently we faced two issues with the release pipeline:

_First issue_: 

The `Sign Agent Assemblies (3rd Party Assemblies Signing)` step could take up to 40 minutes this could cause cancel of the pipeline job due to a hit of time limitation. Current value for `timeoutInMinutes` is set to 60 minutes.

_Second issue_:

The `Delete CodeSignSummary.md` step could failed due to the following error:

```console
##[error]Error: Failed rmRF: EPERM: operation not permitted, unlink 'D:\a\1\s\_layout\win-x64\CodeSignSummary-RandomGUID.md'
```

The issue itself seems to be intermittent since and related to the environment.

**Fix description**:
To fix the first issue we can increase `timeoutInMinutes` to make sure that the pipeline job would not be canceled by ADO after 60 minutes. For the second issue, we can set `retryCountOnTaskFailure` so ADO will retry the `Delete CodeSignSummary.md` step several times before failing the pipeline job.

_Changelog_:
- `build-jobs.yml`: Increase default value for `timeoutInMinutes` from 60 to 120 minutes
- `signing.yml`: Set `retryCountOnTaskFailure` to 4 for `Delete CodeSignSummary.md` pipeline step