### PR TITLE
Disable major agent update from v2 to v3

### DIFF
--- a/src/Agent.Listener/SelfUpdater.cs
+++ b/src/Agent.Listener/SelfUpdater.cs
@@ -148,9 +148,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             Trace.Info($"Current running agent version is {BuildConstants.AgentPackage.Version}");
             PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
 
-            //Checking if current system support .NET 6 agent
+            // Checking if current system support .NET 6 agent
             if (agentVersion.Major == 2 && serverVersion.Major == 3)
             {
+                if (AgentKnobs.DisableAgentMajorUpdate.GetValue(_knobContext).AsBoolean())
+                {
+                    Trace.Info("Agent major update disabled, skipping update");
+                    return false;
+                }
+
                 Trace.Verbose("Checking if your system supports .NET 6");
 
                 try

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -277,6 +277,16 @@ namespace Agent.Sdk.Knob
             new BuiltInDefaultKnobSource("0"));
 
         // Misc
+        
+        public const string DisableAgentMajorUpdateVariableName = "AZP_AGENT_MAJOR_UPGRADE_DISABLED";
+
+        public static readonly Knob DisableAgentMajorUpdate = new Knob(
+            nameof(DisableAgentMajorUpdate),
+            "Disable agent major update.",
+            new RuntimeKnobSource(DisableAgentMajorUpdateVariableName),
+            new EnvironmentKnobSource(DisableAgentMajorUpdateVariableName),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob DisableAgentDowngrade = new Knob(
             nameof(DisableAgentDowngrade),
             "Disable agent downgrades. Upgrades will still be allowed.",


### PR DESCRIPTION
**Reason:**
Prevent update to a major version with FF

**Description:**
If an incoming update message with server agent version 3 and FF is enabled it has to skip updating

**Checks:**
- [ ] TBD