### PR TITLE
Mount Workspace

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -532,5 +532,12 @@ namespace Agent.Sdk.Knob
             "If true, the agent will check in the 'Initialize job' step each task used in the job for task deprecation.",
             new EnvironmentKnobSource("AZP_AGENT_CHECK_FOR_TASK_DEPRECATION"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob MountWorkspace = new Knob(
+            nameof(MountWorkspace),
+            "If true, the agent will mount the Pipeline.Workspace directory instead of the Working directory for steps which target a Docker container.",
+            new RuntimeKnobSource("AZP_AGENT_MOUNT_WORKSPACE"),
+            new EnvironmentKnobSource("AZP_AGENT_MOUNT_WORKSPACE"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }


### PR DESCRIPTION
***Description:*** With these changes, `docker create` will mount the pipeline workspace instead of the working directory.

[Related issue](https://github.com/microsoft/azure-pipelines-agent/issues/4479)

***Steps to reproduce:***
* Run this pipeline twice and check the `source` folder after each run —
```yml
trigger: none

pool: <Self-Hosted Agent Pool>

variables:
  system.debug: true

resources:
  containers:
  - container: <container>
    image: <image>

jobs:
- job:
  steps:
  - checkout: self
    path: source/project/repo

  - bash: |
      cd ../..
      touch ./$(build.buildid).label
    target: <container>
```

* Check the `Initialize containers` step —

  * The first time `docker create` runs with `-v "<agent>\_work\1":"/__w/1"`

  * The second time `docker create` runs with `-v "<agent>\_work\1\source\project":"/__w/1/source/project"`

***Tip:*** Select `Hide whitespace` during the review —

![image](https://github.com/microsoft/azure-pipelines-agent/assets/61472718/bc149b94-5a59-4cd4-ab46-3c682eff8fc3)
