### PR TITLE
Revert "Allow env.sh to accept additional env var names"

### DIFF
--- a/src/Misc/layoutroot/env.sh
+++ b/src/Misc/layoutroot/env.sh
@@ -17,16 +17,6 @@ varCheckList=(
     'AGENT_TOOLSDIRECTORY'
     )
 
-# Allows the caller to specify additional vars on the commandline, for example:
-# ./env.sh DOTNET_SYSTEM_GLOBALIZATION_INVARIANT DOTNET_ROOT
-for arg in "$@"
-do
-    if [[ ! " ${varCheckList[@]} " =~ " ${arg} " ]]; then
-        varCheckList+=($arg)
-    fi
-done
-
-
 envContents=""
 
 if [ -f ".env" ]; then


### PR DESCRIPTION
This PR reverts commit 27e3d4e177e83aac805bf93c38233fa1a9f06101.

Related issue:
- https://github.com/microsoft/azure-pipelines-agent/issues/4142