### PR TITLE
Set UTF-8 encoding for working with GB18030

### DIFF
--- a/src/Agent.Plugins/TFCliManager.cs
+++ b/src/Agent.Plugins/TFCliManager.cs
@@ -29,9 +29,9 @@ namespace Agent.Plugins.Repository
             }
         }
 
-        // When output is redirected, TF.exe writes output using the current system code page
-        // (i.e. CP_ACP or code page 0). E.g. code page 1252 on an en-US box.
-        protected override Encoding OutputEncoding => StringUtil.GetSystemEncoding();
+        // We ship a special version of TF.exe which uses UTF-8 instead of default encoding to support all the Unicode characters
+        // to comply with GB18030. Mainstream TF.exe uses default system encoding for redirected output.
+        protected override Encoding OutputEncoding => Encoding.UTF8;
 
         protected override string Switch => "/";
 

--- a/src/Agent.Plugins/TfsVCCliManager.cs
+++ b/src/Agent.Plugins/TfsVCCliManager.cs
@@ -33,7 +33,7 @@ namespace Agent.Plugins.Repository
         public abstract Task<bool> TryWorkspaceDeleteAsync(ITfsVCWorkspace workspace);
         public abstract Task WorkspacesRemoveAsync(ITfsVCWorkspace workspace);
 
-        protected virtual Encoding OutputEncoding => null;
+        protected virtual Encoding OutputEncoding => Encoding.UTF8;
 
         protected string SourceVersion
         {

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -164,7 +164,7 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
     acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/x${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
     acquireExternalTool "$CONTAINER_URL/pdbstr/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore
-    acquireExternalTool "$CONTAINER_URL/vstsom/m153_d91bed0b/vstsom.zip" tf
+    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
 
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget


### PR DESCRIPTION
**Changes:**
- Update new TF.exe version in externals
- Set UTF-8 encoding for working with GB18030


Based on [PR](https://github.com/microsoft/azure-pipelines-agent/pull/4432)