### PR TITLE
Update vmImage to macos-11 and disable falling tests

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -183,7 +183,7 @@ stages:
         jobName: build_osx
         displayName: macOS (x64)
         pool:
-          vmImage: macOS-10.15
+          vmImage: macOS-11
         os: osx
         arch: x64
         branch: ${{ parameters.branch }}

--- a/src/Test/L0/ProcessExtensionL0.cs
+++ b/src/Test/L0/ProcessExtensionL0.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
+        [Trait("SkipOn", "darwin")]
         public async Task SuccessReadProcessEnv()
         {
             using (TestHostContext hc = new TestHostContext(this))

--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -43,6 +43,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         [Trait("SkipOn", "windows")]
+        [Trait("SkipOn", "darwin")]
         public async Task TestCancel()
         {
             const int SecondsToRun = 20;


### PR DESCRIPTION
Due to the brownout of the `macOS` `v10.5` image, we need to adjust our pipelines.
_Related announcement_:
- actions/virtual-environments/issues/5583

This PR contains the following changes:
- Updated reference from macOS-10.5 to macOS-11.
- Disabled two unit tests which are no more possible to run on the newer macOS version.

**Documentation changes required**: 
- N/A

**Added unit tests**: 
- N/A

**Attached related issue**: 
- No

Testing:
Following changes were tested by executing unit tests, and in CI.

