### PR TITLE
Pass oauth token for tf.exe utility securely to avoid it being logged in OS

### DIFF
--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -12,6 +12,7 @@ using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using System.IO;
 using Agent.Sdk.Knob;
+using System.Linq;
 
 namespace Agent.Plugins.Repository
 {
@@ -113,10 +114,8 @@ namespace Agent.Plugins.Repository
         {
             Guid guid = Guid.NewGuid();
             string temporaryName = $"tfs_cmd_{guid}.txt";
-            using(StreamWriter sw = new StreamWriter(Path.Combine(this.SourcesDirectory, temporaryName)))
-            {
-                sw.WriteLine(command);
-            }
+            using StreamWriter sw = new StreamWriter(Path.Combine(this.SourcesDirectory, temporaryName));
+            sw.WriteLine(command);
             return temporaryName;
         }
 
@@ -296,18 +295,11 @@ namespace Agent.Plugins.Repository
 
         private void CleanupTfsVCOutput(ref TfsVCPorcelainCommandResult command, string executedCommand)
         {
-            List<string> stringsToRemove = new List<string>();
-            foreach(var item in command.Output)
-            {
-                if(item.Contains(executedCommand))
-                {
-                    stringsToRemove.Add(item);
-                }
-            }
-            foreach(var item in stringsToRemove)
-            {
-                command.Output.Remove(item);
-            }
+            List<string> stringsToRemove = command
+                .Output
+                .Where(item => item.Contains(executedCommand))
+                .ToList();
+            command.Output.RemoveAll(item => stringsToRemove.Contains(item));
         }
 
         private string FormatArguments(FormatFlags formatFlags, params string[] args)

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -369,7 +369,5 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new EnvironmentKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new BuiltInDefaultKnobSource("false"));
-
-  
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -112,6 +112,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_GIT_USE_SECURE_PARAMETER_PASSING"),
             new BuiltInDefaultKnobSource("true"));
 
+        public static readonly Knob TfVCUseSecureParameterPassing = new Knob(
+            nameof(TfVCUseSecureParameterPassing),
+            "If true, don't pass auth token in TFVC parameters",
+            new RuntimeKnobSource("agent.TfVCUseSecureParameterPassing"),
+            new EnvironmentKnobSource("AGENT_TFVC_USE_SECURE_PARAMETER_PASSING"),
+            new BuiltInDefaultKnobSource("true"));
+
         public const string QuietCheckoutRuntimeVarName = "agent.source.checkout.quiet";
         public const string QuietCheckoutEnvVarName = "AGENT_SOURCE_CHECKOUT_QUIET";
 
@@ -362,5 +369,7 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new EnvironmentKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new BuiltInDefaultKnobSource("false"));
+
+  
     }
 }

--- a/src/Agent.Worker/Build/TfsVCCommandManager.cs
+++ b/src/Agent.Worker/Build/TfsVCCommandManager.cs
@@ -200,7 +200,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             return temporaryName;
         }
 
-
         protected async Task<TfsVCPorcelainCommandResult> TryRunPorcelainCommandAsync(FormatFlags formatFlags, bool ignoreStderr, params string[] args)
         {
             // Validation.


### PR DESCRIPTION
**Problem** 
In some cases operation system might log the execution of the `tf.exe` utility by `azure-pipelines-agent` and later these tokens might leak outside the system.

**Resolution**
This PR introduces a new Knob (which is disabled by default), which was presented to resolve any issues which these changes might cause.

**Testing**
Was covered:
Checkout procedure - passed
Release artifacts upload - passed
Using ADO and On-Prem solutions.

On the following systems: 
Windows 10 - passed
Ubuntu [in progress]

Now TFVC will use the prepared file as a command line argument and inside this file agent will store commands to execute. And remove this file after execution.

For cases where Agent is expecting XML output was added a method that removes extra output from the tf.exe command line utility