### PR TITLE
Avoid agent downgrading from 3.x to 2.x

### DIFF
--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -147,6 +147,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             Trace.Info($"Current running agent version is {BuildConstants.AgentPackage.Version}");
             PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
 
+            if (serverVersion.Major == 2 && agentVersion.Major == 3)
+            {
+                Trace.Info("We don't downgrade agent from 3.* to 2.*, skipping update");
+                return false;
+            }
+
             if (serverVersion.CompareTo(agentVersion) > 0)
             {
                 return true;


### PR DESCRIPTION
**Description of issue**:

Need to add a logic to prevent agent downgrading from version `3.*` to `2.*` 

**Description of fix**:

Added logic to skip updating agent if major numbers of server version is `2` and agent version is `3`

**Added unit tests**: 
- NO

**Attached related issue**:
- Link to PR in the issue

**Checklist**:
- [x] There are no risky dependency updates
- [x] Changes have been tested