### PR TITLE
Make warnings/errors during checking if system supports .NET 6 being pushed to Kusto telemetry

### DIFF
--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -72,6 +72,52 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     context.Start();
                     context.Section(StringUtil.Loc("StepStarting", StringUtil.Loc("InitializeJob")));
 
+                    // Check if a system supports .NET 6
+                    PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
+                    if (agentVersion.Major < 3)
+                    {
+                        try
+                        {
+                            Trace.Verbose("Checking if your system supports .NET 6");
+
+                            string systemId = PlatformUtil.GetSystemId();
+                            SystemVersion systemVersion = PlatformUtil.GetSystemVersion();
+                            string notSupportNet6Message = null;
+
+                            if (await PlatformUtil.DoesSystemPersistsInNet6Whitelist())
+                            {
+                                // Check version of the system
+                                if (!await PlatformUtil.IsNet6Supported())
+                                {
+                                    notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version";
+                                    if (AgentKnobs.AgentFailOnIncompatibleOS.GetValue(jobContext).AsBoolean() &&
+                                        !AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean())
+                                    {
+                                        throw new UnsupportedOsException(StringUtil.Loc("FailAgentOnUnsupportedOs"));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which has not been tested with the .NET 6 based v3 agent. The v2 agent wil not automatically upgrade to the v3 agent. You can manually download the .NET 6 based v3 agent from https://github.com/microsoft/azure-pipelines-agent/releases. See https://aka.ms/azdo-pipeline-agent-version";
+                            }
+
+                            if (!string.IsNullOrWhiteSpace(notSupportNet6Message))
+                            {
+                                context.Warning(notSupportNet6Message);
+                            }
+                        }
+                        catch (UnsupportedOsException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
+                            context.Warning(ex.Message);
+                        }
+                    }
+
                     // Set agent version variable.
                     context.SetVariable(Constants.Variables.Agent.Version, BuildConstants.AgentPackage.Version);
                     context.Output(StringUtil.Loc("AgentNameLog", context.Variables.Get(Constants.Variables.Agent.Name)));
@@ -591,5 +637,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Trace.Error(ex);
             }
         }
+    }
+
+    public class UnsupportedOsException : Exception {
+        public UnsupportedOsException(string message) : base(message) { }
     }
 }

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -102,52 +102,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 jobContext = HostContext.CreateService<IExecutionContext>();
                 jobContext.InitializeJob(message, jobRequestCancellationToken);
 
-                // Check if a system supports .NET 6
-                PackageVersion agentVersion = new PackageVersion(BuildConstants.AgentPackage.Version);
-                if (agentVersion.Major < 3)
-                {
-                    try
-                    {
-                        Trace.Verbose("Checking if your system supports .NET 6");
-
-                        string systemId = PlatformUtil.GetSystemId();
-                        SystemVersion systemVersion = PlatformUtil.GetSystemVersion();
-                        string notSupportNet6Message = null;
-
-                        if (await PlatformUtil.DoesSystemPersistsInNet6Whitelist())
-                        {
-                            // Check version of the system
-                            if (!await PlatformUtil.IsNet6Supported())
-                            {
-                                notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version";
-                                if (AgentKnobs.AgentFailOnIncompatibleOS.GetValue(jobContext).AsBoolean() &&
-                                    !AgentKnobs.AcknowledgeNoUpdates.GetValue(jobContext).AsBoolean())
-                                {
-                                    jobContext.Error(StringUtil.Loc("FailAgentOnUnsupportedOs"));
-                                    return await CompleteJobAsync(jobServer, jobContext, message, TaskResult.Failed);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            notSupportNet6Message = $"The operating system the agent is running on is \"{systemId}\" ({systemVersion}), which has not been tested with the .NET 6 based v3 agent. The v2 agent wil not automatically upgrade to the v3 agent. You can manually download the .NET 6 based v3 agent from https://github.com/microsoft/azure-pipelines-agent/releases. See https://aka.ms/azdo-pipeline-agent-version";
-                        }
- 
-                        if (!string.IsNullOrWhiteSpace(notSupportNet6Message))
-                        {                            
-                            
-
-                            jobContext.AddIssue(new Issue() { Type = IssueType.Warning, Message = notSupportNet6Message });
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        jobContext.Warning($"Error has occurred while checking if system supports .NET 6: {ex.Message}");
-                        Trace.Error($"Error has occurred while checking if system supports .NET 6: {ex}");
-
-                    }
-                }
-
                 Trace.Info("Starting the job execution context.");
                 jobContext.Start();
                 jobContext.Section(StringUtil.Loc("StepStarting", message.JobDisplayName));


### PR DESCRIPTION
**Description of issue:**
Warnings and errors during checking if system supports .NET 6 is not presented in `Kusto`

**Description of fix:**
Based on code of this method [public long Write(string tag, string inputMessage, bool canMaskSecrets = true)](https://github.com/microsoft/azure-pipelines-agent/blob/fa4e296d0ffc146de8e1ebd7cf8c5cf56b254b26/src/Agent.Worker/ExecutionContext.cs#L685) we need to rise errors and warnings in child context to be able to push it to telemetry. So I moved logic of checking if system supports `.NET 6` from `JobRunner.cs` to `JobExtension.cs` into method `InitializeJob`

**Screenshot:**
![image](https://user-images.githubusercontent.com/11807074/225883111-24022a68-0524-4b44-a3e8-19ed904efe77.png)

**How it was tested:**
- DevFabric with Kusto telemetry was deployed locally and test pipeline was run on agent with changes from the PR
- also it was tested on dev.azure.com, here is a test pipeline: https://abtttestorg.visualstudio.com/Other/_build/results?buildId=6299&view=results

**Test case:**
Test pipeline:
```yaml
trigger: none

strategy:
  matrix:
    'FailOnUnsupportedOs':
      AGENT_FAIL_ON_INCOMPATIBLE_OS: 'true'
    'AcknowledgeNoUpdatesUnsupportedOs':
      AGENT_FAIL_ON_INCOMPATIBLE_OS: 'true'
      AGENT_ACKNOWLEDGE_NO_UPDATES: 'true'
    'AbsentNet6List':
      NET6LIST: 'delete'
    'UnsupportedOs':
      NET6LIST: 'unsupported'
    'UntestedOs':
      NET6LIST: 'untested'
    'SupportedOs':
      NET6LIST: 'none'

pool: default

steps:
- script: echo "Hello world!"
  displayName: 'Run a one-line script'
```

1. add `System.Diagnostics.Debugger.Launch()` at the beginning of method `InitializeJob` of class `JobExtension.cs` to be able to interact with `net6.json` file before job start.
2. build agent, setup test pipeline
3. run agent on Windows 10/11
4. perform follow actions before corresponding jobs:
    - `FailOnUnsupportedOs`: remove `10th` version of `Windows Client` from `net6.json` 
    - `AcknowledgeNoUpdatesUnsupportedOs`: same as for `FailOnUnsupportedOs`
    - `AbsentNet6List`: rename `net6.json` to `net6.json_`
    - `UnsupportedOs`: the same as for `FailOnUnsupportedOs`
    - `UntestedOs`: remove `Windows Client` part from `net6.json` file
    - `SupportedOs`: do nothing with `net6.json` file

Expected result:
    - `FailOnUnsupportedOs`: job must be failed with error `This operating system will stop receiving updates of the Pipelines Agent in the future. To be able to continue to run pipelines please upgrade the operating system or set an environment variable or agent knob "AGENT_ACKNOWLEDGE_NO_UPDATES" to "true". See https://aka.ms/azdo-pipeline-agent-v2-eos for more information.`
    - `AcknowledgeNoUpdatesUnsupportedOs`: job must be succeeded with warning `The operating system the agent is running on is "Windows Client" (OS name: 10, OS version: 22621), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version`
    - `AbsentNet6List`: job must be succeeded with warning `File with list of systems supporting .NET 6 is absent`
    - `UnsupportedOs`: job must be succeeded with warning `The operating system the agent is running on is "Windows Client" (OS name: 10, OS version: 22621), which will not be supported by the .NET 6 based v3 agent. Please upgrade the operating system of this host to ensure compatibility with the v3 agent. See https://aka.ms/azdo-pipeline-agent-version`
    - `UntestedOs`: job must be succeeded with warning `The operating system the agent is running on is "Windows Client" (OS name: 10, OS version: 22621), which has not been tested with the .NET 6 based v3 agent. The v2 agent wil not automatically upgrade to the v3 agent. You can manually download the .NET 6 based v3 agent from https://github.com/microsoft/azure-pipelines-agent/releases. See https://aka.ms/azdo-pipeline-agent-version`
    - `SupportedOs`: job must be succeeded without warnings
Also all warnings/errors must be found in Kusto:
```kusto
let vStartTime = ago(10d);
let vEndTime = now();
ClientTrace
| where PreciseTimeStamp > vStartTime and PreciseTimeStamp < vEndTime
| where HostId == "578c6bff-7ac3-4d21-8f30-79a1b2c90fed"
| extend Warnings = parse_json(Properties).Warnings
| extend Errors = parse_json(Properties).Errors
| where array_length(Warnings) > 0 or array_length(Errors) > 0
| project PreciseTimeStamp, Warnings, Errors
| sort by PreciseTimeStamp desc
```