### PR TITLE
Bug 2030875 - azure-pipelines-task-lib repo logs passwords in plain text

### DIFF
--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Net.Sockets;
 using System.Collections.Generic;
+using Agent.Sdk;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -128,7 +129,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         if (!(string.Equals(command.Area, "task", StringComparison.OrdinalIgnoreCase) &&
                               string.Equals(command.Event, "debug", StringComparison.OrdinalIgnoreCase)))
                         {
-                            context.Debug($"Processed: {input}");
+                            context.Debug($"Processed: {CommandStringConvertor.Unescape(input, unescapePercents)}");
                         }
                     }
                 }


### PR DESCRIPTION
**Description of issue:**
Customer experiences issue with password containing `%` sign. When he set secret via method `setSecret` from `azure-pipelines-task-lib` while env `DECODE_PERCENTS` equals to `false` then password is not being masked in logs. There are actually two issues:
- when `DECODE_PERCENTS` equals to `true` then agent doesn't mask a password when outputs command itself
- when `DECODE_PERCENTS` equals to `false` then agent masks a password only when outputs commands and debug messages ignoring another ones
This happens because of the fact that agent set secret based on value of `DECODE_PERCENTS`. Since we always get secret from `azure-pipelines-task-lib` with encoded percent sign, for example: `password%AZP25123`, the agent sets secret as `password%123` when `DECODE_PERCENTS` equals to `true` and as `password%AZP25123` when `DECODE_PERCENTS` equals to `false`

**Description of fix:**
I implemented logic which checks if `DECODE_PERCENTS` equals to `false` then it adds as secret a decoded value as well to prevent exposing password in lines where `%` sign was not encoded. Also I added logic to decode the sign when agent outputs command it processed when `DECODE_PERCENTS` equals to `true`