### PR TITLE
Add "Mariner" to list of .NET 6 supporting systems

### DIFF
--- a/src/Agent.Listener/net6.json
+++ b/src/Agent.Listener/net6.json
@@ -48,6 +48,14 @@
     ]
   },
   {
+    "id": "mariner",
+    "versions": [
+      {
+        "name": "1.0+"
+      }
+    ]
+  },
+  {
     "id": "opensuse-leap",
     "versions": [
       {


### PR DESCRIPTION
**Description of issue:**
Need to add `CBL-Mariner` to list of `.NET 6` supporting systems

**Description of fix:**
Added `CBL-Mariner` to `net6.json` starting with version `1.0`