### PR TITLE
Check for task deprecation in runtime

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -544,7 +544,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob CheckForTaskDeprecation = new Knob(
             nameof(CheckForTaskDeprecation),
             "If true, the agent will check in the 'Initialize job' step each task used in the job for task deprecation.",
-            new EnvironmentKnobSource("AZP_AGENT_CHECK_FOR_TASK_DEPRECATION"),
+            new RuntimeKnobSource("AZP_AGENT_CHECK_FOR_TASK_DEPRECATION"),
             new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob MountWorkspace = new Knob(

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                 await DownloadAsync(executionContext, task);
 
-                if (AgentKnobs.CheckForTaskDeprecation.GetValue(UtilKnobValueContext.Instance()).AsBoolean())
+                if (AgentKnobs.CheckForTaskDeprecation.GetValue(executionContext).AsBoolean())
                 {
                     CheckForTaskDeprecation(executionContext, task);
                 }


### PR DESCRIPTION
***Description:*** Define `AZP_AGENT_CHECK_FOR_TASK_DEPRECATION` as `RuntimeKnobSource` instead of `EnvironmentKnobSource` to use it as an ADO server feature flag.