### PR TITLE
Update dotnet to 3.1.32

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.0</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.1.32</RuntimeFrameworkVersion>
     <RuntimeIdentifier>$(PackageRuntime)</RuntimeIdentifier>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <AssetTargetFallback>portable-net45+win8</AssetTargetFallback>

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/.helpers.sh"
 
 DOTNETSDK_ROOT="$SCRIPT_DIR/../_dotnetsdk"
-DOTNETSDK_VERSION="3.1.100"
+DOTNETSDK_VERSION="3.1.426"
 DOTNETSDK_INSTALLDIR="$DOTNETSDK_ROOT/$DOTNETSDK_VERSION"
 AGENT_VERSION=$(cat "$SCRIPT_DIR/agentversion" | head -n 1 | tr -d "\n\r")
 


### PR DESCRIPTION
This PR updates .NET Core used in the agent from 3.1.0 to 3.1.32
Changelogs:
https://github.com/dotnet/core/tree/main/release-notes/3.1

Testing
Agent tested on Linux, Windows, and mac by executing several canary pipelines.