### PR TITLE
Update Agent.Worker GitSourceProvider to not pass auth header in arguments

### DIFF
--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -39,6 +39,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
         }
 
+        public override bool GitSupportsConfigEnv(IExecutionContext executionContext, IGitCommandManager gitCommandManager)
+        {
+            return false;
+        }
+
         public override string GenerateAuthHeader(string username, string password)
         {
             // can't generate auth header for external git.
@@ -66,6 +71,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 ArgUtil.NotNull(_gitCommandManager, nameof(_gitCommandManager));
                 return _gitCommandManager.EnsureGitLFSVersion(_minGitLfsVersionSupportAuthHeader, throwOnNotMatch: false);
             }
+        }
+
+        public override bool GitSupportsConfigEnv(IExecutionContext executionContext, IGitCommandManager gitCommandManager)
+        {
+            // v2.31 git supports --config-env.
+            return gitCommandManager.EnsureGitVersion(_minGitVersionConfigEnv, throwOnNotMatch: false);
         }
 
         public override void RequirementCheck(IExecutionContext executionContext, ServiceEndpoint endpoint)
@@ -130,6 +141,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 ArgUtil.NotNull(_gitCommandManager, nameof(_gitCommandManager));
                 return _gitCommandManager.EnsureGitLFSVersion(_minGitLfsVersionSupportAuthHeader, throwOnNotMatch: false);
             }
+        }
+
+        public override bool GitSupportsConfigEnv(IExecutionContext executionContext, IGitCommandManager gitCommandManager)
+        {
+            // v2.31 git supports --config-env.
+            return gitCommandManager.EnsureGitVersion(_minGitVersionConfigEnv, throwOnNotMatch: false);
         }
 
         // When the repository is a TfsGit, figure out the endpoint is hosted vsts git or on-prem tfs git
@@ -222,9 +239,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         // Minimum git-lfs version that supports adding the extra auth header
         protected Version _minGitLfsVersionSupportAuthHeader = new Version(2, 1);
 
+        // min git version that supports new way to pass config via --config-env
+        // Info: https://github.com/git/git/commit/ce81b1da230cf04e231ce337c2946c0671ffb303
+        protected Version _minGitVersionConfigEnv = new Version(2, 31);
+
         public abstract bool GitUseAuthHeaderCmdlineArg { get; }
         public abstract bool GitLfsUseAuthHeaderCmdlineArg { get; }
         public abstract void RequirementCheck(IExecutionContext executionContext, ServiceEndpoint endpoint);
+        public abstract bool GitSupportsConfigEnv(IExecutionContext executionContext, IGitCommandManager gitCommandManager);
+
         public abstract string GenerateAuthHeader(string username, string password);
 
         public async Task GetSourceAsync(
@@ -337,6 +360,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 // Customer choose to own git creds by themselves.
                 executionContext.Output(StringUtil.Loc("SelfManageGitCreds"));
             }
+
+            bool gitUseSecureParameterPassing = AgentKnobs.GitUseSecureParameterPassing.GetValue(executionContext).AsBoolean();
 
             // Initialize git command manager
             _gitCommandManager = HostContext.GetService<IGitCommandManager>();
@@ -640,7 +665,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 // as long 2.9 git exist, VSTS repo, TFS repo and Github repo will use this to handle auth challenge.
                 if (GitUseAuthHeaderCmdlineArg)
                 {
-                    additionalFetchArgs.Add($"-c http.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"");
+                    string configKey = "http.extraheader";
+                    string args = ComposeGitArgs(executionContext, _gitCommandManager, configKey, username, password);
+                    additionalFetchArgs.Add(args);
                 }
                 else
                 {
@@ -728,7 +755,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     if (GitLfsUseAuthHeaderCmdlineArg)
                     {
                         string authorityUrl = repositoryUrl.AbsoluteUri.Replace(repositoryUrl.PathAndQuery, string.Empty);
-                        additionalLfsFetchArgs.Add($"-c http.{authorityUrl}.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"");
+                        string configKey = $"http.{authorityUrl}.extraheader";
+                        string lfsFetchArgs = ComposeGitArgs(executionContext, _gitCommandManager, configKey, username, password);
+                        additionalLfsFetchArgs.Add(lfsFetchArgs);
                     }
                     else
                     {
@@ -834,7 +863,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     if (GitUseAuthHeaderCmdlineArg)
                     {
                         string authorityUrl = repositoryUrl.AbsoluteUri.Replace(repositoryUrl.PathAndQuery, string.Empty);
-                        additionalSubmoduleUpdateArgs.Add($"-c http.{authorityUrl}.extraheader=\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"");
+                        string configKey = $"http.{authorityUrl}.extraheader";
+                        string submoduleUpdateArgs = ComposeGitArgs(executionContext, _gitCommandManager, configKey, username, password);
+                        additionalSubmoduleUpdateArgs.Add(submoduleUpdateArgs);
                     }
 
                     // Prepare proxy config for submodule update.
@@ -897,10 +928,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                     string configKey = $"http.{repositoryUrl.AbsoluteUri}.extraheader";
                     string configValue = $"\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"";
                     _configModifications[configKey] = configValue.Trim('\"');
-                    int exitCode_config = await _gitCommandManager.GitConfig(executionContext, targetPath, configKey, configValue);
-                    if (exitCode_config != 0)
+
+                    if (gitUseSecureParameterPassing)
                     {
-                        throw new InvalidOperationException($"Git config failed with exit code: {exitCode_config}");
+                        await SetAuthTokenInGitConfig(executionContext, _gitCommandManager, targetPath, configKey, configValue.Trim('\"'));
+                    }
+                    else
+                    {
+                        int exitCode_config = await _gitCommandManager.GitConfig(executionContext, targetPath, configKey, configValue);
+                        if (exitCode_config != 0)
+                        {
+                            throw new InvalidOperationException($"Git config failed with exit code: {exitCode_config}");
+                        }
                     }
                 }
 
@@ -1014,10 +1053,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                         string configKey = $"http.{repositoryUrl.AbsoluteUri}.extraheader";
                         string configValue = $"\"AUTHORIZATION: {GenerateAuthHeader(username, password)}\"";
                         _configModifications[configKey] = configValue.Trim('\"');
-                        int exitCode_config = await _gitCommandManager.GitConfig(executionContext, targetPath, configKey, configValue);
-                        if (exitCode_config != 0)
+
+                        if (gitUseSecureParameterPassing)
                         {
-                            throw new InvalidOperationException($"Git config failed with exit code: {exitCode_config}");
+                            await SetAuthTokenInGitConfig(executionContext, _gitCommandManager, targetPath, configKey, configValue.Trim('\"'));
+                        }
+                        else
+                        {
+                            int exitCode_config = await _gitCommandManager.GitConfig(executionContext, targetPath, configKey, configValue);
+                            if (exitCode_config != 0)
+                            {
+                                throw new InvalidOperationException($"Git config failed with exit code: {exitCode_config}");
+                            }
                         }
                     }
 
@@ -1229,6 +1276,32 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
         }
 
+        private async Task ReplaceTokenPlaceholder(IExecutionContext executionContext, string targetPath, string configKey, string tokenPlaceholderConfigValue, string configValue)
+        {
+            //modify git config file on disk.
+            if (!string.IsNullOrEmpty(configValue))
+            {
+                string gitConfig = Path.Combine(targetPath, ".git/config");
+                if (File.Exists(gitConfig))
+                {
+                    string gitConfigContent = File.ReadAllText(Path.Combine(targetPath, ".git", "config"));
+                    using (StreamWriter config = new StreamWriter(gitConfig))
+                    {
+                        if (gitConfigContent.Contains(tokenPlaceholderConfigValue))
+                        {
+                            executionContext.Debug($"Replace token placeholder in git config file");
+                            gitConfigContent = Regex.Replace(gitConfigContent, tokenPlaceholderConfigValue, configValue, RegexOptions.IgnoreCase);
+                        }
+                        await config.WriteAsync(gitConfigContent);
+                    }
+                }
+            }
+            else
+            {
+                executionContext.Warning(StringUtil.Loc("FailToReplaceTokenPlaceholderInGitConfig", configKey));
+            }
+        }
+
         private async Task RemoveCachedCredential(IExecutionContext context, string repositoryPath, Uri repositoryUrl, string remoteName)
         {
             // there is nothing cached in repository Url.
@@ -1289,6 +1362,56 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
 
             return refName;
+        }
+
+        private string ComposeGitArgs(IExecutionContext executionContext,
+            IGitCommandManager gitCommandManager,
+            string configKey,
+            string username,
+            string password)
+        {
+            bool gitSupportsConfigEnv = GitSupportsConfigEnv(executionContext, gitCommandManager);
+            bool gitUseSecureParameterPassing = AgentKnobs.GitUseSecureParameterPassing.GetValue(executionContext).AsBoolean();
+            string configValue = $"AUTHORIZATION: {GenerateAuthHeader(username, password)}";
+
+            // if git version is v2.31 or higher and GitUseSecureParameterPassing knob is enabled
+            if (gitSupportsConfigEnv && gitUseSecureParameterPassing)
+            {
+                string envVariableName = $"env_var_{configKey}";
+                Environment.SetEnvironmentVariable(envVariableName, configValue);
+
+                executionContext.Debug($"Set environment variable {envVariableName}");
+                return $"--config-env={configKey}={envVariableName}";
+            }
+            else
+            {
+                executionContext.Debug($"Use git -c option");
+                return $"-c {configKey}=\"{configValue}\"";
+            }
+        }
+
+        private async Task SetAuthTokenInGitConfig(IExecutionContext executionContext,
+            IGitCommandManager gitCommandManager,
+            string targetPath,
+            string configKey,
+            string configValue)
+        {
+            // Configure a placeholder value. This approach avoids the credential being captured
+            // by process creation audit events, which are commonly logged. For more information,
+            // refer to https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/component-updates/command-line-process-auditing
+
+            Guid tokenPlaceholder = Guid.NewGuid();
+            string tokenPlaceholderConfigValue = $"\"AUTHORIZATION: placeholder_{tokenPlaceholder}\"";
+
+            executionContext.Debug($"Configured placeholder: {tokenPlaceholderConfigValue}");
+
+            int exitCode_config = await gitCommandManager.GitConfig(executionContext, targetPath, configKey, tokenPlaceholderConfigValue);
+            if (exitCode_config != 0)
+            {
+                throw new InvalidOperationException($"Git config failed with exit code: {exitCode_config}");
+            }
+
+            await ReplaceTokenPlaceholder(executionContext, targetPath, configKey, tokenPlaceholderConfigValue.Trim('\"'), configValue);
         }
     }
 }

--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -1281,10 +1281,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             //modify git config file on disk.
             if (!string.IsNullOrEmpty(configValue))
             {
-                string gitConfig = Path.Combine(targetPath, ".git/config");
+                string gitConfig = Path.Combine(targetPath, ".git", "config");
                 if (File.Exists(gitConfig))
                 {
-                    string gitConfigContent = File.ReadAllText(Path.Combine(targetPath, ".git", "config"));
+                    string gitConfigContent = File.ReadAllText(gitConfig);
                     using (StreamWriter config = new StreamWriter(gitConfig))
                     {
                         if (gitConfigContent.Contains(tokenPlaceholderConfigValue))


### PR DESCRIPTION
Fix Agent.Worker/Build/[GitSourceProvider.cs](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Worker/Build/GitSourceProvider.cs) to not pass auth header in arguments.

1. Use [--config-env=name=envvar](https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt) git option  to pass http extraheaders instead of [-c name=value](https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt) 

2. Upadte git config file directly on the disc instead of running git config command for setting http extraheaders

Related PR: https://github.com/microsoft/azure-pipelines-agent/pull/3949