### PR TITLE
Update GitSourceProvider to not pass auth header in arguments

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -400,7 +400,7 @@ namespace Agent.Plugins.Repository
 
             bool gitSupportAuthHeader = GitSupportUseAuthHeader(executionContext, gitCommandManager);
 
-            bool gitUseConfigEnv = AgentKnobs.GitUseConfigEnv.GetValue(executionContext).AsBoolean();
+            bool gitUseSecureParameterPassing = AgentKnobs.GitUseSecureParameterPassing.GetValue(executionContext).AsBoolean();
 
             // Make sure the build machine met all requirements for the git repository
             // For now, the requirement we have are:
@@ -1058,7 +1058,7 @@ namespace Agent.Plugins.Repository
                     string configValue = $"\"AUTHORIZATION: {GenerateAuthHeader(executionContext, username, password, useBearerAuthType)}\"";
                     configModifications[configKey] = configValue.Trim('\"');
 
-                    if (gitUseConfigEnv)
+                    if (gitUseSecureParameterPassing)
                     {
                         await SetAuthTokenInGitConfig(executionContext, gitCommandManager, configKey, configValue.Trim('\"'), repository);
                     }
@@ -1185,7 +1185,7 @@ namespace Agent.Plugins.Repository
                         string configValue = $"\"AUTHORIZATION: {GenerateAuthHeader(executionContext, username, password, useBearerAuthType)}\"";
                         configModifications[configKey] = configValue.Trim('\"');
 
-                        if (gitUseConfigEnv)
+                        if (gitUseSecureParameterPassing)
                         {
                             await SetAuthTokenInGitConfig(executionContext, gitCommandManager, configKey, configValue.Trim('\"'), repository);
                         }
@@ -1472,13 +1472,13 @@ namespace Agent.Plugins.Repository
             bool useBearerAuthType)
         {
             bool gitSupportsConfigEnv = GitSupportsConfigEnv(executionContext, gitCommandManager);
-            bool gitUseConfigEnv = AgentKnobs.GitUseConfigEnv.GetValue(executionContext).AsBoolean();
+            bool gitUseSecureParameterPassing = AgentKnobs.GitUseSecureParameterPassing.GetValue(executionContext).AsBoolean();
 
             string additionalArgs = String.Empty;
             string configValue = $"AUTHORIZATION: {GenerateAuthHeader(executionContext, username, password, useBearerAuthType)}";
 
-            // if git version is v2.31 or higher and gitUseConfigEnv knob is enabled
-            if (gitSupportsConfigEnv && gitUseConfigEnv)
+            // if git version is v2.31 or higher and GitUseSecureParameterPassing knob is enabled
+            if (gitSupportsConfigEnv && gitUseSecureParameterPassing)
             {
                 string envVariableName = $"env_var_{configKey}";
                 Environment.SetEnvironmentVariable(envVariableName, configValue);

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -1393,9 +1393,8 @@ namespace Agent.Plugins.Repository
             }
             else
             {
-                executionContext.Error(StringUtil.Loc("FailToRemoveGitConfig", configKey, configKey, targetPath));
+                executionContext.Warning(StringUtil.Loc("FailToReplaceTokenPlaceholderInGitConfig", configKey));
             }
-
         }
 
         private async Task RemoveCachedCredential(AgentTaskPluginExecutionContext context, GitCliManager gitCommandManager, Uri repositoryUrlWithCred, string repositoryPath, Uri repositoryUrl, string remoteName)

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -105,6 +105,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTS_DISABLE_GIT_PROMPT"),
             new BuiltInDefaultKnobSource("true"));
 
+        public static readonly Knob GitUseConfigEnv = new Knob(
+            nameof(GitUseConfigEnv),
+            "Allow to specify additional command line options to 'docker network' command when creating network for new containers",
+            new RuntimeKnobSource("agent.GitUseConfigEnv"),
+            new EnvironmentKnobSource("AZP_GIT_USE_CONFIG_ENV"),
+            new BuiltInDefaultKnobSource("true"));
+
         public const string QuietCheckoutRuntimeVarName = "agent.source.checkout.quiet";
         public const string QuietCheckoutEnvVarName = "AGENT_SOURCE_CHECKOUT_QUIET";
 

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -105,11 +105,11 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTS_DISABLE_GIT_PROMPT"),
             new BuiltInDefaultKnobSource("true"));
 
-        public static readonly Knob GitUseConfigEnv = new Knob(
-            nameof(GitUseConfigEnv),
-            "Allow to specify additional command line options to 'docker network' command when creating network for new containers",
-            new RuntimeKnobSource("agent.GitUseConfigEnv"),
-            new EnvironmentKnobSource("AZP_GIT_USE_CONFIG_ENV"),
+        public static readonly Knob GitUseSecureParameterPassing = new Knob(
+            nameof(GitUseSecureParameterPassing),
+            "If true, don't pass auth token in git parameters",
+            new RuntimeKnobSource("agent.GitSecureParameterPassing"),
+            new EnvironmentKnobSource("AGENT_GIT_SECURE_PARAMETER_PASSING"),
             new BuiltInDefaultKnobSource("true"));
 
         public const string QuietCheckoutRuntimeVarName = "agent.source.checkout.quiet";

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -108,8 +108,8 @@ namespace Agent.Sdk.Knob
         public static readonly Knob GitUseSecureParameterPassing = new Knob(
             nameof(GitUseSecureParameterPassing),
             "If true, don't pass auth token in git parameters",
-            new RuntimeKnobSource("agent.GitSecureParameterPassing"),
-            new EnvironmentKnobSource("AGENT_GIT_SECURE_PARAMETER_PASSING"),
+            new RuntimeKnobSource("agent.GitUseSecureParameterPassing"),
+            new EnvironmentKnobSource("AGENT_GIT_USE_SECURE_PARAMETER_PASSING"),
             new BuiltInDefaultKnobSource("true"));
 
         public const string QuietCheckoutRuntimeVarName = "agent.source.checkout.quiet";

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -313,6 +313,7 @@
   "FailedToReadFile": "Failed to read {0}. Error : {1}.",
   "FailedToReplaceAgent": "Failed to replace the agent.  Try again or ctrl-c to quit",
   "FailToRemoveGitConfig": "Unable to remove \"{0}\" from the git config. To remove the credential, execute \"git config --unset-all {0}\" from the repository root \"{1}\".",
+  "FailToReplaceTokenPlaceholderInGitConfig": "Unable to replace placeholder for \"{0}\" in the git config file.",
   "FileAssociateProgress": "Total files: {0} ---- Associated files: {1} ({2}%)",
   "FileContainerUploadFailed": "Unable to copy file to server StatusCode={0}: {1}. Source file path: {2}. Target server path: {3}",
   "FileContainerUploadFailedBlob": "Unable to upload file to blob. Source file path: {0}. Target server path: {1}",


### PR DESCRIPTION
Fix Agent.Plugins/[GitSourceProvider.cs](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Plugins/GitSourceProvider.cs) to not pass auth header in arguments.

There are 5 calls of the GenerateAuthHeader method that return the strings with a token (bearer or basic). Note: JWT token used for authorization has an expiration time of 80 min.

1. The are 3 places where we use this auth header as an additional argument for fetching sources. 

- [additionalFetchArgs](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Plugins/GitSourceProvider.cs#L704)
- [additionalLfsFetchArgs](https://github.com/microsoft/azure-pipelines-agent/blob/a4ecb428333af44a0b87b62142e7fce2f556a5d2/src/Agent.Plugins/GitSourceProvider.cs#L800)
- [additionalSubmoduleUpdateArgs](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Plugins/GitSourceProvider.cs#L958)

We used the following git option to pass http extraheaders:  [-c name=value](https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt) 

Replaced it by [--config-env=name=envvar](https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt) 

2.  And we also use this auth header twice for adding to the config file by running git config command in order to support [persistCredentials](https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#allow-scripts-to-access-the-system-token) option:

- [gitSupportAuthHeader && exposeCred](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Plugins/GitSourceProvider.cs#L1026)
- [lfsSupportAuthHeader && exposeCred](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Plugins/GitSourceProvider.cs#L1144)

Resolved it by updating git config file directly on the disc

3. Added GitUseSecureParameterPassing knob which is enabled by default