### PR TITLE
Fixed NullReferenceException in v3.212.0 preview version Agent

### DIFF
--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -576,7 +576,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(taskDefinition.Data, nameof(taskDefinition.Data));
 
             var useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsString();
-            var expectedExecutionHandler = (taskDefinition.Data.Execution != null && taskDefinition.Data.Execution.All != null) ? string.Join(", ", taskDefinition.Data.Execution.All) : "";
+            var expectedExecutionHandler = (taskDefinition.Data.Execution?.All != null) ? string.Join(", ", taskDefinition.Data.Execution.All) : "";
             
             Dictionary<string, string> telemetryData = new Dictionary<string, string>
             {

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -577,6 +577,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             var useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsString();
             var expectedExecutionHandler = (taskDefinition.Data.Execution != null && taskDefinition.Data.Execution.All != null) ? string.Join(", ", taskDefinition.Data.Execution.All) : "";
+            
             Dictionary<string, string> telemetryData = new Dictionary<string, string>
             {
                 { "TaskName", Task.Reference.Name },

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -576,14 +576,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNull(taskDefinition.Data, nameof(taskDefinition.Data));
 
             var useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsString();
-            
+            var expectedExecutionHandler = (taskDefinition.Data.Execution != null && taskDefinition.Data.Execution.All != null) ? string.Join(", ", taskDefinition.Data.Execution.All) : "";
             Dictionary<string, string> telemetryData = new Dictionary<string, string>
             {
                 { "TaskName", Task.Reference.Name },
                 { "TaskId", Task.Reference.Id.ToString() },
                 { "Version", Task.Reference.Version },
                 { "OS", PlatformUtil.HostOS.ToString() },
-                { "ExpectedExecutionHandler", string.Join(", ", taskDefinition.Data.Execution.All) },
+                { "ExpectedExecutionHandler", expectedExecutionHandler },
                 { "RealExecutionHandler", handlerData.ToString() },
                 { "UseNode10", useNode10 },
                 { "JobId", ExecutionContext.Variables.System_JobId.ToString()},


### PR DESCRIPTION
Fix for PublishTelemetry:
Added check for taskDefinition.Data.Execution, because it turned out that not all tasks have Execution information.