### PR TITLE
Add ability to retrieve featureflag status

### DIFF
--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -50,7 +50,8 @@ namespace Agent.Listener.Configuration
             try
             {
                 var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);
-                return FeatureFlagStatus;
+                featureFlag = FeatureFlagStatus;
+                return true;
             } catch(VssServiceException e)
             {
                 Trace.Warning("Unable to retrive feature flag status: " + e.ToString());

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -54,7 +54,8 @@ namespace Agent.Listener.Configuration
             } catch(VssServiceException e)
             {
                 Trace.Warning("Unable to retrive feature flag status: " + e.ToString());
-                return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
+                featureFlag = null;
+                return false;
             }
         }
     }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -36,7 +36,7 @@ namespace Agent.Listener.Configuration
 
         public async Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter)
         {
-            Trace.Verbose(nameof(GetFeatureFlagAsync));
+            traceWriter.Verbose(nameof(GetFeatureFlagAsync));
             ArgUtil.NotNull(featureFlagName, nameof(featureFlagName));
 
             var credMgr = context.GetService<ICredentialManager>();

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -26,7 +26,7 @@ namespace Agent.Listener.Configuration
         /// <returns>The status of the feature flag.</returns>
         /// <exception cref="VssUnauthorizedException">Thrown if token is not suitable for retriving feature flag status</exception>
         /// <exception cref="InvalidOperationException">Thrown if agent is not configured</exception>
-        public Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter);
+        public Task<bool> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter, out FeatureFlag featureFlag);
 
     }
 

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -46,7 +46,7 @@ namespace Agent.Listener.Configuration
             ArgUtil.NotNull(creds, nameof(creds));
             
             AgentSettings settings = configManager.LoadSettings();
-            using var vssConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, Trace);
+            using var vssConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, traceWriter);
             var client = vssConnection.GetClient<FeatureAvailabilityHttpClient>();
 
             var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -53,7 +53,7 @@ namespace Agent.Listener.Configuration
                 return FeatureFlagStatus;
             } catch(VssServiceException e)
             {
-                Trace.Warning("Unable to retrview feature flag status: " + e.ToString());
+                Trace.Warning("Unable to retrive feature flag status: " + e.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
             }
         }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -26,14 +26,14 @@ namespace Agent.Listener.Configuration
         /// <returns>The status of the feature flag.</returns>
         /// <exception cref="VssUnauthorizedException">Thrown if token is not suitable for retriving feature flag status</exception>
         /// <exception cref="InvalidOperationException">Thrown if agent is not configured</exception>
-        public Task<bool> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter, out FeatureFlag featureFlag);
+        public Task<bool> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter);
 
     }
 
     public class FeatureFlagProvider : AgentService, IFeatureFlagProvider
     {
 
-        public async Task<bool> TryGetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter, out FeatureFlag featureFlag)
+        public async Task<bool> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter)
         {
             traceWriter.Verbose(nameof(GetFeatureFlagAsync));
             ArgUtil.NotNull(featureFlagName, nameof(featureFlagName));
@@ -50,12 +50,10 @@ namespace Agent.Listener.Configuration
             try
             {
                 var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);
-                featureFlag = FeatureFlagStatus;
                 return true;
             } catch(VssServiceException e)
             {
                 Trace.Warning("Unable to retrive feature flag status: " + e.ToString());
-                featureFlag = null;
                 return false;
             }
         }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -38,14 +38,19 @@ namespace Agent.Listener.Configuration
         {
             Trace.Verbose(nameof(GetFeatureFlagAsync));
             ArgUtil.NotNull(featureFlagName, nameof(featureFlagName));
+
             var credMgr = context.GetService<ICredentialManager>();
+            var configManager = context.GetService<IConfigurationManager>();
+
             VssCredentials creds = credMgr.LoadCredentials();
             ArgUtil.NotNull(creds, nameof(creds));
-            var configManager = context.GetService<IConfigurationManager>();
+            
             AgentSettings settings = configManager.LoadSettings();
             using var vssConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, Trace);
             var client = vssConnection.GetClient<FeatureAvailabilityHttpClient>();
+
             var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);
+
             return FeatureFlagStatus;
         }
     }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Agent.Sdk;
+using Microsoft.VisualStudio.Services.Agent;
+using Microsoft.VisualStudio.Services.Agent.Listener.Configuration;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.FeatureAvailability;
+using Microsoft.VisualStudio.Services.FeatureAvailability.WebApi;
+using System;
+using System.Threading.Tasks;
+
+namespace Agent.Listener.Configuration
+{
+    [ServiceLocator(Default = typeof(FeatureFlagProvider))]
+    public interface IFeatureFlagProvider : IAgentService
+    {
+        /// <summary>
+        /// Gets the status of a feature flag from the specified service endpoint.
+        /// If request fails, the feature flag is assumed to be off.
+        /// </summary>
+        /// <param name="context">Agent host contexts</param>
+        /// <param name="featureFlagName">The name of the feature flag to get the status of.</param>
+        /// <param name="traceWriter">Trace writer for output</param>
+        /// <returns>The status of the feature flag.</returns>
+        /// <exception cref="VssUnauthorizedException">Thrown if token is not suitable for retriving feature flag status</exception>
+        /// <exception cref="InvalidOperationException">Thrown if agent is not configured</exception>
+        /// <exception cref="VssServiceException">Thrown if network issue or feature flag not found on remote endpoint</exception>
+        public Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter);
+
+    }
+
+    public class FeatureFlagProvider : AgentService, IFeatureFlagProvider
+    {
+
+        public async Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter)
+        {
+            Trace.Verbose(nameof(GetFeatureFlagAsync));
+            ArgUtil.NotNull(featureFlagName, nameof(featureFlagName));
+            var credMgr = context.GetService<ICredentialManager>();
+            VssCredentials creds = credMgr.LoadCredentials();
+            ArgUtil.NotNull(creds, nameof(creds));
+            var configManager = context.GetService<IConfigurationManager>();
+            AgentSettings settings = configManager.LoadSettings();
+            using var vssConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, Trace);
+            var client = vssConnection.GetClient<FeatureAvailabilityHttpClient>();
+            var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);
+            return FeatureFlagStatus;
+        }
+    }
+}

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -26,7 +26,6 @@ namespace Agent.Listener.Configuration
         /// <returns>The status of the feature flag.</returns>
         /// <exception cref="VssUnauthorizedException">Thrown if token is not suitable for retriving feature flag status</exception>
         /// <exception cref="InvalidOperationException">Thrown if agent is not configured</exception>
-        /// <exception cref="VssServiceException">Thrown if network issue or feature flag not found on remote endpoint</exception>
         public Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter);
 
     }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -48,10 +48,15 @@ namespace Agent.Listener.Configuration
             AgentSettings settings = configManager.LoadSettings();
             using var vssConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, traceWriter);
             var client = vssConnection.GetClient<FeatureAvailabilityHttpClient>();
-
-            var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);
-
-            return FeatureFlagStatus;
+            try
+            {
+                var FeatureFlagStatus = await client.GetFeatureFlagByNameAsync(featureFlagName);
+                return FeatureFlagStatus;
+            } catch(VssServiceException e)
+            {
+                Trace.Warning("Unable to retrview feature flag status: " + e.ToString());
+                return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
+            }
         }
     }
 }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -33,7 +33,7 @@ namespace Agent.Listener.Configuration
     public class FeatureFlagProvider : AgentService, IFeatureFlagProvider
     {
 
-        public async Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter)
+        public async Task<bool> TryGetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter, out FeatureFlag featureFlag)
         {
             traceWriter.Verbose(nameof(GetFeatureFlagAsync));
             ArgUtil.NotNull(featureFlagName, nameof(featureFlagName));


### PR DESCRIPTION
## Description

Added `FeatureFlagProvider` service which is responsible for retrieving the status of a feature flag from a service endpoint.  `GetFeatureFlagAsync` method that returns the status of a feature flag.

Example of usage:
```
var service = HostContext.GetService<IFeatureFlagProvider>();
var ffState = await service.GetFeatureFlagAsync(HostContext, "FeatureFlag.Name", TraceWriter);
```

## Testing
Tested locally with various FeatureFlags