### PR TITLE
add ability to disable publishing tests metadata

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -165,6 +165,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTSAGENT_DUMP_JOB_EVENT_LOGS"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob DisableTestsMetadata = new Knob(
+            nameof(DisableTestsMetadata),
+            "If true, publishing tests metadata to evidence store will be disabled.",
+            new RuntimeKnobSource("AZP_AGENT_DISABLE_TESTS_METADATA"),
+            new EnvironmentKnobSource("AZP_AGENT_DISABLE_TESTS_METADATA"),
+            new BuiltInDefaultKnobSource("false"));
+
         // Diag logging
         public static readonly Knob AgentDiagLogPath = new Knob(
             nameof(AgentDiagLogPath),

--- a/src/Agent.Worker/TestResults/Utils/TestResultUtils.cs
+++ b/src/Agent.Worker/TestResults/Utils/TestResultUtils.cs
@@ -1,15 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Agent.Sdk.Knob;
 using System;
-using Microsoft.TeamFoundation.TestClient.PublishTestResults;
-using Microsoft.TeamFoundation.TestManagement.WebApi;
-using Microsoft.VisualStudio.Services.WebApi;
-using Microsoft.TeamFoundation.Core.WebApi;
-using System.Linq;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -19,6 +12,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
     {
         public static void StoreTestRunSummaryInEnvVar(IExecutionContext executionContext, TestRunSummary testRunSummary, string testRunner, string name, string description = "")
         {
+            if (AgentKnobs.DisableTestsMetadata.GetValue(executionContext).AsBoolean())
+            {
+                return;
+            }
+
             try
             {
                 string metadata = GetEvidenceStoreMetadata(executionContext, testRunSummary, testRunner, name, description);


### PR DESCRIPTION
**Description:** this pull request adds the ability to add the `AZP_AGENT_DISABLE_TESTS_METADATA` variable (as an environment variable or as a pipeline variable) to disable adding metadata variables during tests execution since too long an environment block can cause issues.