### PR TITLE
update build-job

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -116,12 +116,6 @@ jobs:
       env:
         ADO_ENABLE_LOGISSUE: true
 
-  - ${{ if or(eq(parameters.os, 'linux'), eq(parameters.os, 'osx')) }}:
-    - task: UseDotNet@2
-      inputs:
-        packageType: 'sdk'
-        version: '2.1.x'
-
   # Check if broken symlinks exist in the agent build
   - task: Bash@3.201.1
     inputs:
@@ -185,6 +179,12 @@ jobs:
         codeCoverageTool: 'cobertura'
         summaryFileLocation: _reports/**/Cobertura.xml
         pathToSources: src
+
+  - ${{ if eq(parameters.os, 'osx') }}:
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        version: '2.1.x'
 
   - ${{ if parameters.sign }}:
     # Signing steps

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -184,7 +184,7 @@ jobs:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '2.1.x'
+        version: '6.0.x'
 
   - ${{ if parameters.sign }}:
     # Signing steps

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -116,6 +116,12 @@ jobs:
       env:
         ADO_ENABLE_LOGISSUE: true
 
+  - ${{ if or(eq(parameters.os, 'linux'), eq(parameters.os, 'osx')) }}:
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        version: '2.1.x'
+
   # Check if broken symlinks exist in the agent build
   - task: Bash@3.201.1
     inputs:
@@ -179,12 +185,6 @@ jobs:
         codeCoverageTool: 'cobertura'
         summaryFileLocation: _reports/**/Cobertura.xml
         pathToSources: src
-
-  - ${{ if eq(parameters.os, 'osx') }}:
-    - task: UseDotNet@2
-      inputs:
-        packageType: 'sdk'
-        version: '2.1.x'
 
   - ${{ if parameters.sign }}:
     # Signing steps

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -124,6 +124,12 @@ jobs:
 
   # Run l0 tests
   - ${{ if parameters.unitTests }}:
+    - ${{ if and(eq(parameters.os, 'win'), eq(parameters.arch, 'x86')) }}:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 3.1 SDK
+        inputs:
+          version: '3.1.x'
+          packageType: 'sdk'
     - script: ${{ variables.devCommand }} testl0 Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Unit tests

--- a/.azure-pipelines/signing.yml
+++ b/.azure-pipelines/signing.yml
@@ -16,7 +16,7 @@ steps:
         displayName: Remove signatures from the third party packages
         condition: ne(variables['DISABLE_SIGNATURE_REMOVAL'], 'true')
 
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
         inputs:
           ConnectedServiceName: VSTSAgentESRP
           FolderPath: '${{ parameters.layoutRoot }}/bin'
@@ -40,7 +40,7 @@ steps:
             ]
         displayName: Sign Agent Assemblies (Strong Name Signing)
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     inputs:
       ConnectedServiceName: VSTSAgentESRP
       FolderPath: '${{ parameters.layoutRoot }}/bin'
@@ -90,7 +90,7 @@ steps:
         ]
     displayName: Sign Agent Assemblies (Authenticode Signing)
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     inputs:
       ConnectedServiceName: VSTSAgentESRP
       FolderPath: '${{ parameters.layoutRoot }}'
@@ -140,7 +140,7 @@ steps:
         ]
     displayName: Sign PowerShell Scripts (Authenticode Signing)
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
     inputs:
       ConnectedServiceName: VSTSAgentESRP
       FolderPath: '${{ parameters.layoutRoot }}'


### PR DESCRIPTION
**Reason**:
Pipeline fails due to DotNet v2 requirement on macOS.

**Description**:
- updated ESRP signing step to v2
- updated DotNet version in UseDotNet task to 6 for macOS (requirement of ESRP v2)

**Checks**:
Agent Pipeline works correctly for Linux, Windows, and macOS.


