### PR TITLE
[AgentService] - Migrate AgentService to .Net Framework 4.8.1

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -108,7 +108,7 @@ stages:
         jobName: build_windows_x64
         displayName: Windows (x64)
         pool:
-          vmImage: windows-2019
+          vmImage: windows-2022
         os: win
         arch: x64
         branch: ${{ parameters.branch }}
@@ -128,7 +128,7 @@ stages:
         jobName: build_windows_x86
         displayName: Windows (x86)
         pool:
-          vmImage: windows-2019
+          vmImage: windows-2022
         os: win
         arch: x86
         branch: ${{ parameters.branch }}

--- a/src/Agent.Service/Windows/AgentService.csproj
+++ b/src/Agent.Service/Windows/AgentService.csproj
@@ -12,7 +12,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>FinalPublicKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/Agent.Service/Windows/App.config
+++ b/src/Agent.Service/Windows/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
     </startup>
 </configuration>


### PR DESCRIPTION
- Migrate AgentService to .Net Framework 4.8.1
- changed pool from win-2019 to win-2022

Tested agent service on Windows 11, 10 and Windows Server 2022