### PR TITLE
Add force of _tasks creation by knob

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -444,5 +444,12 @@ namespace Agent.Sdk.Knob
             "Forces the agent to fetch list of .NET 6 supporting systems from server",
             new EnvironmentKnobSource("AGENT_ENABLE_FETCHING_NET6_LIST"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob ForceCreateTasksDirectory = new Knob(
+            nameof(ForceCreateTasksDirectory),
+            "Forces the agent to create _tasks folder for tasks.",
+            new RuntimeKnobSource("AGENT_FORCE_CREATE_TASKS_DIRECTORY"),
+            new EnvironmentKnobSource("AGENT_FORCE_CREATE_TASKS_DIRECTORY"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -146,6 +146,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     Trace.Info($"Run initial step from extension {this.GetType().Name}.");
                     InitializeJobExtension(context, message?.Steps, message?.Workspace);
 
+                    if (AgentKnobs.ForceCreateTasksDirectory.GetValue(context).AsBoolean())
+                    {
+                        var tasksDir = HostContext.GetDirectory(WellKnownDirectory.Tasks);
+                        try
+                        {
+                            Trace.Info($"Pre-creating {tasksDir} directory");
+                            Directory.CreateDirectory(tasksDir);
+                            IOUtil.ValidateExecutePermission(tasksDir);
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.Error(ex);
+                            context.Error(ex);
+                        }
+                    }
+
                     // Download tasks if not already in the cache
                     Trace.Info("Downloading task definitions.");
                     var taskManager = HostContext.GetService<ITaskManager>();
@@ -639,7 +655,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         }
     }
 
-    public class UnsupportedOsException : Exception {
+    public class UnsupportedOsException : Exception
+    {
         public UnsupportedOsException(string message) : base(message) { }
     }
 }


### PR DESCRIPTION
In case if pipeline job doesn't contain any steps, and have a container, docker may miss the _tasks volume and create it with a wrong permissions, which leads to issues for future jobs.

This PR allows to force the creation of _tasks directory every time.

Work item: internal 2044452