### PR TITLE
Add knob to enable fetching net6.json file from GitHub

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -424,5 +424,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_DISABLE_DRAIN_QUEUES_AFTER_TASK"),
             new EnvironmentKnobSource("AGENT_DISABLE_DRAIN_QUEUES_AFTER_TASK"),
             new BuiltInDefaultKnobSource("false"));
+            
+        public static readonly Knob EnableFetchingNet6List = new Knob(
+            nameof(EnableFetchingNet6List),
+            "Forces the agent to fetch list of .NET 6 supporting systems from server",
+            new RuntimeKnobSource("AGENT_ENABLE_FETCHING_NET6_LIST"),
+            new EnvironmentKnobSource("AGENT_ENABLE_FETCHING_NET6_LIST"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -428,7 +428,6 @@ namespace Agent.Sdk.Knob
         public static readonly Knob EnableFetchingNet6List = new Knob(
             nameof(EnableFetchingNet6List),
             "Forces the agent to fetch list of .NET 6 supporting systems from server",
-            new RuntimeKnobSource("AGENT_ENABLE_FETCHING_NET6_LIST"),
             new EnvironmentKnobSource("AGENT_ENABLE_FETCHING_NET6_LIST"),
             new BuiltInDefaultKnobSource("false"));
     }

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -317,8 +317,10 @@ namespace Agent.Sdk
             string serverFileUrl = "https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json";
             string supportOSfilePath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "net6.json");
             string supportOSfileContent;
+            bool supportOSfileExists = File.Exists(supportOSfilePath);
 
-            if (!File.Exists(supportOSfilePath) || File.GetLastWriteTimeUtc(supportOSfilePath) < DateTime.UtcNow.AddHours(-1))
+            if ((!supportOSfileExists || File.GetLastWriteTimeUtc(supportOSfilePath) < DateTime.UtcNow.AddHours(-1))
+                && AgentKnobs.EnableFetchingNet6List.GetValue(_knobContext).AsBoolean())
             {
                 HttpResponseMessage response = await httpClient.GetAsync(serverFileUrl);
                 if (!response.IsSuccessStatusCode)
@@ -333,6 +335,11 @@ namespace Agent.Sdk
                 if (net6SupportedSystems != null)
                 {
                     return net6SupportedSystems;
+                }
+
+                if (!supportOSfileExists)
+                {
+                    throw new FileNotFoundException("File with list of systems supporing .NET 6 is absent", supportOSfilePath);
                 }
 
                 supportOSfileContent = await File.ReadAllTextAsync(supportOSfilePath);

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -339,7 +339,7 @@ namespace Agent.Sdk
 
                 if (!supportOSfileExists)
                 {
-                    throw new FileNotFoundException("File with list of systems supporing .NET 6 is absent", supportOSfilePath);
+                    throw new FileNotFoundException("File with list of systems supporting .NET 6 is absent", supportOSfilePath);
                 }
 
                 supportOSfileContent = await File.ReadAllTextAsync(supportOSfilePath);

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -140,8 +140,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     }
                     catch (Exception ex)
                     {
+                        jobContext.Warning($"Error has occurred while checking if system supports .NET 6: {ex.Message}");
                         Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
-                        return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
 
                     }
                 }


### PR DESCRIPTION
**Description of issue:**
Many of customers' VMs are restricted to connect to any server except `ADO`, so they experience issue during fetching `net6.json` file from `GitHub`

**Description of fix:**
- implemented knob `AGENT_ENABLE_FETCHING_NET6_LIST` which forces the agent to fetch list of systems supporting `.NET 6` from GitHub repository. It's disabled by default.
- removed logic which fails pipeline if some error occurred during checking if system supports `.NET 6`, writing warning in a pipeline instead

**How it was tested:**
Tested on local build of the agent. Just removed `net6.json` file and with disabled knob I see warning in pipeline `Error has occurred while checking if system supports .NET 6: File with list of systems supporting .NET 6 is absent`, it means that agent didn't get the file from GitHub. With enabled knob, the file is downloaded from GitHub and appears in explorer.