### PR TITLE
Fix long time fetching net6.json file for supported OS list

### DIFF
--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -315,8 +315,9 @@ namespace Agent.Sdk
             string supportOSfilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "net6.json");
             string supportOSfileContent;
 
-            if (!File.Exists(supportOSfilePath) || File.GetLastWriteTimeUtc(supportOSfilePath) < DateTime.UtcNow.AddHours(-1))
+            if (!File.Exists(supportOSfilePath) || File.GetLastWriteTimeUtc(supportOSfilePath) < DateTime.UtcNow.AddDays(3))
             {
+                httpClient.Timeout = TimeSpan.FromSeconds(10);
                 HttpResponseMessage response = await httpClient.GetAsync(serverFileUrl);
                 if (!response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
**Description** Fetching net6.json file take too much time (timeout) if agent host doesn't access to required link. 

Changed default httpclient timeout (100sec) to 10 sec. 
Due to non-frequently update on list supported OS, file stale time increased (1 hour) to 7 days.