### PR TITLE
Added relative path translation in svc.sh script

### DIFF
--- a/src/Misc/layoutbin/systemd.svc.sh.template
+++ b/src/Misc/layoutbin/systemd.svc.sh.template
@@ -22,6 +22,16 @@ if [ $user_id -ne 0 ]; then
     exit 1
 fi
 
+# Change directory to the script root directory
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+cd "$( dirname "$SOURCE" )"
+
 function failed()
 {
    local error=${1:-Undefined error}


### PR DESCRIPTION
**Issue description:**
You can't run agent service setup script from other folder than the one containing script (svc.sh) - relative path issue

**Fix description:**
Added relative path resolving similar to one in configure.sh or run.sh (resolved according to https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script)

**Documentation changes required:** No

**Added unit tests:** Yes