### PR TITLE
Added strict boolean knob values

### DIFF
--- a/src/Agent.Sdk/Knob/KnobValue.cs
+++ b/src/Agent.Sdk/Knob/KnobValue.cs
@@ -26,6 +26,11 @@ namespace Agent.Sdk.Knob
             return StringUtil.ConvertToBoolean(_value);
         }
 
+        public bool AsBooleanStrict()
+        {
+            return StringUtil.ConvertToBooleanStrict(_value);
+        }
+
         public int AsInt()
         {
             return Int32.Parse(_value);

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -75,6 +75,37 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }
         }
 
+        /// <summary>
+        /// Convert String to boolean, valid true string: "1", "true", "$true", valid false string: "0", "false", "$false".
+        /// </summary>
+        /// <param name="value">Input value to convert.</param>
+        /// <returns>Boolean representing parsed value</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="FormatException"></exception>
+        public static bool ConvertToBooleanStrict(string value)
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException("Passed value can not be null.");
+            }
+
+            switch (value.ToLowerInvariant())
+            {
+                case "1":
+                case "true":
+                case "$true":
+                    return true;
+
+                case "0":
+                case "false":
+                case "$false":
+                    return false;
+
+                default:
+                    throw new FormatException("Argument not matches boolean patterns.");
+            }
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720: Identifiers should not contain type")]
         public static string ConvertToJson(object obj, Formatting formatting = Formatting.Indented)
         {


### PR DESCRIPTION
For now we have a logic where if input knob value is "treu", for example, it will be parsed as false.
It's ok if default knob value is "false", but if "true", it may be not the best approach.

Added option to make Boolean knob more strict if necessary.

Changelog:
- Added `ConvertToBooleanStrict` method for `StringUtil`
- Added `AsBooleanStrict` method for knobs
