### PR TITLE
Update deprecated image query script for macOS 10.15

### DIFF
--- a/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
+++ b/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
@@ -17,7 +17,7 @@ $vstsAuthHeader = @{"Authorization"="Basic $base64authinfo"}
 $allHeaders = $vstsAuthHeader + @{"Content-Type"="application/json"; "Accept"="application/json"}
 
 # List of deprecated images
-[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu16', 'ubuntu-16.04', 'DefaultHosted', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
+[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu16', 'ubuntu-16.04', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
 
 try
 {

--- a/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
+++ b/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
@@ -17,7 +17,7 @@ $vstsAuthHeader = @{"Authorization"="Basic $base64authinfo"}
 $allHeaders = $vstsAuthHeader + @{"Content-Type"="application/json"; "Accept"="application/json"}
 
 # List of deprecated images
-[string[]] $deprecatedImages = 'macOS-10.14', 'macOS 10.14', 'MacOS 1014', 'MacOS-1014', 'Ubuntu16', 'ubuntu-16.04', 'DefaultHosted', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
+[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu16', 'ubuntu-16.04', 'DefaultHosted', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
 
 try
 {


### PR DESCRIPTION
Update QueryJobHistoryForRetiredImages.ps1 to find macOS-10.15 images, and remove 'DefaultHosted' from deprecated image labels list.