### PR TITLE
Improve container path translation

### DIFF
--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -215,16 +215,33 @@ namespace Agent.Sdk
                     : StringComparison.Ordinal;
                 foreach (var mapping in _pathMappings)
                 {
+                    string retval = null;
+
+                    path = PlatformUtil.RunningOnWindows ? path.Replace("/", "\\") : path;
                     if (string.Equals(path, mapping.Key, comparison))
                     {
-                        return mapping.Value;
+                        retval = mapping.Value;
                     }
 
                     if (path.StartsWith(mapping.Key + Path.DirectorySeparatorChar, comparison) ||
                         path.StartsWith(mapping.Key + Path.AltDirectorySeparatorChar, comparison))
                     {
-                        return mapping.Value + path.Remove(0, mapping.Key.Length);
+                        retval = mapping.Value + path.Remove(0, mapping.Key.Length);
                     }
+
+                    if (retval != null)
+                    {
+                        if (ImageOS == PlatformUtil.OS.Windows)
+                        {
+                            retval = retval.Replace("/", "\\");
+                        }
+                        else
+                        {
+                            retval = retval.Replace("\\", "/");
+                        }
+                        return retval;
+                    }
+
                 }
             }
 
@@ -242,6 +259,7 @@ namespace Agent.Sdk
                 {
                     string retval = null;
 
+                    path = ImageOS == PlatformUtil.OS.Windows ? path.Replace("/", "\\") : path;
                     if (string.Equals(path, mapping.Value, comparison))
                     {
                         retval = mapping.Key;

--- a/src/Test/L0/Container/ContainerInfoL0.cs
+++ b/src/Test/L0/Container/ContainerInfoL0.cs
@@ -94,6 +94,67 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
             }
         }
 
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData( @"C:\agent\w", PlatformUtil.OS.Windows, @"C:\w", @"C:\w\test", @"C:\agent\w\test")]
+        [InlineData(@"C:\agent\w", PlatformUtil.OS.Windows, @"C:\w", @"C:/w/test", @"C:\agent\w\test")]
+        [InlineData(@"C:\agent\w", PlatformUtil.OS.Windows, @"C:\w", @"C:\w/test", @"C:\agent\w\test")]
+        [InlineData(@"C:\agent\w", PlatformUtil.OS.Linux, @"/w", @"/w/test", @"C:\agent\w\test")]
+        [InlineData(@"C:\agent\w\01", PlatformUtil.OS.Linux, @"/w/01", @"/w\01/02", @"/w\01/02")]
+        public void TranslateToHostPathTests(string mappingHost, PlatformUtil.OS imageOS, string mappingContainer, string containerPath, string expected)
+        {
+            var dockerContainer = new Pipelines.ContainerResource()
+                {
+                    Alias = "vsts_container_preview",
+                    Image = "foo",
+                };
+            using (TestHostContext hc = CreateTestContext())
+            {
+                ContainerInfo info = hc.CreateContainerInfo(dockerContainer);
+                info.ImageOS = imageOS;
+                var mappings = new Dictionary<string, string>
+                {
+                    { mappingHost, mappingContainer }
+                };
+                info.AddPathMappings(mappings);
+
+                var got = info.TranslateToHostPath(containerPath);
+
+                Assert.Equal(expected, got);
+            }
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData( @"C:\agent\w", PlatformUtil.OS.Windows, @"C:\w", @"C:\agent\w\test", @"C:\w\test")]
+        [InlineData(@"C:\agent\w", PlatformUtil.OS.Windows, @"C:\w", @"C:/agent/w/test", @"C:\w\test")]
+        [InlineData(@"C:\agent\w", PlatformUtil.OS.Windows, @"C:\w", @"C:\agent\w/test", @"C:\w\test")]
+        [InlineData(@"C:\agent\w", PlatformUtil.OS.Linux, @"/w", @"C:\agent\w\test", @"/w/test")]
+        public void TranslateToContainerPathTests(string mappingHost, PlatformUtil.OS imageOS, string mappingContainer, string hostPath, string expected)
+        {
+            var dockerContainer = new Pipelines.ContainerResource()
+                {
+                    Alias = "vsts_container_preview",
+                    Image = "foo"
+                };
+            using (TestHostContext hc = CreateTestContext())
+            {
+                ContainerInfo info = hc.CreateContainerInfo(dockerContainer);
+                info.ImageOS = imageOS;
+                var mappings = new Dictionary<string, string>
+                {
+                    { mappingHost, mappingContainer }
+                };
+                info.AddPathMappings(mappings);
+
+                var got = info.TranslateToContainerPath(hostPath);
+
+                Assert.Equal(expected, got);
+            }
+        }
+
 
         [Fact]
         [Trait("Level", "L0")]


### PR DESCRIPTION
Fixes container path translation issues:

- Windows paths with forward slashes cannot be translated
- `TranslateToContainerPath` return values are not normalized, `TranslateToHostPath` values are