### PR TITLE
Update Node16 to 16.17.1 version

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -10,7 +10,7 @@ CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
 NODE10_VERSION="10.24.1"
-NODE16_VERSION="16.15.1"
+NODE16_VERSION="16.17.1"
 MINGIT_VERSION="2.38.1"
 LFS_VERSION="2.13.3"
 


### PR DESCRIPTION
**Issue description**: 
The current version of using NodeJS (16.15.1) has vulnerabilities which have already been fixed in 16.17.1 NodeJS security release.

**Changes description**:
Node16 version updated to 16.17.1

**Related issue**: https://github.com/microsoft/azure-pipelines-agent/issues/4075

**Testing**:
Tested with few tasks with node16 handler