### PR TITLE
Moved logic to drain queues after each task under knob "AGENT_DRAIN_QUEUES_AFTER_TASK"

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -410,5 +410,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_USE_NODE"),
             new EnvironmentKnobSource("AGENT_USE_NODE"),
             new BuiltInDefaultKnobSource(string.Empty));
+
+        public static readonly Knob DrainQueuesAfterTask = new Knob(
+            nameof(DrainQueuesAfterTask),
+            "Forces the agent to drain queues after each task",
+            new RuntimeKnobSource("AGENT_DRAIN_QUEUES_AFTER_TASK"),
+            new EnvironmentKnobSource("AGENT_DRAIN_QUEUES_AFTER_TASK"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.TeamFoundation.DistributedTask.Expressions;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 using Microsoft.VisualStudio.Services.CircuitBreaker;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -309,16 +310,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             step.ExecutionContext.Section(StringUtil.Loc("StepFinishing", step.DisplayName));
             step.ExecutionContext.Complete();
 
-            try
+            if (AgentKnobs.DrainQueuesAfterTask.GetValue(step.ExecutionContext).AsBoolean() == true)
             {
-                // We need to drain the queues after a task just in case if
-                // there are a lot of items since it can cause some UI hangs.
-                await JobServerQueue.DrainQueues();
-            }
-            catch (Exception ex)
-            {
-                Trace.Error($"Error has occurred while draining queues, it can cause some UI glitches but it doesn't affect a pipeline execution itself: {ex}");
-                step.ExecutionContext.Error(ex);
+                try
+                {
+                    // We need to drain the queues after a task just in case if
+                    // there are a lot of items since it can cause some UI hangs.
+                    await JobServerQueue.DrainQueues();
+                }
+                catch (Exception ex)
+                {
+                    Trace.Error($"Error has occurred while draining queues, it can cause some UI glitches but it doesn't affect a pipeline execution itself: {ex}");
+                    step.ExecutionContext.Error(ex);
+                }
             }
         }
 


### PR DESCRIPTION
**Description of issue:**
We have an assumption that logic to drain queues after each task could have side effect: some tasks fails while they passed successfully actually

**Description of fix:**
Due to the fact that it's not clear exactly why this occurs and to mitigate this wide spread issue we decided to move this logic under knob `AGENT_DRAIN_QUEUES_AFTER_TASK` which is disabled by default and see if the issue will be mitigated

**Notes:**
This changes will affect users which experienced with an issue when ADO UI hangs during task producing a lot of lines in a web console