### PR TITLE
Include 'git status' as part of system diagnostics when debugging a pipeline

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -554,6 +554,15 @@ namespace Agent.Plugins.Repository
             return await ExecuteGitCommandAsync(context, repositoryPath, "lfs", "logs last");
         }
 
+        // git status
+        public async Task<int> GitStatus(AgentTaskPluginExecutionContext context, string repositoryPath)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+
+            context.Debug($"Show the working tree status for repository at {repositoryPath}.");
+            return await ExecuteGitCommandAsync(context, repositoryPath, "status", string.Empty);
+        }
+
         // git version
         public virtual async Task<Version> GitVersion(AgentTaskPluginExecutionContext context)
         {

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -102,6 +102,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         // git version
         Task<Version> GitVersion(IExecutionContext context);
+
+        // git status
+        Task<int> GitStatus(IExecutionContext context, string repositoryPath);
     }
 
     public class GitCommandManager : AgentService, IGitCommandManager
@@ -328,6 +331,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
             context.Debug($"Undo any changes to tracked files in the working tree for repository at {repositoryPath}.");
             return await ExecuteGitCommandAsync(context, repositoryPath, "reset", "--hard HEAD");
+        }
+
+        // git status
+        public async Task<int> GitStatus(IExecutionContext context, string repositoryPath)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+
+            context.Debug($"Show the working tree status for repository at {repositoryPath}.");
+            return await ExecuteGitCommandAsync(context, repositoryPath, "status", string.Empty);
         }
 
         // get remote set-url <origin> <url>


### PR DESCRIPTION
**Issue description:**
Currently doesn't outline the status of git repository while running pipeline

**Fix description:**
Added calls of git status command in the checkout step of the pipeline when Enable system diagnostics switch on.

![image](https://user-images.githubusercontent.com/111063382/187243223-192e748e-a261-405f-9e23-a4c85b2ed5d2.png)

**Changes:**
-  `GitStatus` method with call git status command added in `Agent.Plugins.GitCliManager` and `Agent.Worker.Build.GitCommandManager` classes
- Calls of `GitStatus` method added in `Agent.Plugins.GitSourceProvider` and `Agent.Worker.Build.GitSourceProvider` respectively

**Documentation changes required:** No

**Added unit tests:** No