### PR TITLE
Revert PR 4220 "Upgrade vss api netcore version, has BuildXL changes"

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Agent.PluginHost/Agent.PluginHost.csproj
+++ b/src/Agent.PluginHost/Agent.PluginHost.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Agent.Plugins/Agent.Plugins.csproj
+++ b/src/Agent.Plugins/Agent.Plugins.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -3,15 +3,16 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" Condition="$(CodeAnalysis)=='true'" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
 	  <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -391,7 +391,7 @@ namespace Agent.Sdk
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // Logging exception will be handled by JobRunner
                 throw;
@@ -411,7 +411,7 @@ namespace Agent.Sdk
                 if (metadataProvider.HasMetadata())
                     isAzureVM = true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // Logging exception will be handled by JobRunner
                 throw;

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" Condition="$(CodeAnalysis)=='true'" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />
   </ItemGroup>

--- a/src/Common.props
+++ b/src/Common.props
@@ -10,7 +10,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.183-private</VssApiVersion>
+    <VssApiVersion>0.5.181-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
     <InvariantGlobalization>false</InvariantGlobalization>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobFileInfo.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobFileInfo.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
         {
             get
             {
-                return Node.GetDedupIdentifier();
+                return Node.GetDedupIdentifier(HashType.Dedup64K);
             }
         }
         public bool Success { get; set; }

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreUtils.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobStoreUtils.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             foreach (var file in fileNodes.Where(x => x.Success))
             {
                 // ChunkHelper uses 64k block default size
-                var dedupId = file.Node.GetDedupIdentifier();
+                var dedupId = file.Node.GetDedupIdentifier(HashType.Dedup64K);
                 fileDedupIds[dedupId] = file.Path;
             }
 
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             var chunk = await ChunkerHelper.CreateFromFileAsync(FileSystem.Instance, itemPath, cancellationToken, false);
             var rootNode = new DedupNode(new[] { chunk });
             // ChunkHelper uses 64k block default size
-            var dedupId = rootNode.GetDedupIdentifier();
+            var dedupId = rootNode.GetDedupIdentifier(HashType.Dedup64K);
 
             // Setup upload session to keep file for at mimimum one day
             // Blobs will need to be associated with the server with an ID ref otherwise they will be

--- a/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
+++ b/src/Microsoft.VisualStudio.Services.Agent/Microsoft.VisualStudio.Services.Agent.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" Condition="$(CodeAnalysis)=='true'" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />

--- a/src/Test/L1/Mock/FakeJobServer.cs
+++ b/src/Test/L1/Mock/FakeJobServer.cs
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             UploadedAttachmentBlobFiles.Add(itemPath);
             var chunk = await ChunkerHelper.CreateFromFileAsync(FileSystem.Instance, itemPath, cancellationToken, false);
             var rootNode = new DedupNode(new[] { chunk });
-            var dedupId = rootNode.GetDedupIdentifier();
+            var dedupId = rootNode.GetDedupIdentifier(HashType.Dedup64K);
 
             return (dedupId, rootNode.TransitiveContentBytes);
         }

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -8,16 +8,13 @@
     <ProjectReference Include="..\Agent.Sdk\Agent.Sdk.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.4.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.4.0" GeneratePathProperty="true" />
     <PackageReference Include="Moq" Version="4.6.36-alpha" />
+    <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />


### PR DESCRIPTION
Revert PR https://github.com/microsoft/azure-pipelines-agent/pull/4220 as it is causing issues with Downloading Artifacts, when artifact's name contains dots.
Related issue: https://github.com/microsoft/azure-pipelines-agent/issues/4268