### PR TITLE
Run build stage only from the master branch

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -86,7 +86,7 @@ jobs:
     layoutRoot: '_layout/${{ parameters.os }}-${{ parameters.arch }}'
     DisableCFSDetector: true
     DisableDockerDetector: true
-    NugetSecurityAnalysisWarningLevel: "none"
+    nugetMultiFeedWarnLevel: none
     ${{ if eq(parameters.os, 'rhel.6') }}:
       AGENT_USE_NODE10: true
 

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -83,34 +83,22 @@ stages:
         vmImage: ubuntu-latest
       variables:
         DisableDockerDetector: true
-        NugetSecurityAnalysisWarningLevel: none
+        nugetMultiFeedWarnLevel: none
       steps:
       - bash: |
           cd ./.azure-pipelines/scripts/
           npm install axios minimist
 
-          source="$(Build.SourceBranch)"
-          prefix="refs/heads/"
-
-          if [[ "${source}" == "${prefix}"* ]]; then
-              branch="${source#"${prefix}"}"
-
-              if [[ "${branch}" == "master" ]]; then
-                  branch="${{ parameters.branch }}"
-              fi
-
-              echo "Canary \"branch\" parameter: \"${branch}\""
-          else
-              echo "##vso[task.logissue type=error]This test is supported only if the build source branch name is specified directly"
-
-              exit 1
-          fi
+          releaseBranch="${{ parameters.branch }}"
+          sourceBranch="$(Build.SourceBranch)"
+          branch="${releaseBranch:-"${sourceBranch}"}"
+          echo "Canary \"branch\" parameter: \"${branch}\""
 
           node ./run-and-verify.js \
               --projectUrl "$(CANARY_PROJECT_URL)" \
               --pipelineId "$(CANARY_PIPELINE_ID)" \
               --token "$(CANARY_PAT)" \
-              --templateParameters "{ \"branch\": \"${branch}\" }"
+              --templateParameters "{ \"branch\": \"${branch}\", \"template_timeout\": 2 }"
         displayName: Test Proxy Agent
 
   # Windows (x64)

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -34,6 +34,10 @@ parameters:
 - name: skipRhelRelease
   type: boolean
   default: true
+- name: testProxyAgent
+  type: boolean
+  default: true
+  displayName: Test Proxy Agent
 
 pr:
   branches:
@@ -50,6 +54,7 @@ extends:
     publishArtifacts: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
     buildAlternatePackage: false
     skipRhelRelease: ${{ parameters.skipRhelRelease }}
+    testProxyAgent: ${{ parameters.testProxyAgent }}
     win_x64: ${{ parameters.win_x64 }}
     win_x86: ${{ parameters.win_x86 }}
     linux_x64: ${{ parameters.linux_x64 }}

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -36,7 +36,7 @@ parameters:
   default: true
 - name: testProxyAgent
   type: boolean
-  default: true
+  default: false
   displayName: Test Proxy Agent
 
 pr:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -36,7 +36,10 @@ parameters:
   displayName: Test Proxy Agent
 
 variables:
-  releaseBranch: releases/${{ parameters.version }}
+  ${{ if parameters.buildStageOnly }}:
+    releaseBranch: ''
+  ${{ else }}:
+    releaseBranch: releases/${{ parameters.version }}
 
 extends:
   template: .azure-pipelines/pipeline.yml


### PR DESCRIPTION
***Description:***

[The pipeline of the agent release](https://dev.azure.com/mseng/AzureDevOps/_build?definitionId=5845&_a=summary) fails when running from the `master` branch with the `Build Stage Only` flag enabled.
This PR fixes this issue.

Also, the pipeline variable has been renamed from `NugetSecurityAnalysisWarningLevel` to `nugetMultiFeedWarnLevel`.

Also, the end-to-end agent test is added to [the pipeline of the agent CI](https://dev.azure.com/mseng/PipelineTools/_build?definitionId=7502&_a=summary).

These pipeline variables should be added to the pipeline of the agent CI before merging this PR —
* `CANARY_PROJECT_URL` — `https://dev.azure.com/canarytest/PipelineTasks`
* `CANARY_PIPELINE_ID` — `96`
* `CANARY_PAT`