### PR TITLE
Add output if step is skipped

### DIFF
--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -172,6 +172,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     {
                         // Condition == false
                         Trace.Info("Skipping step due to condition evaluation.");
+                        step.ExecutionContext.Output("The result of evaluating the condition is false, skipping the step.");
                         step.ExecutionContext.Complete(TaskResult.Skipped, resultCode: conditionResult.Trace);
                         continue;
                     }


### PR DESCRIPTION
***Description:*** With this change, when a pipeline step is skipped due to its condition, this step will have logs even if the debug mode is not enabled.