### PR TITLE
Bugfixing localization problems in several UnitTests 

### DIFF
--- a/src/Test/L0/Listener/Configuration/ArgumentValidatorTestsL0.cs
+++ b/src/Test/L0/Listener/Configuration/ArgumentValidatorTestsL0.cs
@@ -56,7 +56,38 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
             using (TestHostContext hc = new TestHostContext(this))
             {
                 Assert.False(Validators.NTAccountValidator(string.Empty));
-                Assert.True(Validators.NTAccountValidator("NT AUTHORITY\\LOCAL SERVICE"));
+
+                // English/Default local service account
+                bool foundAccount = Validators.NTAccountValidator(@"NT AUTHORITY\LOCAL SERVICE");
+
+                if(!foundAccount)
+                {
+                    // German local service account
+                    foundAccount = Validators.NTAccountValidator(@"NT-AUTORITÄT\LOKALER DIENST");
+
+                    if (!foundAccount)
+                    {
+                        // French local service account
+                        foundAccount = Validators.NTAccountValidator(@"AUTORITE NT\SERVICE LOCAL");
+
+                        if (!foundAccount)
+                        {
+                            // Italian local service account
+                            foundAccount = Validators.NTAccountValidator(@"NT AUTHORITY\SERVIZIO LOCALE");
+
+                            if (!foundAccount)
+                            {
+                                // Spanish local service account
+                                foundAccount = Validators.NTAccountValidator(@"NT AUTHORITY\SERVICIO LOC");
+
+                                // Account name in rest of the languages is the same as in English
+                            }
+                        }
+                    }
+                }
+
+                Assert.True(foundAccount, @"Wasn't able to validate local service account ""NT AUTHORITY\LOCAL SERVICE"" (tried English/Default name, German name, French name, Italian name and Spanish name)");
+
             }
         }
     }

--- a/src/Test/L0/Listener/Configuration/NativeWindowsServiceHelperL0.cs
+++ b/src/Test/L0/Listener/Configuration/NativeWindowsServiceHelperL0.cs
@@ -35,7 +35,38 @@ namespace Test.L0.Listener.Configuration
 
                 trace.Info("Trying to get the Default Service Account when a BuildRelease Agent is being configured");
                 var defaultServiceAccount = windowsServiceHelper.GetDefaultServiceAccount();
-                Assert.True(defaultServiceAccount.ToString().Equals(@"NT AUTHORITY\NETWORK SERVICE"), "If agent is getting configured as build-release agent, default service accout should be 'NT AUTHORITY\\NETWORK SERVICE'");
+                var defaultServiceAccountName = defaultServiceAccount.ToString().ToUpper();
+
+                // English/Default network service account
+                bool isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"NT AUTHORITY\NETWORK SERVICE");
+
+                if (!isDefaultServiceAccountName)
+                {
+                    // German network service account
+                    isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"NT-AUTORITÄT\NETZWERKDIENST");
+
+                    if (!isDefaultServiceAccountName)
+                    {
+                        // French network service account
+                        isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"AUTORITE NT\SERVICE RÉSEAU");
+
+                        if (!isDefaultServiceAccountName)
+                        {
+                            // Italian network service account
+                            isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"NT AUTHORITY\SERVIZIO DI RETE");
+
+                            if (!isDefaultServiceAccountName)
+                            {
+                                // Spanish network service account
+                                isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"NT AUTHORITY\SERVICIO DE RED");
+
+                                // Account name in rest of the languages is the same as in English
+                            }
+                        }
+                    }
+                }
+
+                Assert.True(isDefaultServiceAccountName, "If agent is getting configured as build-release agent, default service accout should be 'NT AUTHORITY\\NETWORK SERVICE' or its localized counterpart (tried English/Default name, German name, French name, Italian name and Spanish name).");
             }
         }
 
@@ -53,7 +84,26 @@ namespace Test.L0.Listener.Configuration
 
                 trace.Info("Trying to get the Default Service Account when a DeploymentAgent is being configured");
                 var defaultServiceAccount = windowsServiceHelper.GetDefaultAdminServiceAccount();
-                Assert.True(defaultServiceAccount.ToString().Equals(@"NT AUTHORITY\SYSTEM"), "If agent is getting configured as deployment agent, default service accout should be 'NT AUTHORITY\\SYSTEM'");
+                var defaultServiceAccountName = defaultServiceAccount.ToString().ToUpper();
+
+                // English/Default network service account
+                bool isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"NT AUTHORITY\SYSTEM");
+
+                if (!isDefaultServiceAccountName)
+                {
+                    // German network service account
+                    isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"NT-AUTORITÄT\SYSTEM");
+
+                    if (!isDefaultServiceAccountName)
+                    {
+                        // French network service account
+                        isDefaultServiceAccountName = defaultServiceAccountName.Equals(@"AUTORITE NT\SYSTEM");
+
+                        // Account name in Italian, Spanish and rest of the languages is the same as in English
+                    }
+                }
+
+                Assert.True(isDefaultServiceAccountName, "If agent is getting configured as deployment agent, default service accout should be 'NT AUTHORITY\\SYSTEM' or its localized counterpart (tried English/Default name, German name and French name).");
             }
         }
 

--- a/src/Test/L0/Worker/CodeCoverage/CoberturaSummaryReaderTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CoberturaSummaryReaderTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
         private static string GetPathToValidCoberturaFile()
         {
             var file = Path.Combine(Path.GetTempPath(), "coberturaValid.xml");
-            File.WriteAllText(file, CodeCoverageTestConstants.ValidCoberturaXml);
+            File.WriteAllText(file, CodeCoverageTestConstants.ValidCoberturaXmlLocalized);
             return file;
         }
 

--- a/src/Test/L0/Worker/CodeCoverage/CodeCoverageCommandExtensionTests.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CodeCoverageCommandExtensionTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
                 try
                 {
                     Directory.CreateDirectory(reportDirectory);
-                    File.WriteAllText(coberturaXml, CodeCoverageTestConstants.ValidCoberturaXml);
+                    File.WriteAllText(coberturaXml, CodeCoverageTestConstants.ValidCoberturaXmlLocalized);
                     File.WriteAllText((Path.Combine(reportDirectory, "index.html")), string.Empty);
                     File.WriteAllText((Path.Combine(reportDirectory, "frame-summary.html")), string.Empty);
 

--- a/src/Test/L0/Worker/CodeCoverage/CodeCoverageConstants.cs
+++ b/src/Test/L0/Worker/CodeCoverage/CodeCoverageConstants.cs
@@ -209,6 +209,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.CodeCoverage
 		            </package>
 	            </packages>
             </coverage>";
+
+        public static string ValidCoberturaXmlLocalized
+        {
+            get
+            {
+                string replacePattern = "='${before}" + System.Globalization.CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator + "${after}'";
+                return System.Text.RegularExpressions.Regex.Replace(ValidCoberturaXml, @"(?<!version)='(?<before>\d+)\.(?<after>\d+)'", replacePattern);
+            }
+        }
+
         #endregion
 
         #region cobertura ant files

--- a/src/Test/L0/Worker/TestResults/Legacy/XUnitResultReaderTests.cs
+++ b/src/Test/L0/Worker/TestResults/Legacy/XUnitResultReaderTests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.TestResults
             Assert.Equal("This is standard console output for xunit.", runData.Results[0].AttachmentData.ConsoleLog);
             Assert.Equal("Owner", runData.Results[0].RunBy.DisplayName);
             Assert.Equal("Completed", runData.Results[0].State);
-            Assert.Equal("1042.2319", runData.Results[0].DurationInMs.ToString());
+            Assert.Equal("1042.2319", runData.Results[0].DurationInMs.ToString(new NumberFormatInfo() { NumberDecimalSeparator = "." }));
             Assert.Equal("ClassLibrary2.DLL", runData.Results[0].AutomatedTestStorage);
             Assert.Equal("Passed", runData.Results[1].Outcome);
             Assert.Equal("0", runData.Results[1].Priority.ToString());


### PR DESCRIPTION
This is a new pull request replacing the old pull request https://github.com/microsoft/azure-pipelines-agent/pull/3473 which included two changes. Both these changes of the old pull request have been splitted up according to the suggestion by @ismayilov-ismayil. This pull request contains the UnitTest localization problem fixes.

# Bug fixed:
- Localization problems in several UnitTests (Bug https://github.com/microsoft/azure-pipelines-agent/issues/3950)

## Localization problems in several UnitTests fixed
- Some UnitTests always used the point as the decimal separator in strings with numbers. However, this is different in different cultures (it's a comma in German culture for example) and the UnitTests failed on such systems. Adapted these UnitTests to either use numbers in strings with the decimal separator of the current culture or being able to handle numbers with a point as the decimal separator.
- Some UnitTests checked for a correct system user name or if a specific system user name can be found. However, these system user names can be different from the English/Default name in German, French, Italian and Spanish. The checks for these user names were expanded accordingly to also check for the system user names of these other languages so that these UnitTests won't fail any more just because they run on a German, French, Italian or Spanish windows system.
