### PR TITLE
Revert all changes related to migration from RHEL6 to RHEL7

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -24,7 +24,8 @@ parameters:
   - win
   - linux
   - osx
-  - rhel.7
+  - rhel.6
+  - rhel.7.2
 
 - name: arch
   type: string

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -25,7 +25,6 @@ parameters:
   - linux
   - osx
   - rhel.6
-  - rhel.7.2
 
 - name: arch
   type: string

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -211,7 +211,7 @@ jobs:
       displayName: Hash Package
 
     # Upload agent package zip as build artifact
-    - task: PublishBuildArtifacts@1
+    - task: PublishBuildArtifacts@1.200.0
       displayName: Publish Artifact
       inputs:
         pathToPublish: _package
@@ -219,7 +219,7 @@ jobs:
         artifactType: container
 
     # Publish agent package hash too
-    - task: PublishBuildArtifacts@1
+    - task: PublishBuildArtifacts@1.200.0
       displayName: Publish Artifact
       inputs:
         pathToPublish: _package_hash

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -115,7 +115,7 @@ jobs:
         ADO_ENABLE_LOGISSUE: true
 
   # Check if broken symlinks exist in the agent build
-  - task: Bash@3
+  - task: Bash@3.201.1
     inputs:
       filePath: src/Misc/check-symlinks.sh
     displayName: Check symlinks
@@ -155,7 +155,7 @@ jobs:
       condition: always()
 
     # Upload test log
-    - task: PublishBuildArtifacts@1
+    - task: PublishBuildArtifacts@1.200.0
       displayName: Publish Test logs
       inputs:
         pathToPublish: src/Test/TestLogs

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -40,7 +40,7 @@ parameters:
 - name: linux_arm64
   type: boolean
   default: true
-- name: rhel7_x64
+- name: rhel6_x64
   type: boolean
   default: true
 - name: macOS_x64
@@ -53,8 +53,6 @@ resources:
     image: azpagentinfra/arm:latest
   - container: dotnetcore_centos6
     image: azpagentinfra/centos6:latest
-  - container: dotnetcore_centos7
-    image: azpagentinfra/centos7:latest
 
 stages:
 
@@ -159,16 +157,16 @@ stages:
         publishArtifacts: ${{ parameters.publishArtifacts }}
         buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
 
-  # RHEL7 (x64)
-  - ${{ if parameters.rhel7_x64  }}:
+  # RHEL6 (x64)
+  - ${{ if parameters.rhel6_x64 }}:
     - template: build-jobs.yml
       parameters:
-        jobName: build_rhel7_x64
-        displayName: RHEL7 (x64)
+        jobName: build_rhel6_x64
+        displayName: RHEL6 (x64)
         pool:
           vmImage: ubuntu-18.04
-        container: dotnetcore_centos7
-        os: linux
+        container: dotnetcore_centos6
+        os: rhel.6
         arch: x64
         branch: ${{ parameters.branch }}
         componentDetection: false

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -19,10 +19,10 @@ parameters:
   type: boolean
   displayName: Linux (ARM64)
   default: false
-- name: rhel7_x64
+- name: rhel6_x64
   type: boolean
-  displayName: RHEL 7 (x64)
-  default: false
+  displayName: RHEL 6 (x64)
+  default: true
 - name: macOS_x64
   type: boolean
   displayName: macOS (x64)
@@ -47,5 +47,5 @@ extends:
     linux_x64: ${{ parameters.linux_x64 }}
     linux_arm: ${{ parameters.linux_arm }}
     linux_arm64: ${{ parameters.linux_arm64 }}
-    rhel7_x64: ${{ parameters.rhel7_x64 }}
+    rhel6_x64: ${{ parameters.rhel6_x64 }}
     macOS_x64: ${{ parameters.macOS_x64 }}

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Written for .NET Core in C#.
 |![macOS](docs/res/apple_med.png) **macOS**|[![Build & Test][macOS-build-badge]][build]| 
 |![Linux-x64](docs/res/linux_med.png) **Linux x64**|[![Build & Test][linux-x64-build-badge]][build]|
 |![Linux-arm](docs/res/linux_med.png) **Linux ARM**|[![Build & Test][linux-arm-build-badge]][build]|
-|![RHEL7-x64](docs/res/redhat_med.png) **RHEL 7 x64**|[![Build & Test][rhel7-x64-build-badge]][build]|
+|![RHEL6-x64](docs/res/redhat_med.png) **RHEL 6 x64**|[![Build & Test][rhel6-x64-build-badge]][build]|
 
 [win-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x64)
 [win-x86-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x86)
 [macOS-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=macOS%20(x64)
 [linux-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(x64)
 [linux-arm-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(ARM)
-[rhel7-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=RHEL7%20(x64)
+[rhel6-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=RHEL6%20(x64)
 [build]: https://mseng.visualstudio.com/PipelineTools/_build?_a=completed&definitionId=7502
 
 ## Get the Agent

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ Written for .NET Core in C#.
 |![macOS](docs/res/apple_med.png) **macOS**|[![Build & Test][macOS-build-badge]][build]| 
 |![Linux-x64](docs/res/linux_med.png) **Linux x64**|[![Build & Test][linux-x64-build-badge]][build]|
 |![Linux-arm](docs/res/linux_med.png) **Linux ARM**|[![Build & Test][linux-arm-build-badge]][build]|
+|![RHEL7-x64](docs/res/redhat_med.png) **RHEL 7 x64**|[![Build & Test][rhel7-x64-build-badge]][build]|
 
 [win-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x64)
 [win-x86-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x86)
 [macOS-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=macOS%20(x64)
 [linux-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(x64)
 [linux-arm-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(ARM)
+[rhel7-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=RHEL7%20(x64)
 [build]: https://mseng.visualstudio.com/PipelineTools/_build?_a=completed&definitionId=7502
 
 ## Get the Agent

--- a/assets.json
+++ b/assets.json
@@ -72,15 +72,15 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
     },
     {
-        "name": "vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz",
-        "platform": "rhel.7-x64",
+        "name": "vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz",
+        "platform": "rhel.6-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz"
     },
     {
-        "name": "pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz",
-        "platform": "rhel.7-x64",
+        "name": "pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz",
+        "platform": "rhel.6-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz"
     }
 ]

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -9,6 +9,7 @@
 | Linux x64   | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM   | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM64 | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 
 After Download:
 
@@ -74,3 +75,4 @@ See [notes](docs/node6.md) on Node version support for more details.
 | Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| RHEL 6 x64  | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | <HASH> |

--- a/src/Common.props
+++ b/src/Common.props
@@ -43,8 +43,8 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-x64'">
     <OSArchitecture>X64</OSArchitecture>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'rhel.7-x64'">
-    <OSArchitecture>OS_RHEL7;X64</OSArchitecture>
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'rhel.6-x64'">
+    <OSArchitecture>OS_RHEL6;X64</OSArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-arm'">
     <OSArchitecture>ARM</OSArchitecture>

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -64,5 +64,15 @@
         <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add x64 Redhat 6 agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="agent" platform="rhel.7-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add x64 Redhat 6 alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.7-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
   </Steps>
 </ServicingStepGroup>

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -66,12 +66,12 @@
     </ServicingStep>
     <ServicingStep name="Add x64 Redhat 6 agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="rhel.7-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="rhel.6-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Redhat 6 alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.7-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.6-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
   </Steps>

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -16,7 +16,7 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Add-DistributedTaskPackage -PackageType agent -Platform linux-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz
 
-    Add-DistributedTaskPackage -PackageType agent -Platform rhel.7-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz
+    Add-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
 
     # alternate packages
 
@@ -32,5 +32,5 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Add-DistributedTaskPackage -PackageType pipelines-agent -Platform linux-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz
 
-    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform rhel.7-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
 }

--- a/src/Misc/PublishVSTSAgent.template.ps1
+++ b/src/Misc/PublishVSTSAgent.template.ps1
@@ -11,5 +11,5 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Add-DistributedTaskPackage -PackageType agent -Platform linux-arm -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz
 
-    Add-DistributedTaskPackage -PackageType agent -Platform rhel.7-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.7-x64-<AGENT_VERSION>.tar.gz
+    Add-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
 }

--- a/src/Misc/UnpublishVSTSAgent.template.ps1
+++ b/src/Misc/UnpublishVSTSAgent.template.ps1
@@ -11,5 +11,5 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Remove-DistributedTaskPackage -PackageType agent -Platform linux-arm -Version <AGENT_VERSION>
 
-    Remove-DistributedTaskPackage -PackageType agent -Platform rhel.7-x64 -Version <AGENT_VERSION>
+    Remove-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION>
 }

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -191,12 +191,12 @@ if [[ "$PACKAGERUNTIME" == "osx-x64" ]]; then
 fi
 
 # Download the external tools common across OSX and Linux PACKAGERUNTIMEs.
-if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "linux-arm" || "$PACKAGERUNTIME" == "linux-arm64" || "$PACKAGERUNTIME" == "osx-x64" || "$PACKAGERUNTIME" == "rhel.7.2-x64" ]]; then
+if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "linux-arm" || "$PACKAGERUNTIME" == "linux-arm64" || "$PACKAGERUNTIME" == "osx-x64" || "$PACKAGERUNTIME" == "rhel.6-x64" ]]; then
     acquireExternalTool "$CONTAINER_URL/vso-task-lib/0.5.5/vso-task-lib.tar.gz" vso-task-lib
 fi
 
 # Download the external tools common across Linux PACKAGERUNTIMEs (excluding OSX).
-if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "rhel.7.2-x64" ]]; then
+if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "rhel.6-x64" ]]; then
     if [[ "$INCLUDE_NODE6" == "true" ]]; then
         acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" node fix_nested_dir
     fi

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -191,12 +191,12 @@ if [[ "$PACKAGERUNTIME" == "osx-x64" ]]; then
 fi
 
 # Download the external tools common across OSX and Linux PACKAGERUNTIMEs.
-if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "linux-arm" || "$PACKAGERUNTIME" == "linux-arm64" || "$PACKAGERUNTIME" == "osx-x64" || "$PACKAGERUNTIME" == "rhel.7-x64" ]]; then
+if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "linux-arm" || "$PACKAGERUNTIME" == "linux-arm64" || "$PACKAGERUNTIME" == "osx-x64" || "$PACKAGERUNTIME" == "rhel.7.2-x64" ]]; then
     acquireExternalTool "$CONTAINER_URL/vso-task-lib/0.5.5/vso-task-lib.tar.gz" vso-task-lib
 fi
 
 # Download the external tools common across Linux PACKAGERUNTIMEs (excluding OSX).
-if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "rhel.7-x64" ]]; then
+if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "rhel.7.2-x64" ]]; then
     if [[ "$INCLUDE_NODE6" == "true" ]]; then
         acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" node fix_nested_dir
     fi

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 "linux-arm",
                 "linux-arm64",
                 "rhel.6-x64",
-                "rhel.7.2-x64",
                 "osx-x64"
             };
 

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 "linux-arm",
                 "linux-arm64",
                 "rhel.6-x64",
-                "rhel.7-x64",
+                "rhel.7.2-x64",
                 "osx-x64"
             };
 

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -68,9 +68,6 @@ function detect_platform_and_runtime_id ()
             if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
                 DETECTED_RUNTIME_ID='rhel.6-x64'
             fi
-            if [[ $redhatRelease == "CentOS release 7."* || $redhatRelease == "Red Hat Enterprise Linux Server release 7."* ]]; then
-                DETECTED_RUNTIME_ID='rhel.7.2-x64'
-            fi
         fi
 
     elif [[ "$CURRENT_PLATFORM" == 'darwin' ]]; then
@@ -294,7 +291,7 @@ else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
 fi
 
-_VALID_RIDS='linux-x64:linux-arm:linux-arm64:rhel.6-x64:rhel.7.2-x64:osx-x64:win-x64:win-x86'
+_VALID_RIDS='linux-x64:linux-arm:linux-arm64:rhel.6-x64:osx-x64:win-x64:win-x86'
 if [[ ":$_VALID_RIDS:" != *:$RUNTIME_ID:* ]]; then
     failed "must specify a valid target runtime ID (one of: $_VALID_RIDS)"
 fi

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -69,7 +69,7 @@ function detect_platform_and_runtime_id ()
                 DETECTED_RUNTIME_ID='rhel.6-x64'
             fi
             if [[ $redhatRelease == "CentOS release 7."* || $redhatRelease == "Red Hat Enterprise Linux Server release 7."* ]]; then
-                DETECTED_RUNTIME_ID='rhel.7-x64'
+                DETECTED_RUNTIME_ID='rhel.7.2-x64'
             fi
         fi
 
@@ -294,7 +294,7 @@ else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
 fi
 
-_VALID_RIDS='linux-x64:linux-arm:linux-arm64:rhel.6-x64:rhel.7-x64:osx-x64:win-x64:win-x86'
+_VALID_RIDS='linux-x64:linux-arm:linux-arm64:rhel.6-x64:rhel.7.2-x64:osx-x64:win-x64:win-x86'
 if [[ ":$_VALID_RIDS:" != *:$RUNTIME_ID:* ]]; then
     failed "must specify a valid target runtime ID (one of: $_VALID_RIDS)"
 fi


### PR DESCRIPTION
Since we need to maintain next few versions of agent for `RHEL6` as well we need to set version of affected tasks to one which is not migrated to `Node16` yet instead of migration from RHEL6 to RHEL7.

Change Log:
- reverted all changes related to migration from RHEL6 to RHEL7
- hardcoded version of tasks for `PublishBuildArtifacts` and `Bash`