### PR TITLE
Add `AZP_AGENT_CLEANUP_PSMODULES_IN_POWERSHELL` agent knob

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -486,5 +486,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_FORCE_CREATE_TASKS_DIRECTORY"),
             new EnvironmentKnobSource("AGENT_FORCE_CREATE_TASKS_DIRECTORY"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob RunningInPowerShell = new Knob(
+            nameof(RunningInPowerShell),
+            "Removes the PSModulePath environment variable if the agent is running in PowerShell.",
+            new RuntimeKnobSource("AZP_AGENT_IN_PWSH"),
+            new EnvironmentKnobSource("AZP_AGENT_IN_PWSH"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -487,11 +487,11 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_FORCE_CREATE_TASKS_DIRECTORY"),
             new BuiltInDefaultKnobSource("false"));
 
-        public static readonly Knob RunningInPowerShell = new Knob(
-            nameof(RunningInPowerShell),
+        public static readonly Knob CleanupPSModules = new Knob(
+            nameof(CleanupPSModules),
             "Removes the PSModulePath environment variable if the agent is running in PowerShell.",
-            new RuntimeKnobSource("AZP_AGENT_IN_PWSH"),
-            new EnvironmentKnobSource("AZP_AGENT_IN_PWSH"),
+            new RuntimeKnobSource("AZP_AGENT_CLEANUP_PSMODULES_IN_POWERSHELL"),
+            new EnvironmentKnobSource("AZP_AGENT_CLEANUP_PSMODULES_IN_POWERSHELL"),
             new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -300,7 +300,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
         protected void RemovePSModulePathFromEnvironment()
         {
-            if (PlatformUtil.RunningOnWindows && WindowsProcessUtil.AgentIsRunningInPowerShell())
+            if (AgentKnobs.RunningInPowerShell.GetValue(ExecutionContext).AsBoolean() &&
+                PlatformUtil.RunningOnWindows && WindowsProcessUtil.AgentIsRunningInPowerShell())
             {
                 AddEnvironmentVariable("PSModulePath", "");
                 Trace.Info("PSModulePath removed from environment since agent is running on Windows and in PowerShell.");

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -300,7 +300,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
         protected void RemovePSModulePathFromEnvironment()
         {
-            if (AgentKnobs.RunningInPowerShell.GetValue(ExecutionContext).AsBoolean() &&
+            if (AgentKnobs.CleanupPSModules.GetValue(ExecutionContext).AsBoolean() &&
                 PlatformUtil.RunningOnWindows && WindowsProcessUtil.AgentIsRunningInPowerShell())
             {
                 AddEnvironmentVariable("PSModulePath", "");


### PR DESCRIPTION
***Description:*** This PR adds the `AZP_AGENT_CLEANUP_PSMODULES_IN_POWERSHELL` agent knob (`false` by default) for changes implemented in [the previous PR](https://github.com/microsoft/azure-pipelines-agent/pull/4152). New behavior will be disabled by default.