### PR TITLE
Fix issues after conflict resolving for dotnet 6 issues

### DIFF
--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -119,7 +119,7 @@ namespace Agent.Plugins.Repository
             return temporaryName;
         }
 
-        protected async Task<int> RunCommandAsync(FormatFlags formatFlags, bool quiet, bool failOnNonZeroExitCode, params string[] args)
+        protected async Task<int> RunCommandAsync(FormatTags formatFlags, bool quiet, bool failOnNonZeroExitCode, params string[] args)
         {
             // Validation.
             ArgUtil.NotNull(args, nameof(args));
@@ -304,7 +304,7 @@ namespace Agent.Plugins.Repository
             command.Output.RemoveAll(item => stringsToRemove.Contains(item));
         }
 
-        private string FormatArguments(FormatFlags formatFlags, params string[] args)
+        private string FormatArguments(FormatTags formatFlags, params string[] args)
         {
             // Validation.
             ArgUtil.NotNull(args, nameof(args));

--- a/src/Agent.Worker/Build/TfsVCCommandManager.cs
+++ b/src/Agent.Worker/Build/TfsVCCommandManager.cs
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             return temporaryName;
         }
 
-        protected async Task<TfsVCPorcelainCommandResult> TryRunPorcelainCommandAsync(FormatFlags formatFlags, bool ignoreStderr, params string[] args)
+        protected async Task<TfsVCPorcelainCommandResult> TryRunPorcelainCommandAsync(FormatTags formatFlags, bool ignoreStderr, params string[] args)
         {
             // Validation.
             ArgUtil.NotNull(args, nameof(args));
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             command.Output.RemoveAll(item => stringsToRemove.Contains(item));
         }
 
-        private string FormatArguments(FormatFlags formatFlags, params string[] args)
+        private string FormatArguments(FormatTags formatFlags, params string[] args)
         {
             // Validation.
             ArgUtil.NotNull(args, nameof(args));

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -575,7 +575,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(Task.Reference, nameof(Task.Reference));
             ArgUtil.NotNull(taskDefinition.Data, nameof(taskDefinition.Data));
 
-            var useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsString();
+            var useNode10 = AgentKnobs.UseNode16.GetValue(ExecutionContext).AsString();
             
             Dictionary<string, string> telemetryData = new Dictionary<string, string>
             {


### PR DESCRIPTION
After resolving conflicts and moving all changes to a separate branch we face issues with the agent's building.

This PR fixes node10-> node16 knob and FormatFlags on TFVC Provider