### PR TITLE
Move condition result trace from result code to output

### DIFF
--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -171,9 +171,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     if (!conditionResult.Value && conditionEvaluateError == null)
                     {
                         // Condition == false
-                        Trace.Info("Skipping step due to condition evaluation.");
-                        step.ExecutionContext.Output("The result of evaluating the condition is false, skipping the step.");
-                        step.ExecutionContext.Complete(TaskResult.Skipped, resultCode: conditionResult.Trace);
+                        string skipStepMessage = "Skipping step due to condition evaluation.";
+                        Trace.Info(skipStepMessage);
+                        step.ExecutionContext.Output($"{skipStepMessage}\n{conditionResult.Trace}");
+                        step.ExecutionContext.Complete(TaskResult.Skipped, resultCode: skipStepMessage);
                         continue;
                     }
 


### PR DESCRIPTION
***Description:*** With this change, when a pipeline step is skipped due to its condition, the condition result trace will be written in the usual output instead of the result code. An improvement for [the previous PR](https://github.com/microsoft/azure-pipelines-agent/pull/4349).

* Logs on the UI side —
```
Skipping step due to condition evaluation.
```

* Raw logs, pipeline debug mode is disabled —
```log
2023-07-26T09:12:53.5462488Z Skipping step due to condition evaluation.
Evaluating: and(succeeded(), eq('true', 'false'))
Expanded: and(True, eq('true', 'false'))
Result: False
```

* Raw logs, pipeline debug mode is enabled —
```log
2023-07-26T09:36:40.2340286Z ##[debug]Evaluating condition for step: 'stepDisplayName'
2023-07-26T09:36:40.2344564Z ##[debug]Evaluating: and(succeeded(), eq('true', 'false'))
2023-07-26T09:36:40.2344922Z ##[debug]Evaluating and:
2023-07-26T09:36:40.2351490Z ##[debug]..Evaluating succeeded:
2023-07-26T09:36:40.2352773Z ##[debug]..=> True
2023-07-26T09:36:40.2353329Z ##[debug]..Evaluating eq:
2023-07-26T09:36:40.2355224Z ##[debug]....Evaluating String:
2023-07-26T09:36:40.2355948Z ##[debug]....=> 'true'
2023-07-26T09:36:40.2356516Z ##[debug]....Evaluating String:
2023-07-26T09:36:40.2356831Z ##[debug]....=> 'false'
2023-07-26T09:36:40.2361811Z ##[debug]..=> False
2023-07-26T09:36:40.2362468Z ##[debug]=> False
2023-07-26T09:36:40.2363908Z ##[debug]Expanded: and(True, eq('true', 'false'))
2023-07-26T09:36:40.2364203Z ##[debug]Result: False
2023-07-26T09:36:40.2365048Z Skipping step due to condition evaluation.
Evaluating: and(succeeded(), eq('true', 'false'))
Expanded: and(True, eq('true', 'false'))
Result: False
```