### PR TITLE
Change PowerShell ExecutionPolicy to RemoteSigned

### DIFF
--- a/src/Agent.Worker/DiagnosticLogManager.cs
+++ b/src/Agent.Worker/DiagnosticLogManager.cs
@@ -583,7 +583,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             string scriptFile = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), "powershell", "Get-LocalGroupMembership.ps1").Replace("'", "''");
             ArgUtil.File(scriptFile, nameof(scriptFile));
-            string arguments = $@"-NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "". '{scriptFile}'""";
+            string arguments = $@"-NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command "". '{scriptFile}'""";
 
             try
             {

--- a/src/Microsoft.VisualStudio.Services.Agent/Capabilities/PowerShellCapabilitiesProvider.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Capabilities/PowerShellCapabilitiesProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Capabilities
             string powerShellExe = HostContext.GetService<IPowerShellExeUtil>().GetPath();
             string scriptFile = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), "powershell", "Add-Capabilities.ps1").Replace("'", "''");
             ArgUtil.File(scriptFile, nameof(scriptFile));
-            string arguments = $@"-NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "". '{scriptFile}'""";
+            string arguments = $@"-NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command "". '{scriptFile}'""";
 
             string enablePrereleaseVSVersions = AgentKnobs.EnableVSPreReleaseVersions.GetValue(UtilKnobValueContext.Instance()).AsString();
             Environment.SetEnvironmentVariable("IncludePrereleaseVersions", enablePrereleaseVSVersions);


### PR DESCRIPTION
Description: Change PowerShell ExecutionPolicy to RemoteSigned when executing embedded scripts.

Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/3997

Checklist:
- [x] There are no risky dependency updates
- [x] Changes have been tested with Windows and Unix systems