### PR TITLE
Fix that plugins ignores proxy configuration

### DIFF
--- a/src/Agent.Sdk/AgentWebProxy.cs
+++ b/src/Agent.Sdk/AgentWebProxy.cs
@@ -11,10 +11,10 @@ namespace Agent.Sdk
 {
     public class AgentWebProxySettings
     {
-        public static string AgentProxyUrlKey = "agent.proxyurl";
-        public static string AgentProxyUsernameKey = "agent.proxyusername";
-        public static string AgentProxyPasswordKey = "agent.proxypassword";
-        public static string AgentProxyBypassListKey = "agent.proxybypasslist";
+        public static string AgentProxyUrlKey = "Agent.ProxyUrl".ToLowerCase();
+        public static string AgentProxyUsernameKey = "Agent.ProxyUsername".ToLowerCase();
+        public static string AgentProxyPasswordKey = "Agent.ProxyPassword".ToLowerCase();
+        public static string AgentProxyBypassListKey = "Agent.ProxyBypassList".ToLowerCase();
         public string ProxyAddress { get; set; }
         public string ProxyUsername { get; set; }
         public string ProxyPassword { get; set; }

--- a/src/Agent.Sdk/AgentWebProxy.cs
+++ b/src/Agent.Sdk/AgentWebProxy.cs
@@ -11,6 +11,10 @@ namespace Agent.Sdk
 {
     public class AgentWebProxySettings
     {
+        public static string AgentProxyUrlKey = "agent.proxyurl";
+        public static string AgentProxyUsernameKey = "agent.proxyusername";
+        public static string AgentProxyPasswordKey = "agent.proxypassword";
+        public static string AgentProxyBypassListKey = "agent.proxybypasslist";
         public string ProxyAddress { get; set; }
         public string ProxyUsername { get; set; }
         public string ProxyPassword { get; set; }

--- a/src/Agent.Sdk/AgentWebProxy.cs
+++ b/src/Agent.Sdk/AgentWebProxy.cs
@@ -11,10 +11,10 @@ namespace Agent.Sdk
 {
     public class AgentWebProxySettings
     {
-        public static string AgentProxyUrlKey = "Agent.ProxyUrl".ToLowerCase();
-        public static string AgentProxyUsernameKey = "Agent.ProxyUsername".ToLowerCase();
-        public static string AgentProxyPasswordKey = "Agent.ProxyPassword".ToLowerCase();
-        public static string AgentProxyBypassListKey = "Agent.ProxyBypassList".ToLowerCase();
+        public static string AgentProxyUrlKey = "Agent.ProxyUrl".ToLower();
+        public static string AgentProxyUsernameKey = "Agent.ProxyUsername".ToLower();
+        public static string AgentProxyPasswordKey = "Agent.ProxyPassword".ToLower();
+        public static string AgentProxyBypassListKey = "Agent.ProxyBypassList".ToLower();
         public string ProxyAddress { get; set; }
         public string ProxyUsername { get; set; }
         public string ProxyPassword { get; set; }

--- a/src/Agent.Sdk/CommandPlugin.cs
+++ b/src/Agent.Sdk/CommandPlugin.cs
@@ -187,12 +187,12 @@ namespace Agent.Sdk
 
         private AgentWebProxySettings GetProxyConfiguration()
         {
-            string proxyUrl = this.Variables.GetValueOrDefault("Agent.ProxyUrl")?.Value;
+            string proxyUrl = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyUrlKey)?.Value;
             if (!string.IsNullOrEmpty(proxyUrl))
             {
-                string proxyUsername = this.Variables.GetValueOrDefault("Agent.ProxyUsername")?.Value;
-                string proxyPassword = this.Variables.GetValueOrDefault("Agent.ProxyPassword")?.Value;
-                List<string> proxyBypassHosts = StringUtil.ConvertFromJson<List<string>>(this.Variables.GetValueOrDefault("Agent.ProxyBypassList")?.Value ?? "[]");
+                string proxyUsername = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyUsernameKey)?.Value;
+                string proxyPassword = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyPasswordKey)?.Value;
+                List<string> proxyBypassHosts = StringUtil.ConvertFromJson<List<string>>(this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyBypassListKey)?.Value ?? "[]");
                 return new AgentWebProxySettings()
                 {
                     ProxyAddress = proxyUrl,

--- a/src/Agent.Sdk/LogPlugin.cs
+++ b/src/Agent.Sdk/LogPlugin.cs
@@ -146,6 +146,7 @@ namespace Agent.Sdk
         public List<Pipelines.RepositoryResource> Repositories { get; set; }
         public Dictionary<string, VariableValue> Variables { get; set; }
         public Dictionary<string, Pipelines.TaskStepDefinitionReference> Steps { get; set; }
+        public AgentWebProxySettings WebProxySettings { get; private set; }
 
         [JsonIgnore]
         public VssConnection VssConnection
@@ -187,12 +188,12 @@ namespace Agent.Sdk
                 }
             }
 
-            var proxySetting = GetProxyConfiguration();
-            if (proxySetting != null)
+            WebProxySettings = GetProxyConfiguration();
+            if (WebProxySettings != null)
             {
-                if (!string.IsNullOrEmpty(proxySetting.ProxyAddress))
+                if (!string.IsNullOrEmpty(WebProxySettings.ProxyAddress))
                 {
-                    VssHttpMessageHandler.DefaultWebProxy = new AgentWebProxy(proxySetting.ProxyAddress, proxySetting.ProxyUsername, proxySetting.ProxyPassword, proxySetting.ProxyBypassList);
+                    VssHttpMessageHandler.DefaultWebProxy = new AgentWebProxy(WebProxySettings.ProxyAddress, WebProxySettings.ProxyUsername, WebProxySettings.ProxyPassword, WebProxySettings.ProxyBypassList);
                 }
             }
 
@@ -241,12 +242,12 @@ namespace Agent.Sdk
 
         private AgentWebProxySettings GetProxyConfiguration()
         {
-            string proxyUrl = this.Variables.GetValueOrDefault("Agent.ProxyUrl")?.Value;
+            string proxyUrl = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyUrlKey)?.Value;
             if (!string.IsNullOrEmpty(proxyUrl))
             {
-                string proxyUsername = this.Variables.GetValueOrDefault("Agent.ProxyUsername")?.Value;
-                string proxyPassword = this.Variables.GetValueOrDefault("Agent.ProxyPassword")?.Value;
-                List<string> proxyBypassHosts = StringUtil.ConvertFromJson<List<string>>(this.Variables.GetValueOrDefault("Agent.ProxyBypassList")?.Value ?? "[]");
+                string proxyUsername = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyUsernameKey)?.Value;
+                string proxyPassword = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyPasswordKey)?.Value;
+                List<string> proxyBypassHosts = StringUtil.ConvertFromJson<List<string>>(this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyBypassListKey)?.Value ?? "[]");
                 return new AgentWebProxySettings()
                 {
                     ProxyAddress = proxyUrl,
@@ -274,6 +275,11 @@ namespace Agent.Sdk
         private IAgentLogPluginTrace _trace;
         private int _shortCircuitThreshold;
         private int _shortCircuitMonitorFrequency;
+
+        public Dictionary<string, IAgentLogPluginContext> PluginContexts
+        {
+            get => _pluginContexts;
+        }
 
         public AgentLogPluginHost(
             AgentLogPluginHostContext hostContext,

--- a/src/Agent.Sdk/TaskPlugin.cs
+++ b/src/Agent.Sdk/TaskPlugin.cs
@@ -62,6 +62,7 @@ namespace Agent.Sdk
         public Dictionary<string, string> Inputs { get; set; }
         public ContainerInfo Container { get; set; }
         public Dictionary<string, string> JobSettings { get; set; }
+        public AgentWebProxySettings WebProxySettings { get; private set; }
 
         [JsonIgnore]
         public VssConnection VssConnection
@@ -111,12 +112,12 @@ namespace Agent.Sdk
                 }
             }
 
-            var proxySetting = GetProxyConfiguration();
-            if (proxySetting != null)
+            WebProxySettings = GetProxyConfiguration();
+            if (WebProxySettings != null)
             {
-                if (!string.IsNullOrEmpty(proxySetting.ProxyAddress))
+                if (!string.IsNullOrEmpty(WebProxySettings.ProxyAddress))
                 {
-                    VssHttpMessageHandler.DefaultWebProxy = new AgentWebProxy(proxySetting.ProxyAddress, proxySetting.ProxyUsername, proxySetting.ProxyPassword, proxySetting.ProxyBypassList);
+                    VssHttpMessageHandler.DefaultWebProxy = new AgentWebProxy(WebProxySettings.ProxyAddress, WebProxySettings.ProxyUsername, WebProxySettings.ProxyPassword, WebProxySettings.ProxyBypassList);
                 }
             }
 
@@ -319,12 +320,12 @@ namespace Agent.Sdk
 
         public AgentWebProxySettings GetProxyConfiguration()
         {
-            string proxyUrl = this.Variables.GetValueOrDefault("Agent.ProxyUrl")?.Value;
+            string proxyUrl = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyUrlKey)?.Value;
             if (!string.IsNullOrEmpty(proxyUrl))
             {
-                string proxyUsername = this.Variables.GetValueOrDefault("Agent.ProxyUsername")?.Value;
-                string proxyPassword = this.Variables.GetValueOrDefault("Agent.ProxyPassword")?.Value;
-                List<string> proxyBypassHosts = StringUtil.ConvertFromJson<List<string>>(this.Variables.GetValueOrDefault("Agent.ProxyBypassList")?.Value ?? "[]");
+                string proxyUsername = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyUsernameKey)?.Value;
+                string proxyPassword = this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyPasswordKey)?.Value;
+                List<string> proxyBypassHosts = StringUtil.ConvertFromJson<List<string>>(this.Variables.GetValueOrDefault(AgentWebProxySettings.AgentProxyBypassListKey)?.Value ?? "[]");
                 return new AgentWebProxySettings()
                 {
                     ProxyAddress = proxyUrl,

--- a/src/Test/L0/Plugin/RepositoryPluginL0.cs
+++ b/src/Test/L0/Plugin/RepositoryPluginL0.cs
@@ -15,7 +15,6 @@ using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using static Microsoft.VisualStudio.Services.Agent.Tests.LogPluginHost.LogPluginHostL0;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
@@ -273,7 +272,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
         public void RepositoryPlugin_HandleProxyConfig()
         {
             using TestHostContext tc = new TestHostContext(this);
-            TestTrace trace = new TestTrace(tc);
             var proxyUrl = "http://example.com:80";
             var proxyUser = "proxy_user";
             var proxyPassword = "proxy_password";


### PR DESCRIPTION
## Description of issue
The agent plugins: `CommandPlugin`, `LogPlugin`, `TaskPlugin` is ignores proxy configuration for the agent, because these plugins are expected that these parameters are stored in `Agent.ProxyUrl`, `Agent.ProxyUsername`, and so on. But actually, agent stores these parameters in lowercase variables (e.g `agent.proxyurl`).
## Changes

- Introduce static variables containing variable names (to have standardized in all plugins).
- Introduce a public field to have options to test this in the unit tests.
- Added unit tests

## Testing
Tested locally that now plugins respect proxy configuration. 
