### PR TITLE
Added Rocky Linux 8+ Support

### DIFF
--- a/src/Agent.Listener/net6.json
+++ b/src/Agent.Listener/net6.json
@@ -24,6 +24,14 @@
     ]
   },
   {
+    "id": "rocky",
+    "versions": [
+      {
+        "name": "8+"
+      }
+    ]
+  },
+  {
     "id": "debian",
     "versions": [
       {

--- a/src/Agent.Listener/net8.json
+++ b/src/Agent.Listener/net8.json
@@ -19,6 +19,14 @@
     ]
   },
   {
+    "id": "rocky",
+    "versions": [
+      {
+        "name": "8+"
+      }
+    ]
+  },
+  {
     "id": "debian",
     "versions": [
       {


### PR DESCRIPTION
Rocky Linux is binary compatible with RHEL, and is one of many replacements to CentOS

**Rocky 8**
```
# dotnet --info
.NET SDK (reflecting any global.json):
 Version:   6.0.410
 Commit:    28c7c894a3

Runtime Environment:
 OS Name:     rocky
 OS Version:  8.8
 OS Platform: Linux
 RID:         rocky.8-x64
 Base Path:   /usr/share/dotnet/sdk/6.0.410/
```

**Rocky 9**
```
# dotnet --info
.NET SDK (reflecting any global.json):
 Version:   6.0.116
 Commit:    b605cc131f

Runtime Environment:
 OS Name:     rocky
 OS Version:  9.2
 OS Platform: Linux
 RID:         rocky.9-x64
 Base Path:   /usr/lib64/dotnet/sdk/6.0.116/
```