### PR TITLE
Add null & empty check for DeactivateVsoCommands

### DIFF
--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -255,8 +255,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         /// <returns>String without vso commands that can be executed</returns>
         public static string DeactivateVsoCommands(string input)
         {
-            var vsoRegex = new Regex("##vso", RegexOptions.IgnoreCase);
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
 
+            var vsoRegex = new Regex("##vso", RegexOptions.IgnoreCase);
             return vsoRegex.Replace(input, "**vso");
         }
     }

--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -109,7 +109,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 if (deactivatedVariables.TryGetValue(variableName, out var variable))
                 {
-                    deactivatedVariables[variableName] = StringUtil.DeactivateVsoCommands(variable.Value);
+                    var deactivatedVariable = variable ?? new VariableValue();
+
+                    deactivatedVariables[variableName] = StringUtil.DeactivateVsoCommands(deactivatedVariable.Value);
                 }
             }
 

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [InlineData("#vso", "#vso")]
         [InlineData("##vs", "##vs")]
         [InlineData("##VsO", "**vso")]
-        [InlineData("","")]
+        [InlineData("", "")]
         [InlineData(null, "")]
         [InlineData(" ", " ")]
         public void DeactivateVsoCommandsFromStringTest(string input, string expected)

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -20,6 +20,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [InlineData("#vso", "#vso")]
         [InlineData("##vs", "##vs")]
         [InlineData("##VsO", "**vso")]
+        [InlineData("","")]
+        [InlineData(null, "")]
+        [InlineData(" ", " ")]
         public void DeactivateVsoCommandsFromStringTest(string input, string expected)
         {
             var result = StringUtil.DeactivateVsoCommands(input);

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Trait("Category", "Worker")]
         public void VerifyJobRequestMessageVsoCommandsDeactivated()
         {
-            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobwitvsocommands");
+            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobWithVsoCommands");
 
             message.Variables[Constants.Variables.Build.SourceVersionMessage] = "##vso[setVariable]etc1";
             message.Variables[Constants.Variables.System.SourceVersionMessage] = "##vso[setVariable]etc2";
@@ -253,7 +253,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Trait("Category", "Worker")]
         public void VerifyIfOtherVariablesNotDeactivatesVsoCommands()
         {
-            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobwitvsocommands");
+            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobWithVsoCommands");
 
             message.Variables[Constants.Variables.Build.RepoName] = "##vso[setVariable]etc1";
             message.Variables[Constants.Variables.System.JobId] = "##vso[setVariable]etc2";
@@ -269,7 +269,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Trait("Category", "Worker")]
         public void VerifyJobRequestMessageVsoCommandsDeactivatedIfVariableCasesNotMatch()
         {
-            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobwitvsocommands");
+            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobWithVsoCommands");
 
             message.Variables[Constants.Variables.Build.SourceVersionMessage.ToUpper()] = "##vso[setVariable]etc1";
             message.Variables[Constants.Variables.System.SourceVersionMessage.ToUpper()] = "##vso[setVariable]etc2";
@@ -289,7 +289,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Trait("Category", "Worker")]
         public void VerifyJobRequestMessageVsoCommandsDeactivatedIfVariableCasesHandlesNullValues()
         {
-            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobwitvsocommands");
+            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobWithVsoCommands");
 
             message.Variables[Constants.Variables.Build.SourceVersionMessage] = "";
             message.Variables[Constants.Variables.System.SourceVersionMessage] = null;

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -284,6 +284,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             Assert.Equal("**vso[setVariable]etc4", scrubbedMessage.Variables[Constants.Variables.System.DefinitionName]);
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void VerifyJobRequestMessageVsoCommandsDeactivatedIfVariableCasesHandlesNullValues()
+        {
+            Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobwitvsocommands");
+
+            message.Variables[Constants.Variables.Build.SourceVersionMessage] = "";
+            message.Variables[Constants.Variables.System.SourceVersionMessage] = null;
+            message.Variables[Constants.Variables.Build.DefinitionName] = " ";
+
+            var scrubbedMessage = WorkerUtilities.DeactivateVsoCommandsFromJobMessageVariables(message);
+
+            Assert.Equal("", scrubbedMessage.Variables[Constants.Variables.Build.SourceVersionMessage]);
+            Assert.Equal("", scrubbedMessage.Variables[Constants.Variables.System.SourceVersionMessage]);
+            Assert.Equal(" ", scrubbedMessage.Variables[Constants.Variables.Build.DefinitionName]);
+        }
+
         private bool IsMessageIdentical(Pipelines.AgentJobRequestMessage source, Pipelines.AgentJobRequestMessage target)
         {
             if (source == null && target == null)


### PR DESCRIPTION
Fix the runtime failure if the input for `DeactivateVsoCommands` is null

Previous PR with implementation - https://github.com/microsoft/azure-pipelines-agent/pull/3987

Changelog:
- Added null checking for `DeactivateVsoCommands` and `DeactivateVsoCommandsFromJobMessageVariables`
- Added new test cases