### PR TITLE
Feature:2024632 - Fail RHEL 6 on v2 agent, unless a knob is set

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -124,6 +124,15 @@ jobs:
 
   # Run l0 tests
   - ${{ if parameters.unitTests }}:
+    - ${{ if and(eq(parameters.os, 'win'), eq(parameters.arch, 'x86')) }}:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 3.1 SDK
+        inputs:
+          version: '3.1.x'
+          packageType: 'runtime'
+          installationPath: 'C:\Program Files (x86)\dotnet'
+        env:
+          PROCESSOR_ARCHITECTURE: x86
     - script: ${{ variables.devCommand }} testl0 Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Unit tests
@@ -139,9 +148,10 @@ jobs:
       - task: UseDotNet@2
         displayName: Install .NET Core 3.1 SDK
         inputs:
-          version: '3.1.22'
+          version: '3.1.x'
           packageType: runtime
           performMultiLevelLookup: true
+          installationPath: 'C:\Program Files (x86)\dotnet'
     - script: ${{ variables.devCommand }} testl1 Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Functional tests

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -392,5 +392,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_USE_NODE"),
             new EnvironmentKnobSource("AGENT_USE_NODE"),
             new BuiltInDefaultKnobSource(string.Empty));
+
+        public static readonly Knob AcknowledgeNoUpdates = new Knob(
+            nameof(AcknowledgeNoUpdates),
+            "Allows to run pipelines on agent which doesn't get updates",
+            new RuntimeKnobSource("AGENT_ACKNOWLEDGE_NO_UPDATES"),
+            new EnvironmentKnobSource("AGENT_ACKNOWLEDGE_NO_UPDATES"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -352,7 +352,7 @@ namespace Agent.Sdk
         public ParsedVersion Version { get; }
 
         [JsonConstructor]
-        public SystemVersion(string name, string version)
+        public SystemVersion(string name, string version = null)
         {
             if (name == null && version == null)
             {

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -474,7 +474,7 @@ namespace Agent.Sdk
             this.Id.Equals(systemId, StringComparison.OrdinalIgnoreCase);
 
         public bool Equals(string systemId, SystemVersion systemVersion) => 
-            this.Equals(systemId) || this.Versions.Length > 0 
+            this.Equals(systemId) && this.Versions.Length > 0 
                 ? this.Versions.Any(version => version.Equals(systemVersion))
                 : false;
     }

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -675,6 +675,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 try
                 {
                     Trace.Verbose("Checking if your system supports .NET 6");
+
                     string systemId = PlatformUtil.GetSystemId();
                     SystemVersion systemVersion = PlatformUtil.GetSystemVersion();
                     string notSupportNet6Message = null;

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -666,6 +666,66 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             // Hook up JobServerQueueThrottling event, we will log warning on server tarpit.
             _jobServerQueue.JobServerQueueThrottling += JobServerQueueThrottling_EventReceived;
+
+            // Get version of system where agent is running
+            string systemId = null;
+            SystemVersion systemVersion = null;
+
+            try
+            {
+                systemId = PlatformUtil.GetSystemId();
+                systemVersion = PlatformUtil.GetSystemVersion();
+            }
+            catch (Exception ex)
+            {
+                Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
+            }
+
+            // Check if system is RHEL 6 and throw exception then
+            bool acknowledgeNoUpdatesKnob = AgentKnobs.AcknowledgeNoUpdates.GetValue(this).AsBoolean();
+            if (!acknowledgeNoUpdatesKnob && systemId == "rhel" && systemVersion.Equals(new SystemVersion("6")))
+            {
+                string errorMessage = "Red Hat 6 will no longer receive updates of the Pipelines Agent. To be able to continue run pipelines please upgrade the operating system or set an environment variable or agent kbob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-rhel6 for more information.";
+                Trace.Error(errorMessage);
+                AddIssue(new Issue() { Type = IssueType.Error, Message = errorMessage });
+                throw new Exception(errorMessage);
+            }
+
+            // Check if a system supports .NET 6
+            PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
+
+            if (agentVersion.Major < 3 && systemId != null && systemVersion != null)
+            {
+                try
+                {
+                    Trace.Verbose("Checking if your system supports .NET 6");
+
+                    
+                    string notSupportNet6Message = null;
+
+                    if (PlatformUtil.DoesSystemPersistsInNet6Whitelist())
+                    {
+                        // Check version of the system
+                        if (!PlatformUtil.IsNet6Supported())
+                        {
+                            notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version";
+                        }
+                    }
+                    else
+                    {
+                        notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which has not been tested with the .NET 6 based v3 agent. The v2 agent wil not automatically upgrade to the v3 agent. You can manually download the .NET 6 based v3 agent from https://github.com/microsoft/azure-pipelines-agent/releases. See https://aka.ms/azdo-pipeline-agent-version";
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(notSupportNet6Message))
+                    {
+                        AddIssue(new Issue() { Type = IssueType.Warning, Message = notSupportNet6Message });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
+                }
+            }
         }
 
         private string GetWorkspaceIdentifier(Pipelines.AgentJobRequestMessage message)

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -667,40 +667,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             // Hook up JobServerQueueThrottling event, we will log warning on server tarpit.
             _jobServerQueue.JobServerQueueThrottling += JobServerQueueThrottling_EventReceived;
 
-            // Get version of system where agent is running
-            string systemId = null;
-            SystemVersion systemVersion = null;
-
-            try
-            {
-                systemId = PlatformUtil.GetSystemId();
-                systemVersion = PlatformUtil.GetSystemVersion();
-            }
-            catch (Exception ex)
-            {
-                Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
-            }
-
-            // Check if system is RHEL 6 and throw exception then
-            bool acknowledgeNoUpdatesKnob = AgentKnobs.AcknowledgeNoUpdates.GetValue(this).AsBoolean();
-            if (!acknowledgeNoUpdatesKnob && systemId == "rhel" && systemVersion.Equals(new SystemVersion("6")))
-            {
-                string errorMessage = "Red Hat 6 will no longer receive updates of the Pipelines Agent. To be able to continue run pipelines please upgrade the operating system or set an environment variable or agent kbob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-rhel6 for more information.";
-                Trace.Error(errorMessage);
-                AddIssue(new Issue() { Type = IssueType.Error, Message = errorMessage });
-                throw new Exception(errorMessage);
-            }
-
             // Check if a system supports .NET 6
             PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
 
-            if (agentVersion.Major < 3 && systemId != null && systemVersion != null)
+            if (agentVersion.Major < 3)
             {
                 try
                 {
                     Trace.Verbose("Checking if your system supports .NET 6");
-
-                    
+                    string systemId = PlatformUtil.GetSystemId();
+                    SystemVersion systemVersion = PlatformUtil.GetSystemVersion();
                     string notSupportNet6Message = null;
 
                     if (PlatformUtil.DoesSystemPersistsInNet6Whitelist())

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -98,67 +98,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Create the job execution context.
                 jobContext = HostContext.CreateService<IExecutionContext>();
                 jobContext.InitializeJob(message, jobRequestCancellationToken);
-
-                // Get version of system where agent is running
-                string systemId = null;
-                SystemVersion systemVersion = null;
-
-                try
-                {
-                    systemId = PlatformUtil.GetSystemId();
-                    systemVersion = PlatformUtil.GetSystemVersion();
-                }
-                catch (Exception ex)
-                {
-                    Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
-                }
-
-                // Check if system is RHEL 6 and throw exception then
-                bool acknowledgeNoUpdatesKnob = AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean();
-                if (!acknowledgeNoUpdatesKnob && systemId == "rhel" && systemVersion.Equals(new SystemVersion("6")))
-                {
-                    string errorMessage = "Red Hat 6 will no longer receive updates of the Pipelines Agent. To be able to continue run pipelines please upgrade the operating system or set an environment variable or agent kbob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-rhel6 for more information.";
-                    Trace.Error(errorMessage);
-                    jobContext.Error(errorMessage);
-                    return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
-                }
-
-                // Check if a system supports .NET 6
-                PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
-
-                if (agentVersion.Major < 3 && systemId != null && systemVersion != null)
-                {
-                    try
-                    {
-                        Trace.Verbose("Checking if your system supports .NET 6");
-
-
-                        string notSupportNet6Message = null;
-
-                        if (PlatformUtil.DoesSystemPersistsInNet6Whitelist())
-                        {
-                            // Check version of the system
-                            if (!PlatformUtil.IsNet6Supported())
-                            {
-                                notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version";
-                            }
-                        }
-                        else
-                        {
-                            notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which has not been tested with the .NET 6 based v3 agent. The v2 agent wil not automatically upgrade to the v3 agent. You can manually download the .NET 6 based v3 agent from https://github.com/microsoft/azure-pipelines-agent/releases. See https://aka.ms/azdo-pipeline-agent-version";
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(notSupportNet6Message))
-                        {
-                            jobContext.AddIssue(new Issue() { Type = IssueType.Warning, Message = notSupportNet6Message });
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
-                    }
-                }
-
                 Trace.Info("Starting the job execution context.");
                 jobContext.Start();
                 jobContext.Section(StringUtil.Loc("StepStarting", message.JobDisplayName));

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -98,6 +98,67 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Create the job execution context.
                 jobContext = HostContext.CreateService<IExecutionContext>();
                 jobContext.InitializeJob(message, jobRequestCancellationToken);
+
+                // Get version of system where agent is running
+                string systemId = null;
+                SystemVersion systemVersion = null;
+
+                try
+                {
+                    systemId = PlatformUtil.GetSystemId();
+                    systemVersion = PlatformUtil.GetSystemVersion();
+                }
+                catch (Exception ex)
+                {
+                    Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
+                }
+
+                // Check if system is RHEL 6 and throw exception then
+                bool acknowledgeNoUpdatesKnob = AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean();
+                if (!acknowledgeNoUpdatesKnob && systemId == "rhel" && systemVersion.Equals(new SystemVersion("6")))
+                {
+                    string errorMessage = "Red Hat 6 will no longer receive updates of the Pipelines Agent. To be able to continue run pipelines please upgrade the operating system or set an environment variable or agent kbob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-rhel6 for more information.";
+                    Trace.Error(errorMessage);
+                    jobContext.Error(errorMessage);
+                    return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
+                }
+
+                // Check if a system supports .NET 6
+                PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
+
+                if (agentVersion.Major < 3 && systemId != null && systemVersion != null)
+                {
+                    try
+                    {
+                        Trace.Verbose("Checking if your system supports .NET 6");
+
+
+                        string notSupportNet6Message = null;
+
+                        if (PlatformUtil.DoesSystemPersistsInNet6Whitelist())
+                        {
+                            // Check version of the system
+                            if (!PlatformUtil.IsNet6Supported())
+                            {
+                                notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version";
+                            }
+                        }
+                        else
+                        {
+                            notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which has not been tested with the .NET 6 based v3 agent. The v2 agent wil not automatically upgrade to the v3 agent. You can manually download the .NET 6 based v3 agent from https://github.com/microsoft/azure-pipelines-agent/releases. See https://aka.ms/azdo-pipeline-agent-version";
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(notSupportNet6Message))
+                        {
+                            jobContext.AddIssue(new Issue() { Type = IssueType.Warning, Message = notSupportNet6Message });
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
+                    }
+                }
+
                 Trace.Info("Starting the job execution context.");
                 jobContext.Start();
                 jobContext.Section(StringUtil.Loc("StepStarting", message.JobDisplayName));

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -18,6 +18,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Newtonsoft.Json.Linq;
+using Microsoft.VisualStudio.Services.Agent.Worker.Handlers;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -28,10 +29,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         void UpdateMetadata(JobMetadataMessage message);
     }
 
+    [ServiceLocator(Default = typeof(JobRunnerHelper))]
+    public interface IJobRunnerHelper
+    {
+        bool RunningOnRHEL6 { get; }
+    }
+
+    public class JobRunnerHelper: IJobRunnerHelper
+    {
+        public bool RunningOnRHEL6 => PlatformUtil.RunningOnRHEL6;
+    }
+
     public sealed class JobRunner : AgentService, IJobRunner
     {
         private IJobServerQueue _jobServerQueue;
         private ITempDirectoryManager _tempDirectoryManager;
+        private IJobRunnerHelper _jobRunnerHelper;
         /// <summary>
         /// Add public accessor for _jobServerQueue to make JobRunner more testable
         /// See /Test/L0/Worker/JobRunnerL0.cs
@@ -40,6 +53,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         {
             set => _jobServerQueue = value;
         }
+
+        public JobRunner()
+        {
+            _jobRunnerHelper = new JobRunnerHelper();
+        }
+
+        public JobRunner(IJobRunnerHelper jobRunnerHelper)
+        {
+            _jobRunnerHelper = jobRunnerHelper;
+        }
+
         public async Task<TaskResult> RunAsync(Pipelines.AgentJobRequestMessage message, CancellationToken jobRequestCancellationToken)
         {
             // Validate parameters.
@@ -101,7 +125,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 // Check if system is RHEL 6 and throw exception then
                 bool acknowledgeNoUpdatesKnob = AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean();
-                if (!acknowledgeNoUpdatesKnob && PlatformUtil.RunningOnRHEL6)
+                if (!acknowledgeNoUpdatesKnob && _jobRunnerHelper.RunningOnRHEL6)
                 {
                     string errorMessage = "Red Hat 6 will no longer receive updates of the Pipelines Agent. To be able to continue run pipelines please upgrade the operating system or set an environment variable or agent kbob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-rhel6 for more information.";
                     Trace.Error(errorMessage);

--- a/src/Test/L0/Worker/JobRunnerL0.cs
+++ b/src/Test/L0/Worker/JobRunnerL0.cs
@@ -11,7 +11,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 using System.Threading;
-using System.Collections.ObjectModel;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
@@ -436,6 +435,96 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 _jobRunner.JobServerQueue = hc.GetService<IJobServerQueue>();
                 _jobRunner.UpdateMetadata(new JobMetadataMessage(It.IsAny<Guid>(), It.IsAny<Int32>()));
                 _jobServerQueue.Verify(x => x.UpdateWebConsoleLineRate(It.IsAny<Int32>()), Times.Once());
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task FailJobOnRHEL6()
+        {
+            var jobRunnerHelper = GetMockedJobRunnerHelper();
+            jobRunnerHelper
+                .Setup(x => x.RunningOnRHEL6)
+                .Returns(true);
+            using (var _tokenSource = new CancellationTokenSource())
+            using (TestHostContext hc = CreateTestContext(jobRunnerHelper: jobRunnerHelper.Object))
+            {
+                _jobExtension
+                    .Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Returns(new Task<List<IStep>>(() => Enumerable.Empty<IStep>().ToList()));
+
+                await _jobRunner.RunAsync(_message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Failed, _jobEc.Result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task FailJobOnRHEL6MSI()
+        {
+            var jobRunnerHelper = GetMockedJobRunnerHelper();
+            jobRunnerHelper
+                .Setup(x => x.RunningOnRHEL6)
+                .Returns(true);
+            using (var _tokenSource = new CancellationTokenSource())
+            using (TestHostContext hc = CreateMSITestContext(jobRunnerHelper: jobRunnerHelper.Object))
+            {
+                _jobExtension
+                    .Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Returns(new Task<List<IStep>>(() => Enumerable.Empty<IStep>().ToList()));
+
+                await _jobRunner.RunAsync(_message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Failed, _jobEc.Result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task SucceededJobOnRHEL6IfKnobSpecified()
+        {
+            var jobRunnerHelper = GetMockedJobRunnerHelper();
+            jobRunnerHelper
+                .Setup(x => x.RunningOnRHEL6)
+                .Returns(true);
+            using (var _tokenSource = new CancellationTokenSource())
+            using (TestHostContext hc = CreateTestContext(jobRunnerHelper: jobRunnerHelper.Object))
+            {
+                _jobExtension
+                    .Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Returns(async () => Enumerable.Empty<IStep>().ToList());
+                _message.Variables["AGENT_ACKNOWLEDGE_NO_UPDATES"] = "true";
+
+                await _jobRunner.RunAsync(_message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Succeeded, _jobEc.Result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task SucceededJobOnRHEL6IfKnobSpecifiedMSI()
+        {
+            var jobRunnerHelper = GetMockedJobRunnerHelper();
+            jobRunnerHelper
+                .Setup(x => x.RunningOnRHEL6)
+                .Returns(true);
+            using (var _tokenSource = new CancellationTokenSource())
+            using (TestHostContext hc = CreateMSITestContext(jobRunnerHelper: jobRunnerHelper.Object))
+            {
+                _jobExtension
+                    .Setup(x => x.InitializeJob(It.IsAny<IExecutionContext>(), It.IsAny<Pipelines.AgentJobRequestMessage>()))
+                    .Returns(async () => Enumerable.Empty<IStep>().ToList());
+                _message.Variables["AGENT_ACKNOWLEDGE_NO_UPDATES"] = "true";
+
+                await _jobRunner.RunAsync(_message, _tokenSource.Token);
+
+                Assert.Equal(TaskResult.Succeeded, _jobEc.Result);
             }
         }
     }

--- a/src/Test/L0/Worker/JobRunnerL0.cs
+++ b/src/Test/L0/Worker/JobRunnerL0.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         private Mock<ITempDirectoryManager> _temp;
         private Mock<IDiagnosticLogManager> _diagnosticLogManager;
 
-        private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
+        private TestHostContext CreateTestContext([CallerMemberName] String testName = "", IJobRunnerHelper jobRunnerHelper = null)
         {
             var hc = new TestHostContext(this, testName);
 
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             expressionManager.Initialize(hc);
             hc.SetSingleton<IExpressionManager>(expressionManager);
 
-            _jobRunner = new JobRunner();
+            _jobRunner = new JobRunner(jobRunnerHelper ?? GetMockedJobRunnerHelper().Object);
             _jobRunner.Initialize(hc);
 
             TaskOrchestrationPlanReference plan = new TaskOrchestrationPlanReference();
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             return hc;
         }
 
-        private TestHostContext CreateMSITestContext([CallerMemberName] String testName = "")
+        private TestHostContext CreateMSITestContext([CallerMemberName] String testName = "", IJobRunnerHelper jobRunnerHelper = null)
         {
             var hc = new TestHostContext(this, testName);
             _jobEc = new Agent.Worker.ExecutionContext();
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             expressionManager.Initialize(hc);
             hc.SetSingleton<IExpressionManager>(expressionManager);
 
-            _jobRunner = new JobRunner();
+            _jobRunner = new JobRunner(jobRunnerHelper ?? GetMockedJobRunnerHelper().Object);
             _jobRunner.Initialize(hc);
 
             TaskOrchestrationPlanReference plan = new TaskOrchestrationPlanReference();
@@ -203,6 +203,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             hc.EnqueueInstance<IExecutionContext>(_jobEc);
             hc.EnqueueInstance<IPagingLogger>(_logger.Object);
             return hc;
+        }
+
+        private Mock<IJobRunnerHelper> GetMockedJobRunnerHelper()
+        {
+            var mockedJobRUnnerHelper = new Mock<IJobRunnerHelper>();
+
+            mockedJobRUnnerHelper
+                .Setup(x => x.RunningOnRHEL6)
+                .Returns(false);
+
+            return mockedJobRUnnerHelper;
         }
 
         [Fact]

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -645,6 +645,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
     'build.sourceVersionMessage': {
       'value': 'Update azure-pipelines-1.yml for Azure Pipelines',
       'isReadOnly': true
+    },
+    'AGENT_ACKNOWLEDGE_NO_UPDATES': {
+      'value': 'true',
+      'isReadOnly': true
     }
   },
   'messageType': 'PipelineAgentJobRequest',


### PR DESCRIPTION
**Description:**
Need to implement logic to fail pipeline on RHEL 6 until knob `AGENT_ACKNOWLEDGE_NO_UPDATES` is specified

**Changes:**
- added knob `AGENT_ACKNOWLEDGE_NO_UPDATES`
- implemented logic to fail pipeline on RHEL 6 without specified knob `AGENT_ACKNOWLEDGE_NO_UPDATES`