### PR TITLE
Remove Debugger.Launch from Test_Base_Node10

### DIFF
--- a/src/Test/L1/Worker/CoreL1Tests.cs
+++ b/src/Test/L1/Worker/CoreL1Tests.cs
@@ -82,7 +82,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     // Assert we used Node 10 from debug logs
-                    System.Diagnostics.Debugger.Launch();
                     var log = GetTimelineLogLines(steps[1]);
                     Assert.Equal(1, log.Where(x => x.Contains("Using node path:") && x.Contains("node10")).Count());
                 }


### PR DESCRIPTION
Just a small PR which removes debugging launch from test. 
Note that with this line, the test still passes in CI - https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=18248113&view=logs&j=06a33a71-ab93-5282-5919-5a79d81723b9&t=bd4d9075-3887-508e-9afc-cfd2f482127c&l=484
But it may fail in the future.