### PR TITLE
Added legacy lib sources for support on Ubuntu 22.04

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -7,7 +7,7 @@ if [ $user_id -ne 0 ]; then
     exit 1
 fi
 
-# Determine OS type 
+# Determine OS type
 # Debian based OS (Debian, Ubuntu, Linux Mint) has /etc/debian_version
 # Fedora based OS (Fedora, Redhat, Centos, Oracle Linux 7) has /etc/redhat-release
 # SUSE based OS (OpenSUSE, SUSE Enterprise) has ID_LIKE=suse in /etc/os-release
@@ -19,7 +19,7 @@ function print_repositories_and_deps_warning()
     echo "For issues with dependencies installation (like 'dependency was not found in repository' or 'problem retrieving the repository index file') - you can reach out to distribution owner for futher support."
 }
 
-function print_errormessage() 
+function print_errormessage()
 {
     echo "Can't install dotnet core dependencies."
     print_repositories_and_deps_warning
@@ -27,7 +27,7 @@ function print_errormessage()
     echo "https://docs.microsoft.com/dotnet/core/install/linux"
 }
 
-function print_rhel6message() 
+function print_rhel6message()
 {
     echo "We did our best effort to install dotnet core dependencies"
     echo "However, there are some dependencies which require manual installation"
@@ -36,13 +36,13 @@ function print_rhel6message()
     echo "https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md"
 }
 
-function print_rhel6errormessage() 
+function print_rhel6errormessage()
 {
     echo "We couldn't install dotnet core dependencies"
     print_repositories_and_deps_warning
     echo "You can manually install all required dependencies based on following documentation"
     echo "https://docs.microsoft.com/dotnet/core/install/linux"
-    echo "In addition, there are some dependencies which require manual installation. Please follow this documentation" 
+    echo "In addition, there are some dependencies which require manual installation. Please follow this documentation"
     echo "https://github.com/dotnet/core/blob/main/Documentation/build-and-install-rhel6-prerequisites.md"
 }
 
@@ -58,12 +58,12 @@ then
         echo "--------Debian Version--------"
         cat /etc/debian_version
         echo "------------------------------"
-        
-        # prefer apt over apt-get        
+
+        # prefer apt over apt-get
         command -v apt
         if [ $? -eq 0 ]
         then
-            apt update && apt install -y liblttng-ust0 libkrb5-3 zlib1g debsums
+            apt update && apt install -y libkrb5-3 zlib1g debsums && (apt install -y liblttng-ust0 || apt install -y liblttng-ust1)
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -71,10 +71,12 @@ then
                 exit 1
             fi
 
-	        # debian 10 uses libssl1.1
+            # debian 10 uses libssl1.1
             # debian 9 uses libssl1.0.2
-            # other debian linux use libssl1.0.0
-            apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0
+            # other debian linux use libssl1.0.0            
+            apt install -y libssl1.1 || apt install -y libssl1.0.2 || apt install -y libssl1.0.0 || \
+                    (wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb \
+                    && dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb)
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -82,8 +84,8 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-            apt install -y libicu67 || apt install -y libicu66 || apt install -y libicu63 || apt install -y libicu60 || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
+            # libicu versions: libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+            apt install -y libicu70 || apt install -y libicu67 || apt install  -y libicu66 || apt install -y libicu63 || apt install -y libicu60  || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -94,18 +96,7 @@ then
             command -v apt-get
             if [ $? -eq 0 ]
             then
-                apt-get update && apt-get install -y liblttng-ust0 libkrb5-3 zlib1g debsums
-                if [ $? -ne 0 ]
-                then
-                    echo "'apt-get' failed with exit code '$?'"
-                    print_errormessage
-                    exit 1
-                fi
-                
-                # debian 10 uses libssl1.1
-                # debian 9 uses libssl1.0.2
-                # other debian linux use libssl1.0.0
-                apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0
+                    apt-get update && apt-get install -y libkrb5-3 zlib1g debsums && (apt-get install -y liblttng-ust0 || apt-get install -y liblttng-ust1)
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -113,8 +104,21 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-                apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
+                # debian 10 uses libssl1.1
+                # debian 9 uses libssl1.0.2
+                # other debian linux use libssl1.0.0
+                apt-get install -y libssl1.1 || apt-get install -y libssl1.0.2 || apt-get install -y libssl1.0.0 || \
+                   (wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb \
+                   && dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb)
+                if [ $? -ne 0 ]
+                then
+                    echo "'apt-get' failed with exit code '$?'"
+                    print_errormessage
+                    exit 1
+                fi
+
+                # libicu versions: libicu->70 libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+                apt-get install -y libicu70 || apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"
@@ -146,7 +150,7 @@ then
                 if [ $? -eq 0 ]
                 then
                    useCompatSsl=1
-                else 
+                else
                     grep -i 'fedora release 27' /etc/fedora-release
                     if [ $? -eq 0 ]
                     then
@@ -162,7 +166,7 @@ then
 
                 if [ $useCompatSsl -eq 1 ]
                 then
-                    echo "Use compat-openssl10-devel instead of openssl-devel for Fedora 27/28 (dotnet core requires openssl 1.0.x)"                    
+                    echo "Use compat-openssl10-devel instead of openssl-devel for Fedora 27/28 (dotnet core requires openssl 1.0.x)"
                     dnf install -y compat-openssl10
                     if [ $? -ne 0 ]
                     then
@@ -178,7 +182,7 @@ then
                         print_errormessage
                         exit 1
                     fi
-                fi       
+                fi
 
                 dnf install -y lttng-ust krb5-libs zlib libicu
                 if [ $? -ne 0 ]
@@ -186,7 +190,7 @@ then
                     echo "'dnf' failed with exit code '$?'"
                     print_errormessage
                     exit 1
-                fi         
+                fi
             else
                 echo "Can not find 'dnf'"
                 print_errormessage
@@ -198,7 +202,7 @@ then
             then
                 yum install -y openssl-libs krb5-libs zlib libicu
                 if [ $? -ne 0 ]
-                then                    
+                then
                     echo "'yum' failed with exit code '$?'"
                     print_errormessage
                     exit 1
@@ -210,7 +214,7 @@ then
                     yum install -y wget ca-certificates && wget -P /etc/yum.repos.d/ https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo && rpmkeys --import https://packages.efficios.com/rhel/repo.key && yum updateinfo -y && yum install -y lttng-ust
                 fi
                 if [ $? -ne 0 ]
-                then                    
+                then
                     echo "'lttng-ust' installation failed with exit code '$?'"
                     print_errormessage
                     exit 1
@@ -269,7 +273,7 @@ then
                 then
                 yum install -y icu
                 if [ $? -ne 0 ]
-                then                    
+                then
                     echo "'yum' failed with exit code '$?'"
                     print_errormessage
                     exit 1
@@ -300,7 +304,7 @@ then
         then
             yum install -y openssl krb5-libs zlib
             if [ $? -ne 0 ]
-            then                    
+            then
                 echo "'yum' failed with exit code '$?'"
                 print_rhel6errormessage
                 exit 1


### PR DESCRIPTION
**Description:**  .Net 3.1 requires libssl1.1 which is not supported by Ubuntu 22.04 release. Added script to installdependencies.sh to get this lib from direct source.
