### PR TITLE
Fix for agent hang when process cannot be killed

### DIFF
--- a/src/Agent.Listener/JobDispatcher.cs
+++ b/src/Agent.Listener/JobDispatcher.cs
@@ -444,6 +444,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                 inheritConsoleHandler: false,
                                 keepStandardInOpen: false,
                                 highPriorityProcess: true,
+                                continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,
                                 cancellationToken: workerProcessCancelTokenSource.Token);
                         }
                     );

--- a/src/Agent.Sdk/AssemblyInfo.cs
+++ b/src/Agent.Sdk/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Test")]

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -375,8 +375,9 @@ namespace Agent.Sdk.Knob
         public static readonly Knob ContinueAfterCancelProcessTreeKillAttempt = new Knob(
             nameof(ContinueAfterCancelProcessTreeKillAttempt),
             "If true, continue cancellation after attempt to KillProcessTree",
+            new RuntimeKnobSource(ContinueAfterCancelProcessTreeKillAttemptVariableName),
             new EnvironmentKnobSource(ContinueAfterCancelProcessTreeKillAttemptVariableName),
-            new BuiltInDefaultKnobSource("true"));
+            new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob UseNode = new Knob(
             nameof(UseNode),

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -369,5 +369,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new EnvironmentKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob ContinueAfterCancelProcessTreeKillAttempt = new Knob(
+            nameof(ContinueAfterCancelProcessTreeKillAttempt),
+            "If true, continue cancellation after attempt to KillProcessTree",
+            new RuntimeKnobSource("VSTSAGENT_CONTINUE_AFTER_CANCEL_PROCESSTREEKILL_ATTEMPT"),
+            new EnvironmentKnobSource("VSTSAGENT_CONTINUE_AFTER_CANCEL_PROCESSTREEKILL_ATTEMPT"),
+            new BuiltInDefaultKnobSource("true"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -370,11 +370,12 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTSAGENT_DUMP_PACKAGES_VERIFICATION_RESULTS"),
             new BuiltInDefaultKnobSource("false"));
 
+        public const string ContinueAfterCancelProcessTreeKillAttemptVariableName = "VSTSAGENT_CONTINUE_AFTER_CANCEL_PROCESSTREEKILL_ATTEMPT";
+
         public static readonly Knob ContinueAfterCancelProcessTreeKillAttempt = new Knob(
             nameof(ContinueAfterCancelProcessTreeKillAttempt),
             "If true, continue cancellation after attempt to KillProcessTree",
-            new RuntimeKnobSource("VSTSAGENT_CONTINUE_AFTER_CANCEL_PROCESSTREEKILL_ATTEMPT"),
-            new EnvironmentKnobSource("VSTSAGENT_CONTINUE_AFTER_CANCEL_PROCESSTREEKILL_ATTEMPT"),
+            new EnvironmentKnobSource(ContinueAfterCancelProcessTreeKillAttemptVariableName),
             new BuiltInDefaultKnobSource("true"));
     }
 }

--- a/src/Agent.Sdk/ProcessInvoker.MacLinux.cs
+++ b/src/Agent.Sdk/ProcessInvoker.MacLinux.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Services.Agent.Util
 {
-    public sealed partial class ProcessInvoker : IDisposable
+    public partial class ProcessInvoker : IDisposable
     {
         private async Task<bool> SendPosixSignal(PosixSignals signal, TimeSpan timeout)
         {

--- a/src/Agent.Sdk/ProcessInvoker.Windows.cs
+++ b/src/Agent.Sdk/ProcessInvoker.Windows.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Services.Agent.Util
 {
-    public sealed partial class ProcessInvoker : IDisposable
+    public partial class ProcessInvoker : IDisposable
     {
         private async Task<bool> SendCtrlSignal(ConsoleCtrlEvent signal, TimeSpan timeout)
         {

--- a/src/Agent.Sdk/ProcessInvoker.cs
+++ b/src/Agent.Sdk/ProcessInvoker.cs
@@ -326,10 +326,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }))
             {
                 Trace.Info($"Process started with process id {_proc.Id}, waiting for process exit.");
+                bool continueAfterCancelProcessTreeKillAttempt = AgentKnobs.ContinueAfterCancelProcessTreeKillAttempt.GetValue(UtilKnobValueContext.Instance()).AsBoolean();
+
                 while (true)
                 {
                     Task outputSignal = _outputProcessEvent.WaitAsync();
-                    bool continueAfterCancelProcessTreeKillAttempt = AgentKnobs.ContinueAfterCancelProcessTreeKillAttempt.GetValue(UtilKnobValueContext.Instance()).AsBoolean();
                     Task[] tasks;
 
                     if (continueAfterCancelProcessTreeKillAttempt)
@@ -444,6 +445,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
         internal protected virtual async Task CancelAndKillProcessTree(bool killProcessOnCancel)
         {
+            Trace.Info("skipping CancelAndKillProcessTree");
+            return ;
+            
             ArgUtil.NotNull(_proc, nameof(_proc));
             if (!killProcessOnCancel)
             {

--- a/src/Agent.Sdk/ProcessInvoker.cs
+++ b/src/Agent.Sdk/ProcessInvoker.cs
@@ -445,9 +445,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
         internal protected virtual async Task CancelAndKillProcessTree(bool killProcessOnCancel)
         {
-            Trace.Info("skipping CancelAndKillProcessTree");
-            return ;
-            
             ArgUtil.NotNull(_proc, nameof(_proc));
             if (!killProcessOnCancel)
             {

--- a/src/Agent.Sdk/ProcessInvoker.cs
+++ b/src/Agent.Sdk/ProcessInvoker.cs
@@ -385,7 +385,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             GC.SuppressFinalize(this);
         }
 
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/Agent.Worker/AgentLogPlugin.cs
+++ b/src/Agent.Worker/AgentLogPlugin.cs
@@ -122,6 +122,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                                              redirectStandardIn: _redirectedStdin,
                                                              inheritConsoleHandler: false,
                                                              keepStandardInOpen: true,
+                                                             continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,
                                                              cancellationToken: token);
 
                 // construct plugin context

--- a/src/Agent.Worker/Handlers/HandlerFactory.cs
+++ b/src/Agent.Worker/Handlers/HandlerFactory.cs
@@ -125,6 +125,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             handler.Inputs = inputs;
             handler.SecureFiles = secureFiles;
             handler.TaskDirectory = taskDirectory;
+
+            handler.AfterExecutionContextInitialized();
             return handler;
         }
 

--- a/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
+++ b/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
@@ -240,6 +240,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                                                        killProcessOnCancel: false,
                                                                        redirectStandardIn: null,
                                                                        inheritConsoleHandler: !ExecutionContext.Variables.Retain_Default_Encoding,
+                                                                       continueAfterCancelProcessTreeKillAttempt: _continueAfterCancelProcessTreeKillAttempt,
                                                                        cancellationToken: ExecutionContext.CancellationToken);
 
                     // the exit code from vstsPSHost.exe indicate how many error record we get during execution

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -190,6 +190,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                                   outputEncoding: outputEncoding,
                                                   killProcessOnCancel: false,
                                                   inheritConsoleHandler: !ExecutionContext.Variables.Retain_Default_Encoding,
+                                                  continueAfterCancelProcessTreeKillAttempt: _continueAfterCancelProcessTreeKillAttempt,
                                                   cancellationToken: ExecutionContext.CancellationToken);
 
                 // Wait for either the node exit or force finish through ##vso command

--- a/src/Agent.Worker/Handlers/PowerShell3Handler.cs
+++ b/src/Agent.Worker/Handlers/PowerShell3Handler.cs
@@ -77,6 +77,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                             outputEncoding: null,
                                             killProcessOnCancel: false,
                                             inheritConsoleHandler: !ExecutionContext.Variables.Retain_Default_Encoding,
+                                            continueAfterCancelProcessTreeKillAttempt: _continueAfterCancelProcessTreeKillAttempt,
                                             cancellationToken: ExecutionContext.CancellationToken);
             }
             finally

--- a/src/Agent.Worker/Handlers/PowerShellExeHandler.cs
+++ b/src/Agent.Worker/Handlers/PowerShellExeHandler.cs
@@ -150,6 +150,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                                                      killProcessOnCancel: false,
                                                                      redirectStandardIn: null,
                                                                      inheritConsoleHandler: !ExecutionContext.Variables.Retain_Default_Encoding,
+                                                                     continueAfterCancelProcessTreeKillAttempt: _continueAfterCancelProcessTreeKillAttempt,
                                                                      cancellationToken: ExecutionContext.CancellationToken);
                     FlushErrorData();
 

--- a/src/Agent.Worker/Handlers/ProcessHandler.cs
+++ b/src/Agent.Worker/Handlers/ProcessHandler.cs
@@ -156,6 +156,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                                                  killProcessOnCancel: false,
                                                                  redirectStandardIn: null,
                                                                  inheritConsoleHandler: !ExecutionContext.Variables.Retain_Default_Encoding,
+                                                                 continueAfterCancelProcessTreeKillAttempt: _continueAfterCancelProcessTreeKillAttempt,
                                                                  cancellationToken: ExecutionContext.CancellationToken);
                 FlushErrorData();
 

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                Encoding outputEncoding,
                                bool killProcessOnCancel,
                                bool inheritConsoleHandler,
+                               bool continueAfterCancelProcessTreeKillAttempt,
                                CancellationToken cancellationToken);
     }
 
@@ -64,6 +65,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                             Encoding outputEncoding,
                                             bool killProcessOnCancel,
                                             bool inheritConsoleHandler,
+                                            bool continueAfterCancelProcessTreeKillAttempt,
                                             CancellationToken cancellationToken)
         {
             using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
@@ -80,6 +82,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                                          killProcessOnCancel: killProcessOnCancel,
                                                          redirectStandardIn: null,
                                                          inheritConsoleHandler: inheritConsoleHandler,
+                                                         continueAfterCancelProcessTreeKillAttempt: continueAfterCancelProcessTreeKillAttempt,
                                                          cancellationToken: cancellationToken);
             }
         }
@@ -134,6 +137,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                             Encoding outputEncoding,
                                             bool killProcessOnCancel,
                                             bool inheritConsoleHandler,
+                                            bool continueAfterCancelProcessTreeKillAttempt,
                                             CancellationToken cancellationToken)
         {
             // make sure container exist.
@@ -219,6 +223,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                                                          killProcessOnCancel: killProcessOnCancel,
                                                          redirectStandardIn: redirectStandardIn,
                                                          inheritConsoleHandler: inheritConsoleHandler,
+                                                         continueAfterCancelProcessTreeKillAttempt: continueAfterCancelProcessTreeKillAttempt,
                                                          cancellationToken: cancellationToken);
             }
         }

--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -344,6 +344,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                                 killProcessOnCancel: false,
                                                 redirectStandardIn: null,
                                                 inheritConsoleHandler: true,
+                                                continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,                                                
                                                 cancellationToken: step.ExecutionContext.CancellationToken);
                         if (exitCode == 0)
                         {

--- a/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
+++ b/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
@@ -22,5 +22,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
         public const string EnableFlakyCheckInAgentFeatureFlag = "TestManagement.Agent.PTR.EnableFlakyCheck";
 
         public static readonly string EnableXUnitHeirarchicalParsing = "TestManagement.PublishTestResultsTask.EnableXUnitHeirarchicalParsing";
+
+        public static readonly string ContinueAfterCancelProcessTreeKillAttempt = "TestManagement.Agent.ProcessInvoker.ContinueAfterCancelProcessTreeKillAttempt";
     }
 }

--- a/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
+++ b/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
@@ -22,7 +22,5 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
         public const string EnableFlakyCheckInAgentFeatureFlag = "TestManagement.Agent.PTR.EnableFlakyCheck";
 
         public static readonly string EnableXUnitHeirarchicalParsing = "TestManagement.PublishTestResultsTask.EnableXUnitHeirarchicalParsing";
-
-        public static readonly string ContinueAfterCancelProcessTreeKillAttempt = "TestManagement.Agent.ProcessInvoker.ContinueAfterCancelProcessTreeKillAttempt";
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/ProcessInvoker.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ProcessInvoker.cs
@@ -72,6 +72,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             bool killProcessOnCancel,
             InputQueue<string> redirectStandardIn,
             bool inheritConsoleHandler,
+            bool continueAfterCancelProcessTreeKillAttempt,
             CancellationToken cancellationToken);
 
         Task<int> ExecuteAsync(
@@ -85,6 +86,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             InputQueue<string> redirectStandardIn,
             bool inheritConsoleHandler,
             bool keepStandardInOpen,
+            bool continueAfterCancelProcessTreeKillAttempt,
             CancellationToken cancellationToken);
 
         Task<int> ExecuteAsync(
@@ -99,6 +101,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             bool inheritConsoleHandler,
             bool keepStandardInOpen,
             bool highPriorityProcess,
+            bool continueAfterCancelProcessTreeKillAttempt,
             CancellationToken cancellationToken);
     }
 
@@ -220,6 +223,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 killProcessOnCancel: killProcessOnCancel,
                 redirectStandardIn: redirectStandardIn,
                 inheritConsoleHandler: false,
+                continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,
                 cancellationToken: cancellationToken
             );
         }
@@ -234,6 +238,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             bool killProcessOnCancel,
             InputQueue<string> redirectStandardIn,
             bool inheritConsoleHandler,
+            bool continueAfterCancelProcessTreeKillAttempt,
             CancellationToken cancellationToken)
         {
             return ExecuteAsync(
@@ -247,6 +252,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 redirectStandardIn: redirectStandardIn,
                 inheritConsoleHandler: inheritConsoleHandler,
                 keepStandardInOpen: false,
+                continueAfterCancelProcessTreeKillAttempt: continueAfterCancelProcessTreeKillAttempt,
                 cancellationToken: cancellationToken
             );
         }
@@ -262,6 +268,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             InputQueue<string> redirectStandardIn,
             bool inheritConsoleHandler,
             bool keepStandardInOpen,
+            bool continueAfterCancelProcessTreeKillAttempt,
             CancellationToken cancellationToken)
         {
             return ExecuteAsync(
@@ -276,6 +283,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 inheritConsoleHandler: inheritConsoleHandler,
                 keepStandardInOpen: keepStandardInOpen,
                 highPriorityProcess: false,
+                continueAfterCancelProcessTreeKillAttempt: continueAfterCancelProcessTreeKillAttempt,
                 cancellationToken: cancellationToken
             );
         }
@@ -292,23 +300,25 @@ namespace Microsoft.VisualStudio.Services.Agent
             bool inheritConsoleHandler,
             bool keepStandardInOpen,
             bool highPriorityProcess,
+            bool continueAfterCancelProcessTreeKillAttempt,
             CancellationToken cancellationToken)
         {
             _invoker.ErrorDataReceived += this.ErrorDataReceived;
             _invoker.OutputDataReceived += this.OutputDataReceived;
             return await _invoker.ExecuteAsync(
-                workingDirectory,
-                fileName,
-                arguments,
-                environment,
-                requireExitCodeZero,
-                outputEncoding,
-                killProcessOnCancel,
-                redirectStandardIn,
-                inheritConsoleHandler,
-                keepStandardInOpen,
-                highPriorityProcess,
-                cancellationToken);
+                workingDirectory: workingDirectory,
+                fileName: fileName,
+                arguments: arguments,
+                environment: environment,
+                requireExitCodeZero: requireExitCodeZero,
+                outputEncoding: outputEncoding,
+                killProcessOnCancel: killProcessOnCancel,
+                redirectStandardIn: redirectStandardIn,
+                inheritConsoleHandler: inheritConsoleHandler,
+                keepStandardInOpen: keepStandardInOpen,
+                highPriorityProcess: highPriorityProcess,
+                continueAfterCancelProcessTreeKillAttempt: continueAfterCancelProcessTreeKillAttempt,
+                cancellationToken: cancellationToken);
         }
 
         public void Dispose()

--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -121,13 +121,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 {
                     Stopwatch watch = Stopwatch.StartNew();
                     Task execTask;
+
+                    const bool continueAfterCancelProcessTreeKillAttempt = true;
                     if (TestUtil.IsWindows())
                     {
-                        execTask = processInvoker.ExecuteAsync("", "cmd", $"/c \"ping 127.0.0.1 -n {SecondsToRun} > nul\"", null, tokenSource.Token);
+                        execTask = processInvoker.ExecuteAsync("", "cmd", $"/c \"ping 127.0.0.1 -n {SecondsToRun} > nul\"", null, false, null, false, null, false, false, false, continueAfterCancelProcessTreeKillAttempt, tokenSource.Token);
                     }
                     else
                     {
-                        execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}s\"", null, tokenSource.Token);
+                        execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}s\"", null, false, null, false, null, false, false, false, continueAfterCancelProcessTreeKillAttempt, tokenSource.Token);
                     }
 
                     await Task.Delay(500);
@@ -228,8 +230,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
 
                     processInvoker.Initialize(hc);
                     var proc = (TestUtil.IsWindows())
-                        ? processInvoker.ExecuteAsync("", "cmd.exe", "/c more", null, false, null, false, redirectSTDIN, false, true, cancellationTokenSource.Token)
-                        : processInvoker.ExecuteAsync("", "bash", "-c \"read input; echo $input; read input; echo $input; read input; echo $input;\"", null, false, null, false, redirectSTDIN, false, true, cancellationTokenSource.Token);
+                        ? processInvoker.ExecuteAsync("", "cmd.exe", "/c more", null, false, null, false, redirectSTDIN, false, true, ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault, cancellationTokenSource.Token)
+                        : processInvoker.ExecuteAsync("", "bash", "-c \"read input; echo $input; read input; echo $input; read input; echo $input;\"", null, false, null, false, redirectSTDIN, false, true, ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault, cancellationTokenSource.Token);
 
                     redirectSTDIN.Enqueue("More line of STDIN");
                     redirectSTDIN.Enqueue("More line of STDIN");
@@ -284,6 +286,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                         {
                             var proc = await processInvoker.ExecuteAsync("", "bash", "-c \"cat /proc/$$/oom_score_adj\"", null, false, null, false, null, false, false,
                                                                 highPriorityProcess: false,
+                                                                continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,
                                                                 cancellationToken: tokenSource.Token);
                             Assert.Equal(oomScoreAdj, 500);
                         }
@@ -326,6 +329,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                                                                     new Dictionary<string, string> { {"PIPELINE_JOB_OOMSCOREADJ", "1234"} },
                                                                     false, null, false, null, false, false,
                                                                     highPriorityProcess: false,
+                                                                    continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,
                                                                     cancellationToken: tokenSource.Token);
                             Assert.Equal(oomScoreAdj, 1234);
                         }
@@ -368,6 +372,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                         {
                             var proc = await processInvoker.ExecuteAsync("", "bash", "-c \"cat /proc/$$/oom_score_adj\"", null, false, null, false, null, false, false,
                                                                 highPriorityProcess: true,
+                                                                continueAfterCancelProcessTreeKillAttempt: ProcessInvoker.ContinueAfterCancelProcessTreeKillAttemptDefault,
                                                                 cancellationToken: tokenSource.Token);
                             Assert.Equal(oomScoreAdj, 123);
                         }

--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Agent.Sdk;
+using Agent.Sdk.Knob;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -42,7 +44,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        [Trait("SkipOn", "windows")]
         [Trait("SkipOn", "darwin")]
         public async Task TestCancel()
         {
@@ -55,7 +56,79 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 {
                     processInvoker.Initialize(hc);
                     Stopwatch watch = Stopwatch.StartNew();
-                    Task execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}s\"", null, tokenSource.Token);
+                    Task execTask;
+                    if (TestUtil.IsWindows())
+                    {
+                        execTask = processInvoker.ExecuteAsync("", "cmd", $"/c \"ping 127.0.0.1 -n {SecondsToRun} > nul\"", null, tokenSource.Token);
+                    }
+                    else
+                    {
+                        execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}s\"", null, tokenSource.Token);
+                    }
+
+                    await Task.Delay(500);
+                    tokenSource.Cancel();
+                    try
+                    {
+                        await execTask;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        trace.Info("Get expected OperationCanceledException.");
+                    }
+
+                    Assert.True(execTask.IsCompleted);
+                    Assert.True(!execTask.IsFaulted);
+                    Assert.True(execTask.IsCanceled);
+                    watch.Stop();
+                    long elapsedSeconds = watch.ElapsedMilliseconds / 1000;
+
+                    // if cancellation fails, then execution time is more than 15 seconds
+                    long expectedSeconds = (SecondsToRun * 3) / 4;
+
+                    Assert.True(elapsedSeconds <= expectedSeconds, $"cancellation failed, because task took too long to run. {elapsedSeconds}");
+                }
+            }
+        }
+
+        class ProcessInvokerWithOutKillingCancelledTask : ProcessInvoker
+        {
+            public ProcessInvokerWithOutKillingCancelledTask(ITraceWriter trace, bool disableWorkerCommands = false) : base(trace, disableWorkerCommands)
+            {
+            }
+
+            // override CancelAndKillProcessTree to avoid killing the cancelled task,
+            // so we can test that execution continues 
+            protected internal override Task CancelAndKillProcessTree(bool killProcessOnCancel)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        //Run a process that normally takes 20sec to finish and cancel it.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        [Trait("SkipOn", "darwin")]
+        public async Task TestCancelEnsureCompletedWhenTaskNotKilled()
+        {
+            const int SecondsToRun = 20;
+            using (TestHostContext hc = new TestHostContext(this))
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Tracing trace = hc.GetTrace();
+                using (var processInvoker = new ProcessInvokerWithOutKillingCancelledTask(trace, false))
+                {
+                    Stopwatch watch = Stopwatch.StartNew();
+                    Task execTask;
+                    if (TestUtil.IsWindows())
+                    {
+                        execTask = processInvoker.ExecuteAsync("", "cmd", $"/c \"ping 127.0.0.1 -n {SecondsToRun} > nul\"", null, tokenSource.Token);
+                    }
+                    else
+                    {
+                        execTask = processInvoker.ExecuteAsync("", "bash", $"-c \"sleep {SecondsToRun}s\"", null, tokenSource.Token);
+                    }
 
                     await Task.Delay(500);
                     tokenSource.Cancel();


### PR DESCRIPTION
This PR fixes an issue where the agent will hang and fail to upload logs if the process executed cannot be killed during cancellation.   The pipeline hangs until timeoutInMinutes  + cancelTimeoutInMinutes

The log fails to upload and a blank log is shown in the log viewer UX:
![image](https://user-images.githubusercontent.com/44985659/205241514-5ca49603-b8c4-4eff-bb02-ee011288eba6.png)

**Analysis**
Killing process during cancellation is 'best effort' and may fail if, for some reason, the process cannot be killed.  In that case, the agent waits forever in a loop for the process to exit.  Fix is to exit the loop after attempting to kill the process.

**Testing**
This issue is not easy to reproduce, because it requires the agent to launch a process that cannot be killed
I simulated this condition by modifying ProcessInvoker to skip killing the process

**Knob / Enabling **
The behavior is disabled by default.  This change is enabled by setting knob: VSTSAGENT_CONTINUE_AFTER_CANCEL_PROCESSTREEKILL_ATTEMPT

VSO 2009025
