### PR TITLE
Increase limit for AZP_IGNORE_SECRETS_SHORTER_THAN knob to 6

### DIFF
--- a/src/Agent.Sdk/Util/ILoggedSecretMasker.cs
+++ b/src/Agent.Sdk/Util/ILoggedSecretMasker.cs
@@ -8,7 +8,7 @@ namespace Agent.Sdk.Util
     /// </summary>
     public interface ILoggedSecretMasker : ISecretMasker
     {
-        int MinSecretLengthLimit { get; }
+        static int MinSecretLengthLimit { get; }
 
         void AddRegex(String pattern, string origin);
         void AddValue(String value, string origin);

--- a/src/Agent.Sdk/Util/LoggedSecretMasker.cs
+++ b/src/Agent.Sdk/Util/LoggedSecretMasker.cs
@@ -72,7 +72,7 @@ namespace Agent.Sdk.Util
 
         // We don't allow to skip secrets longer than 4 characters.
         // Note: the secret that will be ignored is of length n-1.
-        public int MinSecretLengthLimit => 7;
+        public static int MinSecretLengthLimit => 7;
 
         public int MinSecretLength
         {

--- a/src/Agent.Sdk/Util/LoggedSecretMasker.cs
+++ b/src/Agent.Sdk/Util/LoggedSecretMasker.cs
@@ -71,7 +71,8 @@ namespace Agent.Sdk.Util
         }
 
         // We don't allow to skip secrets longer than 4 characters.
-        public int MinSecretLengthLimit => 4;
+        // Note: the secret that will be ignored is of length n-1.
+        public int MinSecretLengthLimit => 7;
 
         public int MinSecretLength
         {

--- a/src/Agent.Sdk/Util/LoggedSecretMasker.cs
+++ b/src/Agent.Sdk/Util/LoggedSecretMasker.cs
@@ -72,7 +72,7 @@ namespace Agent.Sdk.Util
 
         // We don't allow to skip secrets longer than 4 characters.
         // Note: the secret that will be ignored is of length n-1.
-        public static int MinSecretLengthLimit => 7;
+        public static int MinSecretLengthLimit => 6;
 
         public int MinSecretLength
         {

--- a/src/Test/L0/SecretMaskerTests/LoggedSecretMaskerL0.cs
+++ b/src/Test/L0/SecretMaskerTests/LoggedSecretMaskerL0.cs
@@ -58,15 +58,33 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         {
             var lsm = new LoggedSecretMasker(_secretMasker)
             {
-                MinSecretLength = 3
+                MinSecretLength = LoggedSecretMasker.MinSecretLengthLimit
             };
-            var inputMessage = "123456";
+            var inputMessage = "1234567";
 
-            lsm.AddValue("123");
+            lsm.AddValue("12345");
             lsm.RemoveShortSecretsFromDictionary();
             var resultMessage = lsm.MaskSecrets(inputMessage);
 
-            Assert.Equal("***456", resultMessage);
+            Assert.Equal("1234567", resultMessage);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void LoggedSecretMasker_ShortSecret_Removes_From_Dictionary_BoundaryValue2()
+        {
+            var lsm = new LoggedSecretMasker(_secretMasker)
+            {
+                MinSecretLength = LoggedSecretMasker.MinSecretLengthLimit - 1
+            };
+            var inputMessage = "1234567";
+
+            lsm.AddValue("123456");
+            lsm.RemoveShortSecretsFromDictionary();
+            var resultMessage = lsm.MaskSecrets(inputMessage);
+
+            Assert.Equal("***7", resultMessage);
         }
 
         [Fact]
@@ -91,9 +109,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         public void LoggedSecretMasker_Sets_MinSecretLength_To_MaxValue()
         {
             var lsm = new LoggedSecretMasker(_secretMasker);
-            var expectedMinSecretsLengthValue = lsm.MinSecretLengthLimit;
+            var expectedMinSecretsLengthValue = LoggedSecretMasker.MinSecretLengthLimit;
 
-            lsm.MinSecretLength = 5;
+            lsm.MinSecretLength = LoggedSecretMasker.MinSecretLengthLimit + 1;
 
             Assert.Equal(expectedMinSecretsLengthValue, lsm.MinSecretLength);
         }


### PR DESCRIPTION
Changelog:
- Set `MinSecretLengthLimit` as static
- Increase AZP_IGNORE_SECRETS_SHORTER_THAN limit up to 6
- Update tests
