### PR TITLE
Code changes to fix PTR duplicate tests issue in linux

### DIFF
--- a/src/Agent.Worker/TestResults/Legacy/TrxResultReader.cs
+++ b/src/Agent.Worker/TestResults/Legacy/TrxResultReader.cs
@@ -156,14 +156,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
                     // set it as "name" from the parent (where it is always present)
                     XmlNode testResultNode = definitionNode.SelectSingleNode("./TestMethod");
                     string automatedTestName = null;
-                    if (testResultNode != null && testResultNode.Attributes["className"] != null && testResultNode.Attributes["name"] != null)
+                    if (testResultNode != null && testResultNode.Attributes["className"] != null && (definitionNode.Attributes["name"]?.Value != null || testResultNode.Attributes["name"] != null))
                     {
                         // At times the class names are coming as
                         // className="MS.TF.Test.AgileX.VSTests.WiLinking.UI.WiLinkingUIQueryTests"
                         // at other times, they are as
                         // className="UnitTestProject3.UnitTest1, UnitTestProject3, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
                         string className = testResultNode.Attributes["className"].Value.Split(',')[0];
-                        automatedTestName = className + "." + testResultNode.Attributes["name"].Value;
+
+                        string testCaseName;
+                        //For Datadriven tests definitionNode:name is unique whereas testResultnode:name is not
+                        //And for non DataDriven tests both definitionNode:name and testResultnode:name will be same
+                        if (definitionNode.Attributes["name"]?.Value != null)
+                        {
+                            testCaseName = definitionNode.Attributes["name"].Value;
+                        }
+                        else
+                        {
+                            testCaseName = testResultNode.Attributes["name"].Value;
+                        }
+
+
+                        automatedTestName = className + "." + testCaseName;
                     }
                     else if (definitionNode.Attributes["name"] != null)
                     {


### PR DESCRIPTION
**Problem Statement:** Vstest Publish Test Result for DataDriven tests for different inputs is showing against the same name, although in trx file their names are shown correctly.

**Changes Summary:** After Mstest Adapter changes from hierarchical to flat structure for data driven tests. DataDriven tests for different inputs is shown with duplicate names. The duplicate is because AutomatedTestName attribute is still getting generated as same for all the different inputs for a given testmethod and as a result only one entry is getting created in TestCaseReference table (This is the behaviour for hierarchical structure: one entry in testcasereference table and tests with different inputs as subresults). Expected behaviour is that each testcase should have one entry in the TestCaseReference table and in the flat structure every test with a data input is considered a separate testcase and there are no subresults for any testcase.

**Notable change:** Code changes are made to generate different AutomatedTestName for each testcase in DataDriven tests for flat structure. The existing hierarchical behaviour should not be affected by this change.

**Assumptions:** NA

Problem Statement: Vstest Publish Test Result for DataDriven tests for different inputs is showing against the same name, although in trx file their names are shown correctly.

Changes Summary: After Mstest Adapter changes from hierarchical to flat structure for data driven tests. DataDriven tests for different inputs is shown with duplicate names. The duplicate is because AutomatedTestName attribute is still getting generated as same for all the different inputs for a given testmethod and as a result only one entry is getting created in TestCaseReference table (This is the behaviour for hierarchical structure: one entry in testcasereference table and tests with different inputs as subresults). Expected behaviour is that each testcase should have one entry in the TestCaseReference table and in the flat structure every test with a data input is considered a separate testcase and there are no subresults for any testcase.

Notable change: Code changes are made to generate different AutomatedTestName for each testcase in DataDriven tests for flat structure. The existing hierarchical behaviour should not be affected by this change.

Assumptions: NA

**Test Assurances:** TODO: testing in progress