### PR TITLE
[Draft] Set InvariantGlobalization to false for Common.csproj

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -12,6 +12,7 @@
     <DebugConstant></DebugConstant>
     <VssApiVersion>0.5.180-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
+    <InvariantGlobalization>false</InvariantGlobalization>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
**Issue description**:
Agent based on .NET 6 might fail on some Linux system with the exception:
`##[error]System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name')
`.

It is related to the breaking changes introduced in .NET6:
https://learn.microsoft.com/en-us/dotnet/core/compatibility/globalization/6.0/culture-creation-invariant-mode


**Solution**:
This fix disables InvariantGlobalization in agent solution

