### PR TITLE
fix issue when repo/path contains spaces

### DIFF
--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -296,9 +296,10 @@ namespace Agent.Plugins.Repository
 
         private void CleanupTfsVCOutput(ref TfsVCPorcelainCommandResult command, string executedCommand)
         {
+            // tf.exe removes double quotes from the output, we also replace it in the input command to correctly find the extra output
             List<string> stringsToRemove = command
                 .Output
-                .Where(item => item.Contains(executedCommand))
+                .Where(item => item.Contains(executedCommand.Replace("\"", "")))
                 .ToList();
             command.Output.RemoveAll(item => stringsToRemove.Contains(item));
         }

--- a/src/Agent.Worker/Build/TfsVCCommandManager.cs
+++ b/src/Agent.Worker/Build/TfsVCCommandManager.cs
@@ -277,9 +277,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         private void CleanupTfsVCOutput(ref TfsVCPorcelainCommandResult command, string executedCommand)
         {
+            // tf.exe removes double quotes from the output, we also replace it in the input command to correctly find the extra output
             List<string> stringsToRemove = command
                 .Output
-                .Where(item => item.Contains(executedCommand))
+                .Where(item => item.Contains(executedCommand.Replace("\"", "")))
                 .ToList();
             command.Output.RemoveAll(item => stringsToRemove.Contains(item));
         }


### PR DESCRIPTION
**Problem Description:**
`tfs vc` plugin for the checkout task incorrectly handles the situation when the repository or agent paths contain spaces.
To avoid logging of the token by OS we [introduced saving `tfs vc` ](https://github.com/microsoft/azure-pipelines-agent/pull/3969)commands inside the temp file.

Since the agent using the output of the `tf` command internally additional function [was added ](https://github.com/microsoft/azure-pipelines-agent/blob/fdf9ee757d5dde6ca610ca300a5cda3600bf5ee7/src/Agent.Plugins/TfsVCCliManager.cs#L297) to remove extra output which is existed by design in `tf` cli tool
But tf utility is removing all double quotes in the output, and the agent is not correctly filtering this output in such cases

**What's changed**:
This PR introduces a fix to this function and replaces all double quotes in the command to correctly filter output.

**Testing**:
Tested locally with the following scenarios:
- [x] checkout tfs vc repository
- [x] checkout tfs vc repository when path contains spaces
- [x] checkout tfs vc repository in cases when the path to workdir / agent contains spaces.

**Related PRs**:
https://github.com/microsoft/azure-pipelines-agent/pull/3969