### PR TITLE
Added support for IBM s390x architecture (.NET 6)

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
-    <RuntimeFrameworkVersion>6.0.13</RuntimeFrameworkVersion>
+   <!-- <RuntimeFrameworkVersion>6.0.13</RuntimeFrameworkVersion> -->
     <RuntimeIdentifier>$(PackageRuntime)</RuntimeIdentifier>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <AssetTargetFallback>portable-net45+win8</AssetTargetFallback>
@@ -30,6 +30,7 @@
     <OSPlatform>OS_LINUX</OSPlatform>
   </PropertyGroup>
 
+
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64'">
     <OSArchitecture>X64</OSArchitecture>
   </PropertyGroup>
@@ -53,6 +54,10 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-arm64'">
     <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'S390x'">
+    <OSArchitecture>S390X</OSArchitecture>
+  </PropertyGroup>
+
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\rules.ruleset</CodeAnalysisRuleSet>

--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
-   <!-- <RuntimeFrameworkVersion>6.0.13</RuntimeFrameworkVersion> -->
+   <!-- <RuntimeFrameworkVersion>6.0.13</RuntimeFrameworkVersion> row commented as it can prevents builds when is istalled a framework with a different minor version -->
     <RuntimeIdentifier>$(PackageRuntime)</RuntimeIdentifier>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <AssetTargetFallback>portable-net45+win8</AssetTargetFallback>

--- a/src/Microsoft.VisualStudio.Services.Agent/Util/VarUtil.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Util/VarUtil.cs
@@ -59,6 +59,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                         return "ARM";
                     case Architecture.Arm64:
                         return "ARM64";
+                    case Architecture.S390x:
+                        return "S390X";
                     default:
                         throw new NotSupportedException(); // Should never reach here.
                 }

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -207,7 +207,7 @@ if [[ "$PACKAGERUNTIME" == "osx-arm64" ]]; then
 fi
 
 # Download the external tools common across OSX and Linux PACKAGERUNTIMEs.
-if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "linux-arm" || "$PACKAGERUNTIME" == "linux-arm64" || "$PACKAGERUNTIME" == "osx-x64" || "$PACKAGERUNTIME" == "osx-arm64" || "$PACKAGERUNTIME" == "rhel.7.2-x64" ]]; then
+if [[ "$PACKAGERUNTIME" == "linux-x64" || "$PACKAGERUNTIME" == "linux-arm" || "$PACKAGERUNTIME" == "linux-arm64" || "$PACKAGERUNTIME" == "osx-x64" || "$PACKAGERUNTIME" == "osx-arm64" || "$PACKAGERUNTIME" == "rhel.7.2-x64" || "$PACKAGERUNTIME" == "linux-s390x" ]]; then
     acquireExternalTool "$CONTAINER_URL/vso-task-lib/0.5.5/vso-task-lib.tar.gz" vso-task-lib
 fi
 
@@ -238,6 +238,16 @@ if [[ "$PACKAGERUNTIME" == "linux-arm64" ]]; then
     acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-arm64.tar.gz" node16 fix_nested_dir
     acquireExternalTool "$NODE_URL/v${NODE20_VERSION}/node-v${NODE20_VERSION}-linux-arm64.tar.gz" node20 fix_nested_dir
 fi
+
+# Added for s390x arch
+if [[ "$PACKAGERUNTIME" == "linux-s390x" ]]; then
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "$NODE_URL/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-s390x.tar.gz" node fix_nested_dir
+    fi
+    acquireExternalTool "$NODE_URL/v${NODE10_VERSION}/node-v${NODE10_VERSION}-linux-s390x.tar.gz" node10 fix_nested_dir
+    acquireExternalTool "$NODE_URL/v${NODE16_VERSION}/node-v${NODE16_VERSION}-linux-s390x.tar.gz" node16 fix_nested_dir
+fi
+
 
 if [[ "$PACKAGERUNTIME" != "win-x64" && "$PACKAGERUNTIME" != "win-x86" ]]; then
     # remove `npm`, `npx`, `corepack`, and related `node_modules` from the `externals/node*` agent directory

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -21,6 +21,7 @@ source "$SCRIPT_DIR/.helpers.sh"
 
 DOTNETSDK_ROOT="$SCRIPT_DIR/../_dotnetsdk"
 DOTNETSDK_VERSION="6.0.405"
+
 DOTNETSDK_INSTALLDIR="$DOTNETSDK_ROOT/$DOTNETSDK_VERSION"
 AGENT_VERSION=$(cat "$SCRIPT_DIR/agentversion" | head -n 1 | tr -d "\n\r")
 
@@ -87,7 +88,7 @@ function detect_platform_and_runtime_id ()
 
 function escape-s390x()
 {
-   echo $( [[ $1 = "linux-s390x" ]] && echo "" || echo $1 )
+   $( [[ $1 = "linux-s390x" ]] && echo "" || echo $1 )
 }
 
 
@@ -103,7 +104,7 @@ function make_build (){
          | sed -e "/\: error /s/^/${DOTNET_ERROR_PREFIX} /;" \
          || failed build
     else
-        dotnet msbuild -t:"${TARGET}" -p:PackageRuntime="$(escape-s390x $RUNTIME_ID)}" -p:PackageType="${PACKAGE_TYPE}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:CodeAnalysis="true" \
+        dotnet msbuild -t:"${TARGET}" -p:PackageRuntime="$(escape-s390x $RUNTIME_ID)" -p:PackageType="${PACKAGE_TYPE}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:CodeAnalysis="true" \
          || failed build
     fi
 
@@ -315,10 +316,11 @@ PACKAGE_DIR="$SCRIPT_DIR/../_package/$RUNTIME_ID"
 REPORT_DIR="$SCRIPT_DIR/../_reports/$RUNTIME_ID"
 
 if [[ "$RUNTIME_ID" == "linux-s390x"  ]]; then
-    if [[ ! -e "${DOTNETSDK_INSTALLDIR}/dotnet.dll" ]]; then
+    if ! which dotnet > /dev/null ; then
         echo "No dotnet installation detected. In s390x architecture environment you have to install dotnet with packet manager before launching this script"
         exit 1
     fi
+    DOTNETSDK_INSTALLDIR=$(which dotnet | xargs dirname)
 elif [[ (! -d "${DOTNETSDK_INSTALLDIR}") || (! -e "${DOTNETSDK_INSTALLDIR}/.${DOTNETSDK_VERSION}") || (! -e "${DOTNETSDK_INSTALLDIR}/dotnet") ]]; then
 
     # Download dotnet SDK to ../_dotnetsdk directory


### PR DESCRIPTION
Pipeline agent ported to RHEL 8.7 linux for s390x.
To get a free linux vm for testing on s390x architecture you can refer to this link:
[link](https://www.ibm.com/community/z/open-source/virtual-machines-request)

