### PR TITLE
Added CloudId property to agent variables

### DIFF
--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -141,6 +141,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 jobContext.SetVariable(Constants.Variables.Agent.Id, settings.AgentId.ToString(CultureInfo.InvariantCulture));
                 jobContext.SetVariable(Constants.Variables.Agent.HomeDirectory, HostContext.GetDirectory(WellKnownDirectory.Root), isFilePath: true);
                 jobContext.SetVariable(Constants.Variables.Agent.JobName, message.JobDisplayName);
+                jobContext.SetVariable(Constants.Variables.Agent.CloudId, settings.AgentCloudId);
                 jobContext.SetVariable(Constants.Variables.Agent.MachineName, Environment.MachineName);
                 jobContext.SetVariable(Constants.Variables.Agent.Name, settings.AgentName);
                 jobContext.SetVariable(Constants.Variables.Agent.OS, VarUtil.OS);

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -279,6 +279,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 //
                 public static readonly string AcceptTeeEula = "agent.acceptteeeula";
                 public static readonly string BuildDirectory = "agent.builddirectory";
+                public static readonly string CloudId = "agent.cloudid";
                 public static readonly string ContainerId = "agent.containerid";
                 public static readonly string ContainerMapping = "agent.containermapping";
                 public static readonly string ContainerNetwork = "agent.containernetwork";
@@ -458,6 +459,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 // Agent variables
                 Agent.AcceptTeeEula,
                 Agent.BuildDirectory,
+                Agent.CloudId,
                 Agent.ContainerId,
                 Agent.ContainerMapping,
                 Agent.ContainerNetwork,


### PR DESCRIPTION
**Description**:
Added property Agent.CloudId for access outside the agent. 
It could be use to determine in pipeline or task is it running on a hosted agent, or not.

**Changelog**:

- Property CloudId added to the agent variables
- Added initialization of CloudId agent property on job running by AgentJobRequestMessage.AgentCloudId property

**Documentation changes required**: No

**Added unit tests**: No

**Attached related issue**: Link to PR in the task

**Checklist**:

- [x]  There are no risky dependency updates
- [x]  Changes have been tested