### PR TITLE
FEATURE: Agent should gather telemetry on Task runner invocations

### DIFF
--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -579,13 +579,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             
             Dictionary<string, string> telemetryData = new Dictionary<string, string>
             {
-                { "Task Name", Task.Reference.Name },
-                { "Task Id", Task.Reference.Id.ToString() },
+                { "TaskName", Task.Reference.Name },
+                { "TaskId", Task.Reference.Id.ToString() },
                 { "Version", Task.Reference.Version },
                 { "OS", PlatformUtil.HostOS.ToString() },
-                { "Expected Execution Handler", string.Join(", ", taskDefinition.Data.Execution.All) },
-                { "Real Execution Handler", handlerData.ToString() },
-                { "UseNode10", useNode10 }
+                { "ExpectedExecutionHandler", string.Join(", ", taskDefinition.Data.Execution.All) },
+                { "RealExecutionHandler", handlerData.ToString() },
+                { "UseNode10", useNode10 },
+                { "JobId", ExecutionContext.Variables.System_JobId.ToString()},
+                { "PlanId", ExecutionContext.Variables.Get("system.planId")}
             };
 
             var cmd = new Command("telemetry", "publish");

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             // Check that the target container is still running, if not Skip task execution
                             IDockerCommandManager dockerManager = HostContext.GetService<IDockerCommandManager>();
                             bool isContainerRunning = await dockerManager.IsContainerRunning(ExecutionContext, containerTarget.ContainerId);
-
+                            
                             if (!isContainerRunning)
                             {
                                 ExecutionContext.Result = TaskResult.Skipped;
@@ -487,10 +487,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 {
                     if ((currentExecution.All.Any(x => x is PowerShell3HandlerData)) &&
                         (currentExecution.All.Any(x => x is BaseNodeHandlerData)))
-                    {
-                        Trace.Info($"Since we are targeting a container, we will prefer a node handler if one is available");
-                        preferPowershellHandler = false;
-                    }
+                        {
+                            Trace.Info($"Since we are targeting a container, we will prefer a node handler if one is available");
+                            preferPowershellHandler = false;
+                        }
                 }
             }
             Trace.Info($"Get handler data for target platform {targetOS.ToString()}");

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -230,7 +230,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     taskDecoratorManager.IsInjectedInputsContainsSecrets(inputs, out var inputsWithSecrets))
                 {
                     var inputsForReport = taskDecoratorManager.GenerateTaskResultMessage(inputsWithSecrets);
-
                     ExecutionContext.Result = TaskResult.Skipped;
                     ExecutionContext.ResultCode = StringUtil.Loc("SecretsAreNotAllowedInInjectedTaskInputs", inputsForReport);
                     return;

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -590,8 +590,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var json = JsonConvert.SerializeObject(telemetryData, Formatting.None);
             var cmd = new Command("telemetry", "publish");
             cmd.Data = json;
-            cmd.Properties.Add("area", "AzurePipelinesAgent");
-            cmd.Properties.Add("feature", "TaskTelemetry");
+            cmd.Properties.Add("area", "PipelinesTasks");
+            cmd.Properties.Add("feature", "ExecutionHandler");
             publishTelemetryCmd.ProcessCommand(ExecutionContext, cmd);
         }
     }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -568,6 +568,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ExecutionContext.Output($"Help         : {taskDefinition.Data.HelpUrl ?? taskDefinition.Data.HelpMarkDown}");
             ExecutionContext.Output("==============================================================================");
         }
+
         private void PublishTelemetry(Definition taskDefinition, HandlerData handlerData)
         {
             ArgUtil.NotNull(Task, nameof(Task));
@@ -575,23 +576,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(taskDefinition.Data, nameof(taskDefinition.Data));
 
             var useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsString();
-            Dictionary<string, string> telemetryData = new Dictionary<string, string>();
-            telemetryData.Add("Task Name", Task.Reference.Name);
-            telemetryData.Add("Task Id", Task.Reference.Id.ToString());
-            telemetryData.Add("Version", Task.Reference.Version);
-            telemetryData.Add("OS", PlatformUtil.HostOS.ToString());
-            telemetryData.Add("Expected Execution Handler", string.Join(", ", taskDefinition.Data.Execution.All));
-            telemetryData.Add("Real Execution Handler", handlerData.ToString());
-            telemetryData.Add("UseNode10", useNode10);
-
-            var publishTelemetryCmd = new TelemetryCommandExtension();
-            publishTelemetryCmd.Initialize(HostContext);
+            
+            Dictionary<string, string> telemetryData = new Dictionary<string, string>
+            {
+                { "Task Name", Task.Reference.Name },
+                { "Task Id", Task.Reference.Id.ToString() },
+                { "Version", Task.Reference.Version },
+                { "OS", PlatformUtil.HostOS.ToString() },
+                { "Expected Execution Handler", string.Join(", ", taskDefinition.Data.Execution.All) },
+                { "Real Execution Handler", handlerData.ToString() },
+                { "UseNode10", useNode10 }
+            };
 
             var json = JsonConvert.SerializeObject(telemetryData, Formatting.None);
             var cmd = new Command("telemetry", "publish");
             cmd.Data = json;
             cmd.Properties.Add("area", "PipelinesTasks");
             cmd.Properties.Add("feature", "ExecutionHandler");
+
+            var publishTelemetryCmd = new TelemetryCommandExtension();
+            publishTelemetryCmd.Initialize(HostContext);
             publishTelemetryCmd.ProcessCommand(ExecutionContext, cmd);
         }
     }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -588,9 +588,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 { "UseNode10", useNode10 }
             };
 
-            var json = JsonConvert.SerializeObject(telemetryData, Formatting.None);
             var cmd = new Command("telemetry", "publish");
-            cmd.Data = json;
+            cmd.Data = JsonConvert.SerializeObject(telemetryData, Formatting.None);
             cmd.Properties.Add("area", "PipelinesTasks");
             cmd.Properties.Add("feature", "ExecutionHandler");
 

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -230,6 +230,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     taskDecoratorManager.IsInjectedInputsContainsSecrets(inputs, out var inputsWithSecrets))
                 {
                     var inputsForReport = taskDecoratorManager.GenerateTaskResultMessage(inputsWithSecrets);
+                    
                     ExecutionContext.Result = TaskResult.Skipped;
                     ExecutionContext.ResultCode = StringUtil.Loc("SecretsAreNotAllowedInInjectedTaskInputs", inputsForReport);
                     return;


### PR DESCRIPTION
**Description**:
Added new telemetry to be able to track task invocations distributed by runner.
This is needed to track progress with Node runner upgrades for tasks we don't own (Marketplace tasks).
Data collected:
- Task Name
- Task ID
- Version (Major/Minor/Patch)
- OS
- Expected Execution Handler
- Real Execution Handler
- UseNode10
- PlanId
- JobId

PlanId and JobId are collected for the purpose of using them in joining tables in Kusto query

**Changelog**:
- Added new function PublishTelemetry in Agent.Worker/TaskRunner.cs to prepare and publish telemetry data
- Added call of the new function PublishTelemetry in RunAsync method of TaskRunner
- Existing TelemetryCommandExtension and PublishTelemetryCommand classes of Agent Worker are used for publishing telemetry data

**Documentation changes required**: 
- Yes

**Added unit tests**: 
- NO

**Attached related issue**:
- Link to PR in the issue

**Checklist**:
- [x] There are no risky dependency updates
- [x] Changes have been tested