### PR TITLE
Rhel 6 add node10 fallback

### DIFF
--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             bool taskHasNode16Data = Data is Node16HandlerData;
 
             string nodeFolder = "node";
-            if(PlatformUtil.RunningOnRHEL6 && taskHasNode16Data)
+            if (PlatformUtil.RunningOnRHEL6 && taskHasNode16Data)
             {
                 Trace.Info($"Detected RedHat 6, using node 10 as execution handler, instead node16");
                 nodeFolder = "node10";

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -179,7 +179,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             {
                 Trace.Info($"Detected RedHat 6, using node 10 as execution handler, instead node16");
                 nodeFolder = "node10";
-            } else if (taskHasNode16Data)
+            }
+            else if (taskHasNode16Data)
             {
                 Trace.Info($"Task.json has node16 handler data: {taskHasNode16Data}");
                 nodeFolder = "node16";

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 Trace.Info($"Task.json has node10 handler data: {taskHasNode10Data}");
                 nodeFolder = "node10";
             }
-            else if (useNode10)
+            if (useNode10)
             {
                 Trace.Info($"Found UseNode10 knob, use node10 for node tasks: {useNode10}");
                 nodeFolder = "node10";

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -175,7 +175,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             bool taskHasNode16Data = Data is Node16HandlerData;
 
             string nodeFolder = "node";
-            if (taskHasNode16Data)
+            if(PlatformUtil.RunningOnRHEL6 && taskHasNode16Data)
+            {
+                Trace.Info($"Detected RedHat 6, using node 10 as execution handler, instead node16");
+                nodeFolder = "node10";
+            } else if (taskHasNode16Data)
             {
                 Trace.Info($"Task.json has node16 handler data: {taskHasNode16Data}");
                 nodeFolder = "node16";

--- a/src/Test/L0/NodeHandlerL0.cs
+++ b/src/Test/L0/NodeHandlerL0.cs
@@ -61,6 +61,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.Data = nodeVersion == "node16" ? (BaseNodeHandlerData)new Node16HandlerData() : (BaseNodeHandlerData)new Node10HandlerData();
 
                 string actualLocation = nodeHandler.GetNodeLocation();
+                // We should fall back to node10 for node16 tasks, since RHEL 6 is not capable with Node16.
+                if (PlatformUtil.RunningOnRHEL6 && nodeVersion == "node16")
+                {
+                    nodeVersion = "node10";
+                }
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     nodeVersion,
                     "bin",


### PR DESCRIPTION
**Problem**
`RedHat Linux 6` due to old packages is not able to run Node16. 

**Changes**
This PR is switching handler always to `node10` if the system is `RHEL6`.
Also changed logic of `AGENT_USE_NODE10` knob - it will force to use node 10 if specified.

**Testing**
Tested on centos6, + centos6 docker images.