### PR TITLE
Add `node20` execution handler

### DIFF
--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
     [ServiceLocator(Default = typeof(NodeHandler))]
     public interface INodeHandler : IHandler
     {
-        // Data can be of these three types: NodeHandlerData, Node10HandlerData and Node16HandlerData
+        // Data can be of these four types: NodeHandlerData, Node10HandlerData, Node16HandlerData, and Node20HandlerData
         BaseNodeHandlerData Data { get; set; }
     }
 
@@ -55,10 +55,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private const string nodeFolder = "node";
         private const string node10Folder = "node10";
         private const string node16Folder = "node16";
+        private const string node20Folder = "node20";
         private const string nodeLTS = node16Folder;
         private const string useNodeKnobLtsKey = "LTS";
         private const string useNodeKnobUpgradeKey = "UPGRADE";
-        private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder };
+        private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, node20Folder };
         private static Regex _vstsTaskLibVersionNeedsFix = new Regex("^[0-2]\\.[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static string[] _extensionsNode6 ={
             "if (process.versions.node && process.versions.node.match(/^5\\./)) {",
@@ -217,6 +218,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             bool useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsBoolean();
             bool taskHasNode10Data = Data is Node10HandlerData;
             bool taskHasNode16Data = Data is Node16HandlerData;
+            bool taskHasNode20Data = Data is Node20HandlerData;
             string useNodeKnob = AgentKnobs.UseNode.GetValue(ExecutionContext).AsString();
 
             string nodeFolder = NodeHandler.nodeFolder;
@@ -224,6 +226,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             {
                 Trace.Info($"Detected RedHat 6, using node 10 as execution handler, instead node16");
                 nodeFolder = NodeHandler.node10Folder;
+            }
+            else if (taskHasNode20Data)
+            {
+                Trace.Info($"Task.json has node20 handler data: {taskHasNode20Data}");
+                nodeFolder = NodeHandler.node20Folder;
             }
             else if (taskHasNode16Data)
             {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -381,6 +381,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         private NodeHandlerData _node;
         private Node10HandlerData _node10;
         private Node16HandlerData _node16;
+        private Node20HandlerData _node20;
         private PowerShellHandlerData _powerShell;
         private PowerShell3HandlerData _powerShell3;
         private PowerShellExeHandlerData _powerShellExe;
@@ -446,6 +447,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             set
             {
                 _node16 = value;
+                Add(value);
+            }
+        }
+        
+        public Node20HandlerData Node20
+        {
+            get
+            {
+                return _node20;
+            }
+
+            set
+            {
+                _node20 = value;
                 Add(value);
             }
         }
@@ -624,21 +639,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
     public sealed class NodeHandlerData : BaseNodeHandlerData
     {
-        public override int Priority => 3;
+        public override int Priority => 4;
     }
 
     public sealed class Node10HandlerData : BaseNodeHandlerData
     {
-        public override int Priority => 2;
+        public override int Priority => 3;
     }
     public sealed class Node16HandlerData : BaseNodeHandlerData
+    {
+        public override int Priority => 2;
+    }
+    
+    public sealed class Node20HandlerData : BaseNodeHandlerData
     {
         public override int Priority => 1;
     }
 
     public sealed class PowerShell3HandlerData : HandlerData
     {
-        public override int Priority => 4;
+        public override int Priority => 5;
     }
 
     public sealed class PowerShellHandlerData : HandlerData
@@ -656,7 +676,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        public override int Priority => 5;
+        public override int Priority => 6;
 
         public string WorkingDirectory
         {
@@ -687,7 +707,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        public override int Priority => 6;
+        public override int Priority => 7;
 
         public string WorkingDirectory
         {
@@ -744,7 +764,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        public override int Priority => 6;
+        public override int Priority => 7;
 
         public string ScriptType
         {
@@ -801,7 +821,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        public override int Priority => 7;
+        public override int Priority => 8;
 
         public string WorkingDirectory
         {

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -11,6 +11,7 @@ NODE_URL=https://nodejs.org/dist
 NODE_VERSION="6.17.1"
 NODE10_VERSION="10.24.1"
 NODE16_VERSION="16.17.1"
+NODE20_VERSION="20.0.0"
 MINGIT_VERSION="2.39.1"
 LFS_VERSION="3.3.0"
 
@@ -160,6 +161,8 @@ if [[ "$PACKAGERUNTIME" == "win-x64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x64/node.lib" node10/bin
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/win-x64/node.exe" node16/bin
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/win-x64/node.lib" node16/bin
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/win-x64/node.exe" node20/bin
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/win-x64/node.lib" node20/bin
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 fi
 
@@ -178,6 +181,8 @@ if [[ "$PACKAGERUNTIME" == "win-x86" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/win-x86/node.lib" node10/bin
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/win-x86/node.exe" node16/bin
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/win-x86/node.lib" node16/bin
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/win-x86/node.exe" node20/bin
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/win-x86/node.lib" node20/bin
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 fi
 
@@ -188,6 +193,7 @@ if [[ "$PACKAGERUNTIME" == "osx-x64" ]]; then
     fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-darwin-x64.tar.gz" node10 fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-darwin-x64.tar.gz" node16 fix_nested_dir
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-darwin-x64.tar.gz" node20 fix_nested_dir
 fi
 
 # Download the external tools common across OSX and Linux PACKAGERUNTIMEs.
@@ -202,6 +208,7 @@ if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "rhel.6-x64" ]]; 
     fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-x64.tar.gz" node10 fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-x64.tar.gz" node16 fix_nested_dir
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-x64.tar.gz" node20 fix_nested_dir
 fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
@@ -210,6 +217,7 @@ if [[ "$PACKAGERUNTIME" == "linux-arm" ]]; then
     fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-armv7l.tar.gz" node10 fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-armv7l.tar.gz" node16 fix_nested_dir
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-armv7l.tar.gz" node20 fix_nested_dir
 fi
 
 if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
@@ -218,6 +226,7 @@ if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
     fi
     acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-arm64.tar.gz" node10 fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-arm64.tar.gz" node16 fix_nested_dir
+    acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-arm64.tar.gz" node20 fix_nested_dir
 fi
 
 if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
@@ -235,6 +244,11 @@ if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
     rm "$LAYOUT_DIR/externals/node16/bin/npm"
     rm "$LAYOUT_DIR/externals/node16/bin/npx"
     rm "$LAYOUT_DIR/externals/node16/bin/corepack"
+    
+    rm -rf "$LAYOUT_DIR/externals/node20/lib"
+    rm "$LAYOUT_DIR/externals/node20/bin/npm"
+    rm "$LAYOUT_DIR/externals/node20/bin/npx"
+    rm "$LAYOUT_DIR/externals/node20/bin/corepack"
 fi
 
 if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then

--- a/src/Test/L0/NodeHandlerL0.cs
+++ b/src/Test/L0/NodeHandlerL0.cs
@@ -56,6 +56,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Theory]
         [InlineData("node10")]
         [InlineData("node16")]
+        [InlineData("node20")]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         public void UseNewNodeForNewNodeHandler(string nodeVersion)
@@ -69,7 +70,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
 
                 nodeHandler.Initialize(thc);
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc);
-                nodeHandler.Data = nodeVersion == "node16" ? (BaseNodeHandlerData)new Node16HandlerData() : (BaseNodeHandlerData)new Node10HandlerData();
+                nodeHandler.Data = nodeVersion switch
+                {
+                    "node10" => new Node10HandlerData(),
+                    "node16" => new Node16HandlerData(),
+                    "node20" => new Node20HandlerData(),
+                    _ => throw new Exception("Invalid node version"),
+                };
 
                 string actualLocation = nodeHandler.GetNodeLocation();
                 // We should fall back to node10 for node16 tasks, since RHEL 6 is not capable with Node16.

--- a/src/Test/L0/Worker/TaskManagerL0.cs
+++ b/src/Test/L0/Worker/TaskManagerL0.cs
@@ -458,6 +458,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             ""target"": ""Some Node16 target"",
             ""extraNodeArg"": ""Extra node16 arg value""
         },
+        ""Node20"": {
+            ""target"": ""Some Node20 target"",
+            ""extraNodeArg"": ""Extra node20 arg value""
+        },
         ""Process"": {
             ""target"": ""Some process target"",
             ""argumentFormat"": ""Some process argument format"",
@@ -509,12 +513,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                     if (TestUtil.IsWindows())
                     {
                         // Process handler should only be deserialized on Windows.
-                        Assert.Equal(4, definition.Data.Execution.All.Count);
+                        Assert.Equal(5, definition.Data.Execution.All.Count);
                     }
                     else
                     {
                         // Only the Node handlers should be deserialized on non-Windows.
-                        Assert.Equal(3, definition.Data.Execution.All.Count);
+                        Assert.Equal(4, definition.Data.Execution.All.Count);
                     }
 
                     // Node handler should always be deserialized.
@@ -531,12 +535,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                     Assert.NotNull(definition.Data.Execution.Node16); // execution.Node16
                     Assert.Equal(definition.Data.Execution.Node16, definition.Data.Execution.All[2]);
                     Assert.Equal("Some Node16 target", definition.Data.Execution.Node16.Target);
+                    
+                    // Node20 handler should always be deserialized.
+                    Assert.NotNull(definition.Data.Execution.Node20); // execution.Node20
+                    Assert.Equal(definition.Data.Execution.Node20, definition.Data.Execution.All[1]);
+                    Assert.Equal("Some Node20 target", definition.Data.Execution.Node20.Target);
 
                     if (TestUtil.IsWindows())
                     {
                         // Process handler should only be deserialized on Windows.
                         Assert.NotNull(definition.Data.Execution.Process); // execution.Process
-                        Assert.Equal(definition.Data.Execution.Process, definition.Data.Execution.All[3]);
+                        Assert.Equal(definition.Data.Execution.Process, definition.Data.Execution.All[4]);
                         Assert.Equal("Some process argument format", definition.Data.Execution.Process.ArgumentFormat);
                         Assert.NotNull(definition.Data.Execution.Process.Platforms);
                         Assert.Equal(1, definition.Data.Execution.Process.Platforms.Length);


### PR DESCRIPTION
This change adds support for running tasks using Node 20. Support for Node 16 is ending 6 months earlier than originally advertised, to coincide with the end-of-life of OpenSSL 1.1.1[^1].

The table below shows the versions of Node currently used to run tasks, and their upstream support status[^2]:

| Version | Released   | Active Support Ends | Security Support Ends |
|---------|------------|---------------------|-----------------------|
| 6       | 2016-04-26 | 🟥2018-04-30🟥      | 🟥2019-04-30🟥        |
| 10      | 2018-04-24 | 🟥2020-05-19🟥      | 🟥2021-04-30🟥        |
| 16      | 2021-04-20 | 🟥2022-10-18🟥      | 🟧2023-09-11🟧        |
| 20      | 2023-04-18 | 🟩2024-10-24🟩      | 🟩2026-04-30🟩        |

An earlier PR, adding support for Node 18, was closed in favour of Node 16 due to Node 18 requiring glibc 2.28, while Ubuntu 18.04 only supplied glibc 2.27[^3]. But this is no longer an issue as Ubuntu 18.04 is no longer supported as of 2023-04-03[^4], and Ubuntu 20.04 ships with glibc 2.31[^5].

Related to #4239. Followed #3861 for guidance.

[^1]: https://nodejs.org/en/blog/announcements/nodejs16-eol
[^2]: https://endoflife.date/nodejs
[^3]: https://github.com/microsoft/azure-pipelines-agent/pull/3849#issuecomment-1173989948
[^4]: https://github.com/actions/runner-images/issues/6002
[^5]: https://packages.ubuntu.com/source/focal/glibc
[^x]: https://endoflife.date/ubuntu