### PR TITLE
Add osx-arm64 package to CI pipelines & remove rhel6 from releases

### DIFF
--- a/releaseNote.md
+++ b/releaseNote.md
@@ -10,7 +10,6 @@
 | Linux x64   | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM   | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM64 | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| RHEL 6 x64  | [vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 
 After Download:
 
@@ -56,12 +55,6 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 ~/myagent$ tar xzf ~/Downloads/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz
 ```
 
-## RHEL 6 x64
-
-``` bash
-~/$ mkdir myagent && cd myagent
-~/myagent$ tar xzf ~/Downloads/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
-```
 
 ## Alternate Agent Downloads
 
@@ -77,4 +70,3 @@ See [notes](docs/node6.md) on Node version support for more details.
 | Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| RHEL 6 x64  | [pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz) | <HASH> |

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -61,7 +61,7 @@
     </ServicingStep>
     <ServicingStep name="Add x86 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-arm64-<AGENT_VERSION>.zip" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add arm64 osx agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -61,17 +61,17 @@
     </ServicingStep>
     <ServicingStep name="Add x86 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-arm64-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
-    <ServicingStep name="Add x64 Redhat 6 agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+    <ServicingStep name="Add arm64 osx agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="rhel.6-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="osx-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
-    <ServicingStep name="Add x64 Redhat 6 alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+    <ServicingStep name="Add arm64 osx alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="rhel.6-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="osx-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
   </Steps>

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -16,7 +16,7 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Add-DistributedTaskPackage -PackageType agent -Platform linux-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz
 
-    Add-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
+    Add-DistributedTaskPackage -PackageType agent -Platform osx-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz
 
     # alternate packages
 
@@ -32,5 +32,5 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Add-DistributedTaskPackage -PackageType pipelines-agent -Platform linux-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz
 
-    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform osx-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz
 }

--- a/src/Misc/PublishVSTSAgent.template.ps1
+++ b/src/Misc/PublishVSTSAgent.template.ps1
@@ -11,5 +11,5 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Add-DistributedTaskPackage -PackageType agent -Platform linux-arm -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz
 
-    Add-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-rhel.6-x64-<AGENT_VERSION>.tar.gz
+    Add-DistributedTaskPackage -PackageType agent -Platform osx-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz
 }

--- a/src/Misc/UnpublishVSTSAgent.template.ps1
+++ b/src/Misc/UnpublishVSTSAgent.template.ps1
@@ -11,5 +11,5 @@ if ($pwd -notlike '*tfsgheus20' ) {
 
     Remove-DistributedTaskPackage -PackageType agent -Platform linux-arm -Version <AGENT_VERSION>
 
-    Remove-DistributedTaskPackage -PackageType agent -Platform rhel.6-x64 -Version <AGENT_VERSION>
+    Remove-DistributedTaskPackage -PackageType agent -Platform osx-arm64 -Version <AGENT_VERSION>
 }


### PR DESCRIPTION
**Description**
This PR is adding osx-arm64 to CI pipelines & removes RHEL6 system.

**Testing**
Tested manually by executing createAdoPr.js
