### PR TITLE
Introduce the `gMSA` accounts support

### DIFF
--- a/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
+++ b/src/Agent.Listener/Configuration.Windows/NativeWindowsServiceHelper.cs
@@ -76,6 +76,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         void GrantDirectoryPermissionForAccount(string accountName, IList<string> folders);
 
         void RevokeDirectoryPermissionForAccount(IList<string> folders);
+
+        bool IsWellKnownIdentity(string accountName);
+
+        bool IsManagedServiceAccount(string accountName);
     }
 
     public class NativeWindowsServiceHelper : AgentService, INativeWindowsServiceHelper
@@ -370,10 +374,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
         }
 
-        public static bool IsWellKnownIdentity(String accountName)
+        public bool IsWellKnownIdentity(String accountName)
         {
-            NTAccount ntaccount = new NTAccount(accountName);
-            SecurityIdentifier sid = (SecurityIdentifier)ntaccount.Translate(typeof(SecurityIdentifier));
+            var ntaccount = new NTAccount(accountName);
+            var sid = (SecurityIdentifier)ntaccount.Translate(typeof(SecurityIdentifier));
 
             SecurityIdentifier networkServiceSid = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null);
             SecurityIdentifier localServiceSid = new SecurityIdentifier(WellKnownSidType.LocalServiceSid, null);
@@ -452,6 +456,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         public void InstallService(string serviceName, string serviceDisplayName, string logonAccount, string logonPassword, bool setServiceSidTypeAsUnrestricted)
         {
             Trace.Entering();
+
+            try
+            {
+                var isManagedServiceAccount = IsManagedServiceAccount(logonAccount);
+                Trace.Info($"Account '{logonAccount}' is managed service account: {isManagedServiceAccount}.");
+            }
+            catch (Win32Exception e)
+            {
+                Trace.Info($"Fail to check account '{logonAccount}' is managed service account or not due to error: {e.Message}");
+            }
 
             string agentServiceExecutable = "\"" + Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), WindowsServiceControlManager.WindowsServiceControllerName) + "\"";
             IntPtr scmHndl = IntPtr.Zero;
@@ -928,6 +942,40 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             Trace.Info(StringUtil.Format($"Delete the group {groupName}."));
             DeleteLocalGroup(groupName);
         }
+        /// <summary>
+        /// Checks if account is managed service
+        /// </summary>
+        /// <param name="accountName">account name</param>
+        /// <returns>Returns true if account is managed service.</returns>
+        /// <exception cref="Win32Exception">Throws this exception if there is some error during check.</exception>
+        public bool IsManagedServiceAccount(String accountName)
+        {
+            bool isServiceAccount;
+            accountName = SanitizeManagedServiceAccountName(accountName);
+            var result = this.CheckNetIsServiceAccount(null, accountName, out isServiceAccount);
+            if (result == 0)
+            {
+                return isServiceAccount;
+            }
+            else
+            {
+                var lastErrorCode = (int)GetLastError();
+                throw new Win32Exception(lastErrorCode);
+            }
+        }
+
+        /// <summary>
+        /// Checks if account is managed service
+        /// </summary>
+        /// <param name="ServerName"></param>
+        /// <param name="AccountName"></param>
+        /// <param name="isServiceAccount"></param>
+        /// <returns>Returns 0 if account is managed service, otherwise - returns non-zero code</returns>
+        /// <exception cref="Win32Exception">Throws exception if there's an error during check</exception>
+        public virtual uint CheckNetIsServiceAccount(string ServerName, string AccountName, out bool isServiceAccount)
+        {
+            return NativeWindowsServiceHelper.NetIsServiceAccount(ServerName, AccountName, out isServiceAccount);
+        }
 
         private bool IsValidCredentialInternal(string domain, string userName, string logonPassword, UInt32 logonType)
         {
@@ -972,6 +1020,25 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             {
                 Trace.Error(exception);
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Removes '$' character from managed service account name
+        /// </summary>
+        /// <param name="accountName">account name</param>
+        /// <returns></returns>
+        private string SanitizeManagedServiceAccountName(string accountName)
+        {
+            // remove the last '$' for MSA
+            ArgUtil.NotNullOrEmpty(accountName, nameof(accountName));
+            if (accountName[accountName.Length - 1].Equals('$'))
+            {
+                return accountName.Remove(accountName.Length - 1);
+            }
+            else
+            {
+                return accountName;
             }
         }
 
@@ -1268,6 +1335,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             Reboot = 2,
             RunCommand = 3
         }
+
+        [DllImport("Logoncli.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern uint NetIsServiceAccount(string ServerName, string AccountName, [MarshalAs(UnmanagedType.Bool)] out bool IsServiceAccount);
 
         [DllImport("Netapi32.dll")]
         private extern static int NetLocalGroupGetInfo(string servername,

--- a/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/WindowsServiceControlManager.cs
@@ -67,11 +67,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             Trace.Info("LogonAccount after transforming: {0}, user: {1}, domain: {2}", logonAccount, userName, domainName);
 
             string logonPassword = string.Empty;
-            if (!defaultServiceAccount.Equals(new NTAccount(logonAccount)) && !NativeWindowsServiceHelper.IsWellKnownIdentity(logonAccount))
+            if (!defaultServiceAccount.Equals(new NTAccount(logonAccount)) &&
+                !_windowsServiceHelper.IsWellKnownIdentity(logonAccount) &&
+                !_windowsServiceHelper.IsManagedServiceAccount(logonAccount))
             {
                 while (true)
                 {
-                    logonPassword = command.GetWindowsLogonPassword(logonAccount);
+                    try
+                    {
+                        logonPassword = command.GetWindowsLogonPassword(logonAccount);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        Trace.Warning("LogonAccount {0} is not managed service account, although you did not specify WindowsLogonPassword - maybe you wanted to use managed service account? Please see https://aka.ms/gmsa for guidelines to set up sMSA/gMSA account.", logonAccount, userName, domainName);
+                        throw;
+                    }
+
                     if (_windowsServiceHelper.IsValidCredential(domainName, userName, logonPassword))
                     {
                         Trace.Info("Credential validation succeed");

--- a/src/Test/L0/Listener/Configuration/Mocks/MockNativeWindowsServiceHelper.cs
+++ b/src/Test/L0/Listener/Configuration/Mocks/MockNativeWindowsServiceHelper.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.Services.Agent.Listener.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Test.L0.Listener.Configuration.Mocks
+{
+    /// <summary>
+    /// Mock class for NativeWindowsServiceHelper
+    /// Use this to mock any functions of this class
+    /// </summary>
+    public class MockNativeWindowsServiceHelper : NativeWindowsServiceHelper
+    {
+        public bool ShouldAccountBeManagedService { get; set; }
+        public bool ShouldErrorHappenDuringManagedServiceAccoutCheck { get; set; }
+        public override uint CheckNetIsServiceAccount(string ServerName, string AccountName, out bool isServiceAccount)
+        {
+            isServiceAccount = this.ShouldAccountBeManagedService;
+            if (ShouldErrorHappenDuringManagedServiceAccoutCheck)
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/src/Test/L0/Listener/Configuration/NativeWindowsServiceHelperL0.cs
+++ b/src/Test/L0/Listener/Configuration/NativeWindowsServiceHelperL0.cs
@@ -11,6 +11,8 @@ using Xunit;
 using System.Security.Principal;
 using Microsoft.VisualStudio.Services.Agent;
 using Microsoft.VisualStudio.Services.Agent.Tests;
+using Test.L0.Listener.Configuration.Mocks;
+using System.ComponentModel;
 
 namespace Test.L0.Listener.Configuration
 {
@@ -52,6 +54,60 @@ namespace Test.L0.Listener.Configuration
                 trace.Info("Trying to get the Default Service Account when a DeploymentAgent is being configured");
                 var defaultServiceAccount = windowsServiceHelper.GetDefaultAdminServiceAccount();
                 Assert.True(defaultServiceAccount.ToString().Equals(@"NT AUTHORITY\SYSTEM"), "If agent is getting configured as deployment agent, default service accout should be 'NT AUTHORITY\\SYSTEM'");
+            }
+        }
+
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "ConfigurationManagement")]
+        public void EnsureIsManagedServiceAccount_TrueForManagedAccount()
+        {
+            using (TestHostContext tc = new TestHostContext(this, "EnsureIsManagedServiceAccount_TrueForManagedAccount"))
+            {
+                Tracing trace = tc.GetTrace();
+
+                trace.Info("Creating an instance of the MockNativeWindowsServiceHelper class");
+                var windowsServiceHelper = new MockNativeWindowsServiceHelper();
+                windowsServiceHelper.ShouldAccountBeManagedService = true;
+                var isManagedServiceAccount = windowsServiceHelper.IsManagedServiceAccount("managedServiceAccount$");
+
+                Assert.True(isManagedServiceAccount, "Account should be properly determined as managed service");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "ConfigurationManagement")]
+        public void EnsureIsManagedServiceAccount_FalseForNonManagedAccount()
+        {
+            using (TestHostContext tc = new TestHostContext(this, "EnsureIsManagedServiceAccount_TrueForManagedAccount"))
+            {
+                Tracing trace = tc.GetTrace();
+
+                trace.Info("Creating an instance of the MockNativeWindowsServiceHelper class");
+                var windowsServiceHelper = new MockNativeWindowsServiceHelper();
+                windowsServiceHelper.ShouldAccountBeManagedService = false;
+                var isManagedServiceAccount = windowsServiceHelper.IsManagedServiceAccount("managedServiceAccount$");
+
+                Assert.True(!isManagedServiceAccount, "Account should be properly determined as not managed service");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "ConfigurationManagement")]
+        public void EnsureIsManagedServiceAccount_ThrowsExceptionDuringCheck()
+        {
+            using (TestHostContext tc = new TestHostContext(this, "EnsureIsManagedServiceAccount_TrueForManagedAccount"))
+            {
+                Tracing trace = tc.GetTrace();
+
+                trace.Info("Creating an instance of the MockNativeWindowsServiceHelper class");
+                var windowsServiceHelper = new MockNativeWindowsServiceHelper();
+                windowsServiceHelper.ShouldErrorHappenDuringManagedServiceAccoutCheck = true;
+
+                Assert.Throws<Win32Exception>(() => windowsServiceHelper.IsManagedServiceAccount("managedServiceAccount$"));
             }
         }
     }

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -346,7 +346,7 @@ bash ./Misc/externals.sh $RUNTIME_ID "Pre-Cache" || checkRC "externals.sh Pre-Ca
 
 if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
     vswhere=$(find "$DOWNLOAD_DIR" -name vswhere.exe | head -1)
-    vs_location=$("$vswhere" -prerelease -property installationPath)
+    vs_location=$("$vswhere" -latest -property installationPath)
     msbuild_location="$vs_location""\MSBuild\15.0\Bin\msbuild.exe"
 
     if [[ ! -e "${msbuild_location}" ]]; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -346,7 +346,7 @@ bash ./Misc/externals.sh $RUNTIME_ID "Pre-Cache" || checkRC "externals.sh Pre-Ca
 
 if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
     vswhere=$(find "$DOWNLOAD_DIR" -name vswhere.exe | head -1)
-    vs_location=$("$vswhere" -latest -property installationPath)
+    vs_location=$("$vswhere" -prerelease -property installationPath)
     msbuild_location="$vs_location""\MSBuild\15.0\Bin\msbuild.exe"
 
     if [[ ! -e "${msbuild_location}" ]]; then


### PR DESCRIPTION
**Description**:
At the moment Azure Pipelines Agent doesn't support [Group Managed Service Accounts](https://docs.microsoft.com/en-us/windows-server/security/group-managed-service-accounts/group-managed-service-accounts-overview). This PR introduces support for such accounts.

_Note_:
This PR recovered changes made previously:
- #1294
- #3791
- #3845


**Changelog**:

_`NativeWindowsServiceHelper` class_:
- Introduced `IsManagedServiceAccount` and `CheckNetIsServiceAccount` methods - to check if the account is managed service
- Introduced `SanitizeManagedServiceAccountName` method - Removes `$` character from managed service account name
- Introduced `NetIsServiceAccount` method

_`WindowsServiceControlManager` class_:
- Added a warning message if an account is not `gMSA`

_Unit tests_:
- Introduced `MockNativeWindowsServiceHelper` class
- Added unit tests to `NativeWindowsServiceHelperL0` test suit



**Documentation changes required**: 
- Yes

**Added unit tests**: 
- Yes

**Attached related issue**:


- TBD


**Steps to complete PR**:
- [ ] Rework `IsManagedServiceAccount` method to avoid `Win32Exception`
- [ ] Complete E2E testing
- [ ] Prepare documentation for these changes


**Checklist**:
- [x] There are no risky dependency updates
- [ ] Changes have been tested
- [ ] Enough test coverage for changes and current test coverage for the task doesn't look poor
- [ ] We understand how changes affect task behavior
- [ ] There are no breaking changes
- [ ] There are no other concerns
- [ ] I have not discovered any new uncovered test/use cases