### PR TITLE
Fix that GetLinuxName and GetLinuxId return null

### DIFF
--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -240,7 +240,8 @@ namespace Agent.Sdk
                 }
             }
 
-            return null;
+            var version = Environment.OSVersion.Version;
+            return version.ToString(3);
         }
 
         private static string GetOSxName()

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -216,7 +216,9 @@ namespace Agent.Sdk
                 }
             }
 
-            return null;
+            var runtimeIdentifier = RuntimeInformation.RuntimeIdentifier;
+            var id = runtimeIdentifier.Substring(0, runtimeIdentifier.IndexOfAny(new char[] { '.', '-' }));
+            return string.IsNullOrEmpty(id) ? runtimeIdentifier : id;
         }
 
         private static string GetLinuxName()


### PR DESCRIPTION
The Azure Pipelines Agent cannot be used on Arch Linux anymore because `VERSION_ID` is missing in _/etc/os-release_. This causes `GetLinuxName` to return `null`, which throws a `System.Exception` in the subsequent code, preventing builds from being started on that agent. Please see #4242 for a detailed description of the issue.