### PR TITLE
Added knob to break pipeline unless user opt-in

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -282,6 +282,13 @@ namespace Agent.Sdk.Knob
             "Disable agent downgrades. Upgrades will still be allowed.",
             new EnvironmentKnobSource("AZP_AGENT_DOWNGRADE_DISABLED"),
             new BuiltInDefaultKnobSource("false"));
+        
+        public static readonly Knob AcknowledgeNoUpdates = new Knob(
+            nameof(AcknowledgeNoUpdates),
+            "Opt-in to continue using agent without updates on unsopperted OS",
+            new EnvironmentKnobSource("AGENT_ACKNOWLEDGE_NO_UPDATES"),
+            new RuntimeKnobSource("AGENT_ACKNOWLEDGE_NO_UPDATES"),
+            new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob PermissionsCheckFailsafe = new Knob(
             nameof(PermissionsCheckFailsafe),

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         {                            
                             if(!AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean())
                             {
-                                jobContext.AddIssue(new Issue(){Type = IssueType.Error,Message= StringUtil.Loc("FailAgentOnUnsupportedOs")});
+                                jobContext.Error(StringUtil.Loc("FailAgentOnUnsupportedOs"));
                                 return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
                             }
 

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -128,13 +128,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         }
 
                         if (!string.IsNullOrWhiteSpace(notSupportNet6Message))
-                        {
+                        {                            
+                            if(!AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean())
+                            {
+                                jobContext.AddIssue(new Issue(){Type = IssueType.Error,Message= StringUtil.Loc("FailAgentOnUnsupportedOs")});
+                                return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
+                            }
+
                             jobContext.AddIssue(new Issue() { Type = IssueType.Warning, Message = notSupportNet6Message });
                         }
                     }
                     catch (Exception ex)
                     {
                         Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
+                        return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
+
                     }
                 }
 

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -298,6 +298,7 @@
   "ExpectedMappingLocalPath": "Expected mapping[{0}] local path: '{1}'. Actual: '{2}'",
   "ExpectedMappingRecursive": "Expected mapping[{0}] recursive: '{1}'. Actual: '{2}'",
   "ExpectedMappingServerPath": "Expected mapping[{0}] server path: '{1}'. Actual: '{2}'",
+  "FailAgentOnUnsupportedOs": "This operating system will stop receiving updates of the Pipelines Agent in the future. To be able to continue to run pipelines please upgrade the operating system or set an environment variable or agent knob \"AGENT_ACKNOWLEDGE_NO_UPDATES\" to \"true\". See https://aka.ms/azdo-pipeline-agent-nosupport for more information.",
   "Failed": "Failed: ",
   "FailedDeletingTempDirectory0Message1": "Failed to delete temporary directory '{0}'. {1}",
   "FailedTestsInResults": "There are one or more test failures detected in result files. Detailed summary of published test results can be viewed in the Tests tab.",


### PR DESCRIPTION
Added boolean opt-in knob to make sure users agree to continue using agent that will not get updates on unsupported OS 
The Pipeline breaks unless AGENT_ACKNOWLEDGE_NO_UPDATES  is set to true either agent environment or on job variable.

The result looks like:
![image](https://user-images.githubusercontent.com/110806089/220264083-b4e43f0f-8d5f-4fee-8771-a35a38471873.png)

Test cases:
1. Without any env/yaml variables on **supported** OS:  Pipeline **passed**
2. Without any env/yaml variables on **unsupported** OS:  Pipeline **breaks**
3. With ```AGENT_ACKNOWLEDGE_NO_UPDATES=true``` environment variable on unsupported OS: Pipeline **passed**
4.  With  ```AGENT_ACKNOWLEDGE_NO_UPDATES: true``` variable in yaml, agent on unsupported OS:  Pipeline **passed**

``` 
jobs:
- job:
  displayName: "Test unsupported OS"
  variables: 
    AGENT_ACKNOWLEDGE_NO_UPDATE: true
  steps: 
```


