### PR TITLE
Catch agent updating exception

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -323,6 +323,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     Task<bool> selfUpdateTask = null;
                     bool runOnceJobReceived = false;
                     jobDispatcher = HostContext.CreateService<IJobDispatcher>();
+                    TaskAgentMessage previuosMessage = null;
 
                     while (!HostContext.AgentShutdownToken.IsCancellationRequested)
                     {
@@ -338,7 +339,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                 if (completeTask == selfUpdateTask)
                                 {
                                     autoUpdateInProgress = false;
-                                    if (await selfUpdateTask)
+
+                                    bool agentUpdated = false;
+                                    try
+                                    {
+                                        agentUpdated = await selfUpdateTask;
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Trace.Info($"Ignore agent update exception. {ex}");
+                                    }
+
+                                    if (agentUpdated)
                                     {
                                         Trace.Info("Auto update task finished at backend, an agent update is ready to apply exit the current agent instance.");
                                         Trace.Info("Stop message queue looping.");
@@ -365,6 +377,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                     {
                                         Trace.Info("Auto update task finished at backend, there is no available agent update needs to apply, continue message queue looping.");
                                     }
+
+                                    message = previuosMessage;// if agent wasn't updated it's needed to process the previous message
+                                    previuosMessage = null;
                                 }
                             }
 
@@ -390,7 +405,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                 }
                             }
 
-                            message = await getNextMessage; //get next message
+                            message ??= await getNextMessage; //get next message
                             HostContext.WritePerfCounter($"MessageReceived_{message.MessageType}");
                             if (string.Equals(message.MessageType, AgentRefreshMessage.MessageType, StringComparison.OrdinalIgnoreCase))
                             {
@@ -417,6 +432,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                             else if (string.Equals(message.MessageType, JobRequestMessageTypes.AgentJobRequest, StringComparison.OrdinalIgnoreCase) ||
                                     string.Equals(message.MessageType, JobRequestMessageTypes.PipelineAgentJobRequest, StringComparison.OrdinalIgnoreCase))
                             {
+                                if (autoUpdateInProgress)
+                                {
+                                    previuosMessage = message;
+                                }
+
                                 if (autoUpdateInProgress || runOnceJobReceived)
                                 {
                                     skipMessageDeletion = true;


### PR DESCRIPTION
**Issue description**: 
In case of throwing exception due to the agent update (or downgrade) the agent shouts down. If the update starts after the pipeline has run, the pipeline crashes and is marked as cancelled.

**Changes description**:
Added catching the exception during the agent update with continuation of the pipeline processing.

**Related issue**: https://github.com/microsoft/azure-pipelines-agent/issues/3938

**Testing**:
Tested with Azure DevOps Server 2020, Azure DevOps Server 2022 and Azure DevOps Services running the pipelines simultaneously and separately