### PR TITLE
remove npx in the node 10 directory; remove npm, npx, corepack, and related node modules in the node 16 directory

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -221,11 +221,17 @@ if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
 fi
 
 if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
-    rm -rf "$LAYOUT_DIR/externals/node/lib/node_modules/npm"
+    rm -rf "$LAYOUT_DIR/externals/node/lib"
     rm "$LAYOUT_DIR/externals/node/bin/npm"
-    rm -rf "$LAYOUT_DIR/externals/node10/lib/node_modules/npm"
+
+    rm -rf "$LAYOUT_DIR/externals/node10/lib"
     rm "$LAYOUT_DIR/externals/node10/bin/npm"
     rm "$LAYOUT_DIR/externals/node10/bin/npx"
+
+    rm -rf "$LAYOUT_DIR/externals/node16/lib"
+    rm "$LAYOUT_DIR/externals/node16/bin/npm"
+    rm "$LAYOUT_DIR/externals/node16/bin/npx"
+    rm "$LAYOUT_DIR/externals/node16/bin/corepack"
 fi
 
 if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -225,6 +225,7 @@ if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
     rm "$LAYOUT_DIR/externals/node/bin/npm"
     rm -rf "$LAYOUT_DIR/externals/node10/lib/node_modules/npm"
     rm "$LAYOUT_DIR/externals/node10/bin/npm"
+    rm "$LAYOUT_DIR/externals/node10/bin/npx"
 fi
 
 if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -221,6 +221,9 @@ if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
 fi
 
 if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
+    # remove `npm`, `npx`, `corepack`, and related `node_modules` from the `externals/node*` agent directory
+    # they are installed along with node, but agent does not use them
+
     rm -rf "$LAYOUT_DIR/externals/node/lib"
     rm "$LAYOUT_DIR/externals/node/bin/npm"
 


### PR DESCRIPTION
Npm and related modules were removed in [this pull request](https://github.com/microsoft/azure-pipelines-agent/pull/3833).
Npx is a broken symlink. Npx is not used anywhere in the agent. We need to remove it as well.
Tested that applied changes work as expected: Linux agent was built, configured, and launched fine.

`npm`, `npx`, `corepack`, and related `node_modules` in the `externals/node16` directory also were removed.

**Risks analysis checklist:**
* [x] There are no risky dependency updates
* [x] Changes have been tested
* [x] Enough test coverage for changes and current test coverage for the agent doesn't look poor
* [x] We understand how the agent is working, how changes affect agent behavior
* [x] There are no breaking changes
* [x] There are no other concerns
* [x] I have not discovered any new uncovered test/use cases