### PR TITLE
Feature:2024632 - Fail RHEL 6 on v2 agent, unless a knob is set

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -401,5 +401,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_USE_NODE"),
             new EnvironmentKnobSource("AGENT_USE_NODE"),
             new BuiltInDefaultKnobSource(string.Empty));
+
+        public static readonly Knob AcknowledgeNoUpdates = new Knob(
+            nameof(AcknowledgeNoUpdates),
+            "Allows to run pipelines on agent which doesn't get updates",
+            new RuntimeKnobSource("AGENT_ACKNOWLEDGE_NO_UPDATES"),
+            new EnvironmentKnobSource("AGENT_ACKNOWLEDGE_NO_UPDATES"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -373,7 +373,7 @@ namespace Agent.Sdk
         public ParsedVersion Version { get; }
 
         [JsonConstructor]
-        public SystemVersion(string name, string version)
+        public SystemVersion(string name, string version = null)
         {
             if (name == null && version == null)
             {

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 bool acknowledgeNoUpdatesKnob = AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean();
                 if (!acknowledgeNoUpdatesKnob && systemId == "rhel" && systemVersion.Equals(new SystemVersion("6")))
                 {
-                    string errorMessage = "Red Hat 6 is deprecated for Pipelines Agent. To be able to continue run pipelines on it please upgrade the operating system of this host or set environment variable \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\"";
+                    string errorMessage = "Red Hat 6 will no longer receive updates of the Pipelines Agent. To be able to continue run pipelines please upgrade the operating system or set an environment variable or agent kbob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-rhel6 for more information.";
                     Trace.Error(errorMessage);
                     jobContext.Error(errorMessage);
                     return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);


### PR DESCRIPTION
**Description:**
Need to implement logic to fail pipeline on RHEL 6 until knob `AGENT_ACKNOWLEDGE_NO_UPDATES` is specified

**Changes:**
- added knob `AGENT_ACKNOWLEDGE_NO_UPDATES`
- implemented logic to fail pipeline on RHEL 6 without specified knob `AGENT_ACKNOWLEDGE_NO_UPDATES`