### PR TITLE
Add warning for deprecated runners

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -397,8 +397,8 @@ namespace Agent.Sdk.Knob
 
         public const string VstsAgentNodeWarningsVariableName = "VSTSAGENT_ENABLE_NODE_WARNINGS";
 
-        public static readonly Knob AgentDepricatedNodeWarnings = new Knob(
-            nameof(AgentDepricatedNodeWarnings),
+        public static readonly Knob AgentDeprecatedNodeWarnings = new Knob(
+            nameof(AgentDeprecatedNodeWarnings),
             "If true shows warning on depricated node (6) tasks",
             new RuntimeKnobSource(VstsAgentNodeWarningsVariableName),
             new EnvironmentKnobSource(VstsAgentNodeWarningsVariableName),

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -395,6 +395,15 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource(ContinueAfterCancelProcessTreeKillAttemptVariableName),
             new BuiltInDefaultKnobSource("false"));
 
+        public const string VstsAgentNodeWarningsVariableName = "VSTSAGENT_ENABLE_NODE_WARNINGS";
+
+        public static readonly Knob AgentDepricatedNodeWarnings = new Knob(
+            nameof(AgentDepricatedNodeWarnings),
+            "If true shows warning on depricated node (6) tasks",
+            new RuntimeKnobSource(VstsAgentNodeWarningsVariableName),
+            new EnvironmentKnobSource(VstsAgentNodeWarningsVariableName),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob UseNode = new Knob(
             nameof(UseNode),
             "Forces the agent to use different version of Node if when configured runner is not available. Possible values: LTS - make agent use latest LTS version of Node; UPGRADE - make agent use next available version of Node",

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (nodeFolder == NodeHandler.nodeFolder && 
                 AgentKnobs.AgentDeprecatedNodeWarnings.GetValue(ExecutionContext).AsBoolean() == true)
             {
-                ExecutionContext.Warning(StringUtil.Loc("DeprecatedRunner", new[] { Task.Name.ToString() }));
+                ExecutionContext.Warning(StringUtil.Loc("DeprecatedRunner", Task.Name.ToString()));
             }
 
             if (!nodeHandlerHelper.IsNodeFolderExist(nodeFolder, HostContext))

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -241,6 +241,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 Trace.Info($"Found UseNode10 knob, use node10 for node tasks: {useNode10}");
                 nodeFolder = NodeHandler.node10Folder;
             }
+            if (nodeFolder == NodeHandler.nodeFolder && 
+                AgentKnobs.AgentDepricatedNodeWarnings.GetValue(ExecutionContext).AsBoolean() == true)
+            {
+                ExecutionContext.Warning(StringUtil.Loc("DepricatedRunner", new[] { Task.Name.ToString() }));
+            }
 
             if (!nodeHandlerHelper.IsNodeFolderExist(nodeFolder, HostContext))
             {

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -242,9 +242,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 nodeFolder = NodeHandler.node10Folder;
             }
             if (nodeFolder == NodeHandler.nodeFolder && 
-                AgentKnobs.AgentDepricatedNodeWarnings.GetValue(ExecutionContext).AsBoolean() == true)
+                AgentKnobs.AgentDeprecatedNodeWarnings.GetValue(ExecutionContext).AsBoolean() == true)
             {
-                ExecutionContext.Warning(StringUtil.Loc("DepricatedRunner", new[] { Task.Name.ToString() }));
+                ExecutionContext.Warning(StringUtil.Loc("DeprecatedRunner", new[] { Task.Name.ToString() }));
             }
 
             if (!nodeHandlerHelper.IsNodeFolderExist(nodeFolder, HostContext))

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -259,6 +259,7 @@
   "DeploymentPoolName": "Deployment Pool name",
   "DeploymentPoolNotFound": "Deployment pool not found: '{0}'",
   "DeprecatedNode6": "This task uses Node 6 execution handler, which will be removed March 31st 2022. If you are the developer of the task - please consider the migration guideline to Node 10 handler - https://aka.ms/migrateTaskNode10 (check this page also if you would like to disable Node 6 deprecation warnings). If you are the user - feel free to reach out to the owners of this task to proceed on migration.",
+  "DepricatedRunner":"Task '{0}' is dependent on a task runner that is end-of-life and will be removed in the future. Authors should review Node upgrade guidance: https://aka.ms/node-runner-guidance.",
   "DirectoryHierarchyUnauthorized": "Permission to read the directory contents is required for '{0}' and each directory up the hierarchy. {1}",
   "DirectoryIsEmptyForArtifact": "Directory '{0}' is empty. Nothing will be added to build artifact '{1}'.",
   "DirectoryNotFound": "Directory not found: '{0}'",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -259,7 +259,7 @@
   "DeploymentPoolName": "Deployment Pool name",
   "DeploymentPoolNotFound": "Deployment pool not found: '{0}'",
   "DeprecatedNode6": "This task uses Node 6 execution handler, which will be removed March 31st 2022. If you are the developer of the task - please consider the migration guideline to Node 10 handler - https://aka.ms/migrateTaskNode10 (check this page also if you would like to disable Node 6 deprecation warnings). If you are the user - feel free to reach out to the owners of this task to proceed on migration.",
-  "DepricatedRunner": "Task '{0}' is dependent on a task runner that is end-of-life and will be removed in the future. Authors should review Node upgrade guidance: https://aka.ms/node-runner-guidance.",
+  "DeprecatedRunner": "Task '{0}' is dependent on a task runner that is end-of-life and will be removed in the future. Authors should review Node upgrade guidance: https://aka.ms/node-runner-guidance.",
   "DirectoryHierarchyUnauthorized": "Permission to read the directory contents is required for '{0}' and each directory up the hierarchy. {1}",
   "DirectoryIsEmptyForArtifact": "Directory '{0}' is empty. Nothing will be added to build artifact '{1}'.",
   "DirectoryNotFound": "Directory not found: '{0}'",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -259,7 +259,7 @@
   "DeploymentPoolName": "Deployment Pool name",
   "DeploymentPoolNotFound": "Deployment pool not found: '{0}'",
   "DeprecatedNode6": "This task uses Node 6 execution handler, which will be removed March 31st 2022. If you are the developer of the task - please consider the migration guideline to Node 10 handler - https://aka.ms/migrateTaskNode10 (check this page also if you would like to disable Node 6 deprecation warnings). If you are the user - feel free to reach out to the owners of this task to proceed on migration.",
-  "DepricatedRunner":"Task '{0}' is dependent on a task runner that is end-of-life and will be removed in the future. Authors should review Node upgrade guidance: https://aka.ms/node-runner-guidance.",
+  "DepricatedRunner": "Task '{0}' is dependent on a task runner that is end-of-life and will be removed in the future. Authors should review Node upgrade guidance: https://aka.ms/node-runner-guidance.",
   "DirectoryHierarchyUnauthorized": "Permission to read the directory contents is required for '{0}' and each directory up the hierarchy. {1}",
   "DirectoryIsEmptyForArtifact": "Directory '{0}' is empty. Nothing will be added to build artifact '{1}'.",
   "DirectoryNotFound": "Directory not found: '{0}'",


### PR DESCRIPTION
This PR introduces a warning for tasks that are using deprecated Node6 runner in runtime

![image](https://user-images.githubusercontent.com/102740624/219302399-584a9a57-e616-43a8-9579-6cb78e181b05.png)

** Testing **
Tested on local AzureDevOps Server, with FF on and OFF.
