### PR TITLE
Update autoAssignABTT.yml

### DIFF
--- a/.github/workflows/autoAssignABTT.yml
+++ b/.github/workflows/autoAssignABTT.yml
@@ -2,9 +2,8 @@ name: Auto Assign ABTT to Project Board
 
 on:
   issues:
-    types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.ABTT_TOKEN }}
+    types:
+      - opened
 
 jobs:
   assign_one_project:
@@ -18,8 +17,9 @@ jobs:
         labels: |
           Area: Agent
           triage
+
     - name: "Assign issues with 'Area: ABTT' label to project board"
-      uses: srggrs/assign-one-project-github-action@1.2.0
+      uses: actions/add-to-project@v0.4.1
       with:
-        project: 'https://github.com/orgs/microsoft/projects/48'
-        column_name: 'Backlog'
+        project-url: https://github.com/orgs/microsoft/projects/755
+        github-token: ${{ secrets.ABTT_TOKEN }}


### PR DESCRIPTION
Replaced assign-one-project-github-action with [add-to-project](https://github.com/actions/add-to-project#examples) since the old one doesn't support a new type of gh projects

We can't now move to a specific column using this action. Authors recommend using workflow to set a default column
[Setting a specific status or column name to the project item](https://github.com/actions/add-to-project#setting-a-specific-status-or-column-name-to-the-project-item)