### PR TITLE
Fix UI redirection while resource usage exposes log

### DIFF
--- a/src/Agent.Worker/ResourceMetricsManager.cs
+++ b/src/Agent.Worker/ResourceMetricsManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     {
         Task Run();
         void Setup(IExecutionContext context);
+        void SetContext(IExecutionContext context);
     }
 
     public sealed class ResourceMetricsManager : AgentService, IResourceMetricsManager
@@ -27,6 +28,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public void Setup(IExecutionContext context)
         {
+            //initial context
             ArgUtil.NotNull(context, nameof(context));
             _context = context;
 
@@ -38,6 +40,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 _context.Warning($"Unable to get current process, ex:{ex.Message}");
             }
+        }
+        public void SetContext(IExecutionContext context)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            _context = context;
         }
         public async Task Run()
         {
@@ -68,7 +75,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        private const int c_mb = 1024*1024;
+        private const int c_mb = 1024 * 1024;
 
         private Process _currentProcess;
 

--- a/src/Agent.Worker/StepsRunner.cs
+++ b/src/Agent.Worker/StepsRunner.cs
@@ -83,6 +83,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     HostContext.WritePerfCounter($"TaskStart_{taskStep.Task.Reference.Name}_{stepIndex}");
                 }
 
+                // Change the current job context to the step context.
+                var resourceDiagnosticManager = HostContext.GetService<IResourceMetricsManager>();
+                resourceDiagnosticManager.SetContext(step.ExecutionContext);
+                
                 // Variable expansion.
                 step.ExecutionContext.SetStepTarget(step.Target);
                 List<string> expansionWarnings;

--- a/src/Test/L0/Worker/StepsRunnerL0.cs
+++ b/src/Test/L0/Worker/StepsRunnerL0.cs
@@ -39,6 +39,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             _ec = new Mock<IExecutionContext>();
             _ec.SetupAllProperties();
             _ec.Setup(x => x.Variables).Returns(_variables);
+            var rm = new Mock<IResourceMetricsManager>();
+            hc.SetSingleton<IResourceMetricsManager>(rm.Object);
             _stepsRunner = new StepsRunner();
             _stepsRunner.Initialize(hc);
             return hc;

--- a/src/Test/L1/Mock/FakeResourceMetricsManager.cs
+++ b/src/Test/L1/Mock/FakeResourceMetricsManager.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Services.Agent.Worker;
+using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
+{
+    public sealed class FakeResourceMetricsManager : AgentService, IResourceMetricsManager
+    {
+        public async Task Run() { }
+        public void Setup(IExecutionContext context) { }
+        public void SetContext(IExecutionContext context) { }
+
+        public void Dispose() { }
+    }
+}

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -264,6 +264,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             _mockedServices.Add(context.SetupService<IAgentPluginManager>(typeof(FakeAgentPluginManager)));
             _mockedServices.Add(context.SetupService<ITaskManager>(typeof(FakeTaskManager)));
             _mockedServices.Add(context.SetupService<ICustomerIntelligenceServer>(typeof(FakeCustomerIntelligenceServer)));
+            _mockedServices.Add(context.SetupService<IResourceMetricsManager>(typeof(FakeResourceMetricsManager)));
         }
 
         private string GetLogFile(object testClass, string testMethod)


### PR DESCRIPTION
In terms of resource metrics data 'jobContext' was used. It leads the UI redirect to "Job initialization" steps each time.
BUG: https://github.com/microsoft/azure-pipelines-agent/issues/4469
**SLN**: Switch context to step execution each time