### PR TITLE
Changed script path creation logic

### DIFF
--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -149,11 +149,16 @@ async function createConfigChangePR(repoPath, agentVersion) {
 /**
  * Queries whatsprintis.it for current sprint version
  * 
+ * @throws An error will be thrown if the response does not contain a sprint version as a three-digit numeric value
  * @returns current sprint version
  */
 async function getCurrentSprint() {
     const response = await got.get('https://whatsprintis.it/?json', { responseType: 'json' });
-    return response.body.sprint;
+    const sprint = response.body.sprint;
+    if (!/^\d\d\d$/.test(sprint)) {
+        throw new Error(`Sprint must be a three-digit number; received: ${sprint}`);
+    }
+    return sprint;
 }
 
 async function main()


### PR DESCRIPTION
## Task description

The Azure Pipelines Agent release/createAdoPrs.js script downloads remote content from https://whatsprintis.it, appends it to a command line, and then executes it locally. This places the maintainers of that website’s infrastructure within build systems’ trust boundaries, which is unlikely to be intentional. 
Vulnerable code: [https://github.com/microsoft/azure-pipelines-agent/blob/09d3392bae38886b7b8d4b6f5997e7613373c83e/release/createAdoPrs.js#L154](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2f%2fgithub.com%2fmicrosoft%2fazure-pipelines-agent%2fblob%2f09d3392bae38886b7b8d4b6f5997e7613373c83e%2frelease%2fcreateAdoPrs.js%23L154&data=05%7c01%7cbeniaju%40microsoft.com%7cb9faeec607c64f40c42608da6f585a6f%7c72f988bf86f141af91ab2d7cd011db47%7c1%7c0%7c637944722565395548%7cUnknown%7cTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7c3000%7c%7c%7c&sdata=cYfBHfDxFx9Ok5elrqR9AgyJ8sn2FKmPhpd52y731EQ%3D&reserved=0)
![image](https://user-images.githubusercontent.com/93121155/181764404-93715aa8-fd1c-4635-b838-a76c588c556d.png)

We probably shouldn't trust an unsanitized reference to it, especially because the usage of whatsprintis.it gets fed into the sprint var, which gets fed into a pathname upon which things are executed:
```
const publishScriptPathInRepo = path.join('tfs', `m${sprint}`, 'PipelinesAgentRelease', agentVersion, 'Publish.ps1');
...
util.execInForeground(`${GIT} add ${publishScriptPathInRepo}`, repoPath, opt.dryrun);
```
Exploitation would require compromise of the entire site whatsprint.isit, but this can't be ruled out. 

## Changelog

- Added check for a request to `https://whatsprintis.it/`

## Testing

Checked that the modified function works as expected