### PR TITLE
Fix installation on aarch64 / Ubuntu 22.04

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -63,7 +63,7 @@ then
         command -v apt
         if [ $? -eq 0 ]
         then
-            apt update && apt install -y liblttng-ust0 libkrb5-3 zlib1g debsums
+            apt update && apt install -y libkrb5-3 zlib1g debsums && apt install -y liblttng-ust1 || apt install -y liblttng-ust0
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -74,7 +74,7 @@ then
 	        # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
             # other debian linux use libssl1.0.0
-            apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0
+            apt install -y libssl3 || apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -82,8 +82,8 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-            apt install -y libicu67 || apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
+            # libicu versions: libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+            apt install -y libicu70 || apt install -y libicu67 || apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -94,7 +94,7 @@ then
             command -v apt-get
             if [ $? -eq 0 ]
             then
-                apt-get update && apt-get install -y liblttng-ust0 libkrb5-3 zlib1g debsums
+                apt-get update && apt-get install -y libkrb5-3 zlib1g debsums && apt-get install -y liblttng-ust1 || apt-get install -y liblttng-ust0
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -105,7 +105,7 @@ then
                 # debian 10 uses libssl1.1
                 # debian 9 uses libssl1.0.2
                 # other debian linux use libssl1.0.0
-                apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0
+                apt-get install -y libssl3 || apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -113,8 +113,8 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-                apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
+                # libicu versions: libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+                apt-get install -y libicu70 || apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
Address some issues reported in # 3834

Test execution:
```
$ sudo ./bin/installdependencies.sh
--------OS Information--------
PRETTY_NAME="Ubuntu 22.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.1 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
------------------------------
The current OS is Debian based
--------Debian Version--------
bookworm/sid
------------------------------
/usr/bin/apt
Hit:1 https://cli.github.com/packages stable InRelease
Hit:2 https://download.docker.com/linux/ubuntu focal InRelease                                                                              
Hit:4 https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease                                                                      
Hit:5 http://ports.ubuntu.com/ubuntu-ports jammy InRelease                                                
Hit:6 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease
Hit:7 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease
Hit:8 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease
Hit:3 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
1 package can be upgraded. Run 'apt list --upgradable' to see it.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
libkrb5-3 is already the newest version (1.19.2-2).
zlib1g is already the newest version (1:1.2.11.dfsg-2ubuntu9).
debsums is already the newest version (3.0.2).
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
liblttng-ust1 is already the newest version (2.13.1-1ubuntu1).
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
libssl3 is already the newest version (3.0.2-0ubuntu1.6).
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
libicu70 is already the newest version (70.1-2).
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
-----------------------------
 Finish Install Dependencies
-----------------------------
```

Version:
```
$ uname -a
Linux 5c9914744714 5.15.55-0-virt #1-Alpine SMP Mon, 18 Jul 2022 06:51:44 +0000 aarch64 aarch64 aarch64 GNU/Linux
```