### PR TITLE
fix `delay` when there is no `sleep` command

### DIFF
--- a/src/Misc/layoutroot/run-docker.sh
+++ b/src/Misc/layoutroot/run-docker.sh
@@ -5,7 +5,7 @@ function delay {
     if [ -x "$(command -v sleep)" ]; then
         sleep $time >/dev/null
     elif [ -x "$(command -v ping)" ]; then
-        ping -n $time 127.0.0.1 >nul
+        ping -c $((time+1)) 127.0.0.1 > /dev/null
     else
         count=0
 

--- a/src/Misc/layoutroot/run.sh
+++ b/src/Misc/layoutroot/run.sh
@@ -5,7 +5,7 @@ function delay {
     if [ -x "$(command -v sleep)" ]; then
         sleep $time >/dev/null
     elif [ -x "$(command -v ping)" ]; then
-        ping -n $time 127.0.0.1 >nul
+        ping -c $((time+1)) 127.0.0.1 > /dev/null
     else
         count=0
 


### PR DESCRIPTION
This looks like a small typo, so I was not sure if it was worth creating a separate issue and waiting for triage before preparing this PR.

I have been investigating our problem with the azure agent not being able to properly startup (sometimes) on self-hosted instances when my eye has caught this line. I do enjoy the cleverness of this solution, but unless this is some very specific use-case I'm not aware of - I see at least 3 different problems here.

1) I believe there is confusion between `-n` option for windows/linux ping. Actually, they mean different things

This will work for Windows:
```
PS C:\Users\onovak> ping -n 1 127.0.0.1

Pinging 127.0.0.1 with 32 bytes of data:
Reply from 127.0.0.1: bytes=32 time<1ms TTL=128

Ping statistics for 127.0.0.1:
    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
Approximate round trip times in milli-seconds:
    Minimum = 0ms, Maximum = 0ms, Average = 0ms
```

but not for linux:
```
onovak@KBP-9RSLRV2:/mnt/c/Users/onovak$ ping -n 1 127.0.0.1
ping: connect: Invalid argument
onovak@KBP-9RSLRV2:/mnt/c/Users/onovak$ ping -V
ping from iputils s20190709
```

so I believe that `-c` should be used instead:
```
onovak@KBP-9RSLRV2:/mnt/c/Users/onovak$ ping -c 1 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=128 time=0.250 ms

--- 127.0.0.1 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.250/0.250/0.250/0.000 ms
```

2) `>nul` will just redirect output to the `nul` file. It will work, but it will generate some trash file. I believe `> /dev/null` was supposed to be used here:
```
[root@ip-10-243-4-34 test]# ls
[root@ip-10-243-4-34 test]# ping -c 1 127.0.0.1 >nul
[root@ip-10-243-4-34 test]# ls
nul
```

3) With first and second updates in place, `delay 5` will wait only for ~4 seconds because this is four 1-second delays between pings + 5 pings (<1ms each). As a result - we will be way closer to 4s delay than to 5s:
```
onovak@KBP-9RSLRV2:/mnt/c/Users/onovak$ ping -c 5 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=128 time=0.232 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=128 time=0.737 ms
64 bytes from 127.0.0.1: icmp_seq=3 ttl=128 time=0.300 ms
64 bytes from 127.0.0.1: icmp_seq=4 ttl=128 time=0.640 ms
64 bytes from 127.0.0.1: icmp_seq=5 ttl=128 time=0.671 ms

--- 127.0.0.1 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4005ms
rtt min/avg/max/mdev = 0.232/0.516/0.737/0.207 ms
```

to test everything together I've tried:
```
function delay {
    time=${1:-1}

    date
    ping -c $((time+1)) 127.0.0.1 > /dev/null   #new
    date
    ping -n $time 127.0.0.1 >nul                #old
    date
    
}

delay 5

```

result:
```
# ./test.sh
Fri Sep  2 14:59:03 CEST 2022
Fri Sep  2 14:59:08 CEST 2022
ping: connect: Invalid argument
Fri Sep  2 14:59:08 CEST 2022
```
