### PR TITLE
Refactor logic to drain queues after each task

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -295,6 +295,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 this.Warning(StringUtil.Loc("TotalThrottlingDelay", TimeSpan.FromMilliseconds(_totalThrottlingDelayInMilliseconds).TotalSeconds));
             }
 
+            if (!AgentKnobs.DisableDrainQueuesAfterTask.GetValue(this).AsBoolean())
+            {
+                _jobServerQueue.ForceDrainWebConsoleQueue = true;
+                _jobServerQueue.ForceDrainTimelineQueue = true;
+            }
+
             _record.CurrentOperation = currentOperation ?? _record.CurrentOperation;
             _record.ResultCode = resultCode ?? _record.ResultCode;
             _record.FinishTime = DateTime.UtcNow;

--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TeamFoundation.DistributedTask.Expressions;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
-using Microsoft.VisualStudio.Services.CircuitBreaker;
 using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
@@ -35,10 +34,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
     public sealed class StepsRunner : AgentService, IStepsRunner
     {
-        private IJobServerQueue _jobServerQueue;
-
-        private IJobServerQueue JobServerQueue => _jobServerQueue ??= HostContext.GetService<IJobServerQueue>();
-
         // StepsRunner should never throw exception to caller
         public async Task RunAsync(IExecutionContext jobContext, IList<IStep> steps)
         {
@@ -304,21 +299,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             else
             {
                 Trace.Info($"Step result: {step.ExecutionContext.Result}");
-            }
-
-            if (!AgentKnobs.DisableDrainQueuesAfterTask.GetValue(step.ExecutionContext).AsBoolean())
-            {
-                try
-                {
-                    // We need to drain the queues after a task just in case if
-                    // there are a lot of items since it can cause some UI hangs.
-                    await JobServerQueue.DrainQueues();
-                }
-                catch (Exception ex)
-                {
-                    Trace.Error($"Error has occurred while draining queues, it can cause some UI glitches but it doesn't affect a pipeline execution itself: {ex}");
-                    step.ExecutionContext.Error(ex);
-                }
             }
 
             // Complete the step context.

--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -306,10 +306,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Trace.Info($"Step result: {step.ExecutionContext.Result}");
             }
 
-            // Complete the step context.
-            step.ExecutionContext.Section(StringUtil.Loc("StepFinishing", step.DisplayName));
-            step.ExecutionContext.Complete();
-
             if (!AgentKnobs.DisableDrainQueuesAfterTask.GetValue(step.ExecutionContext).AsBoolean())
             {
                 try
@@ -324,6 +320,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     step.ExecutionContext.Error(ex);
                 }
             }
+
+            // Complete the step context.
+            step.ExecutionContext.Section(StringUtil.Loc("StepFinishing", step.DisplayName));
+            step.ExecutionContext.Complete();
         }
 
         private async Task SwitchToUtf8Codepage(IStep step)

--- a/src/Agent.Worker/Worker.cs
+++ b/src/Agent.Worker/Worker.cs
@@ -138,6 +138,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     HostContext.SecretMasker.AddValue(secret.Trim(quoteChar), WellKnownSecretAliases.UserSuppliedSecret);
                 }
             }
+
+            // Here we add a trimmed secret value to the dictionary in case of a possible leak through external tools.
+            var trimChars = new char[] { '\r', '\n', ' ' };
+            HostContext.SecretMasker.AddValue(secret.Trim(trimChars), WellKnownSecretAliases.UserSuppliedSecret);
         }
 
         private void InitializeSecretMasker(Pipelines.AgentJobRequestMessage message)

--- a/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         {
             while (!_jobCompletionSource.Task.IsCompleted || runOnce)
             {
-                bool drain = ForceDrainWebConsoleQueue;
+                bool shouldDrain = ForceDrainWebConsoleQueue;
                 if (ForceDrainWebConsoleQueue)
                 {
                     ForceDrainWebConsoleQueue = false;
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                     // process at most about 500 lines of web console line during regular timer dequeue task.
                     // Send the first line of output to the customer right away
                     // It might take a while to reach 500 line outputs, which would cause delays before customers see the first line
-                    if ((!runOnce && !drain && linesCounter > 500) || _firstConsoleOutputs)
+                    if ((!runOnce && !shouldDrain && linesCounter > 500) || _firstConsoleOutputs)
                     {
                         break;
                     }
@@ -319,7 +319,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                         // We batch and produce 500 lines of web console output every 500ms
                         // If customer's task produce massive of outputs, then the last queue drain run might take forever.
                         // So we will only upload the last 200 lines of each step from all buffered web console lines.
-                        if ((runOnce || drain) && batchedLines.Count > 2)
+                        if ((runOnce || shouldDrain) && batchedLines.Count > 2)
                         {
                             Trace.Info($"Skip {batchedLines.Count - 2} batches web console lines for last run");
                             batchedLines = batchedLines.TakeLast(2).ToList();
@@ -435,7 +435,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         {
             while (!_jobCompletionSource.Task.IsCompleted || runOnce)
             {
-                bool drain = ForceDrainTimelineQueue;
+                bool shouldDrain = ForceDrainTimelineQueue;
 
                 List<PendingTimelineRecord> pendingUpdates = new List<PendingTimelineRecord>();
                 foreach (var timeline in _allTimelines)
@@ -449,7 +449,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                         {
                             records.Add(record);
                             // process at most 25 timeline records update for each timeline.
-                            if (!runOnce && !drain && records.Count > 25)
+                            if (!runOnce && !shouldDrain && records.Count > 25)
                             {
                                 break;
                             }
@@ -521,7 +521,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                     }
                 }
 
-                if (runOnce || drain)
+                if (runOnce || shouldDrain)
                 {
                     // continue process timeline records update,
                     // we might have more records need update,

--- a/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/JobServerQueue.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.Services.Agent
     {
         event EventHandler<ThrottlingEventArgs> JobServerQueueThrottling;
         Task ShutdownAsync();
-        Task DrainQueues();
         void Start(Pipelines.AgentJobRequestMessage jobRequest);
         void QueueWebConsoleLine(Guid stepRecordId, string line, long lineNumber);
         void QueueFileUpload(Guid timelineId, Guid timelineRecordId, string type, string name, string path, bool deleteSource);
@@ -90,28 +89,6 @@ namespace Microsoft.VisualStudio.Services.Agent
         {
             base.Initialize(hostContext);
             _jobServer = hostContext.GetService<IJobServer>();
-        }
-
-        public async Task DrainQueues()
-        {
-            // Drain the queue
-            // ProcessWebConsoleLinesQueueAsync() will never throw exception, live console update is always best effort.
-            Trace.Verbose("Draining web console line queue.");
-            await ProcessWebConsoleLinesQueueAsync(runOnce: true);
-            Trace.Info("Web console line queue drained.");
-
-            // ProcessFilesUploadQueueAsync() will never throw exception, log file upload is always best effort.
-            Trace.Verbose("Draining file upload queue.");
-            await ProcessFilesUploadQueueAsync(runOnce: true);
-            Trace.Info("File upload queue drained.");
-
-            // ProcessTimelinesUpdateQueueAsync() will throw exception during shutdown
-            // if there is any timeline records that failed to update contains output variabls.
-            Trace.Verbose("Draining timeline update queue.");
-            await ProcessTimelinesUpdateQueueAsync(runOnce: true);
-            Trace.Info("Timeline update queue drained.");
-
-            Trace.Info("All queues are drained.");
         }
 
         public void Start(Pipelines.AgentJobRequestMessage jobRequest)
@@ -192,7 +169,24 @@ namespace Microsoft.VisualStudio.Services.Agent
             _queueInProcess = false;
             Trace.Info("All queue process task stopped.");
 
-            await DrainQueues();
+            // Drain the queue
+            // ProcessWebConsoleLinesQueueAsync() will never throw exception, live console update is always best effort.
+            Trace.Verbose("Draining web console line queue.");
+            await ProcessWebConsoleLinesQueueAsync(runOnce: true);
+            Trace.Info("Web console line queue drained.");
+
+            // ProcessFilesUploadQueueAsync() will never throw exception, log file upload is always best effort.
+            Trace.Verbose("Draining file upload queue.");
+            await ProcessFilesUploadQueueAsync(runOnce: true);
+            Trace.Info("File upload queue drained.");
+
+            // ProcessTimelinesUpdateQueueAsync() will throw exception during shutdown
+            // if there is any timeline records that failed to update contains output variabls.
+            Trace.Verbose("Draining timeline update queue.");
+            await ProcessTimelinesUpdateQueueAsync(runOnce: true);
+            Trace.Info("Timeline update queue drained.");
+
+            Trace.Info("All queue process tasks have been stopped, and all queues are drained.");
         }
 
         public void QueueWebConsoleLine(Guid stepRecordId, string line, long lineNumber)


### PR DESCRIPTION
**Description of issue:**
Sometimes task successfully completes but it's marked as failed on ADO side. It was found that logic related to queues draining affects this. Possibly the issue occurred due to the fact that we call methods `ProcessWebConsoleLinesQueueAsync`, `ProcessFilesUploadQueueAsync` and `ProcessTimelinesUpdateQueueAsync` while the methods are called in the beginning of job and being executed in additional thread till job's completion. So additional calls of the methods can interfere with executing ones and probably something goes wrong with updating timeline records.

**Description of fix:**
I have refactored logic to drain queues. I removed extra call of the methods and implemented two additional fields-flags `ForceDrainWebConsoleQueue` and `ForceDrainTimelineQueue`. If the properties are set then web console and timeline queues will be drained as soon as possible by methods `ProcessWebConsoleLinesQueueAsync` and `ProcessTimelinesUpdateQueueAsync` respectively which are being already executed during a job. When draining is completed the properties will be set to `false` automatically. I also kept knob `AGENT_DISABLE_DRAIN_QUEUES_AFTER_TASK` to be able to disable this logic in case any problems. 

**How it was tested:**
There is no way to reproduce the issue and test it locally. So only original issue with hang UI was tested. Since customers mitigated the issue by enabling FF `AGENT_DISABLE_DRAIN_QUEUES_AFTER_TASK`, we will disable it in production on a few scale units and see if issue be back or not.

There is a pipeline which can be used to test if this refactored logic still fixes original issue with hang UI: https://abtttestorg.visualstudio.com/Other/_build/results?buildId=6432&view=results

Behavior with disabled `AGENT_DISABLE_DRAIN_QUEUES_AFTER_TASK`:
![drain](https://user-images.githubusercontent.com/11807074/228187702-e864fd03-8069-4820-8b96-40f50721f135.gif)

Behavior with enabled `AGENT_DISABLE_DRAIN_QUEUES_AFTER_TASK`:
![not-drain](https://user-images.githubusercontent.com/11807074/228187786-8f7c6dac-7bf8-4b26-8bae-bc858b96da38.gif)