### PR TITLE
Workaround to unblock Ubuntu 18 containers (fallback to Node16)

### DIFF
--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -90,6 +90,7 @@ namespace Agent.Sdk
         public string CurrentUserId { get; set; }
         public string CurrentGroupName { get; set; }
         public string CurrentGroupId { get; set; }
+        public bool NeedsNode16Redirect { get; set; }
 
         public bool IsJobContainer { get; set; }
         public bool MapDockerSocket { get; set; }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -807,7 +807,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     {
                         if(container.NeedsNode16Redirect)
                         {
-                            container.CustomNodePath = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node16", "bin", $"node{IOUtil.ExeExtension}"));
+                            container.CustomNodePath = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), NodeHandler.Node16Folder, "bin", $"node{IOUtil.ExeExtension}"));
                         }
                     }
                 }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -18,6 +18,7 @@ using Azure.Identity;
 using Microsoft.TeamFoundation.Work.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker.Container;
+using Microsoft.VisualStudio.Services.Agent.Worker.Handlers;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.Win32;
 using Newtonsoft.Json;
@@ -766,9 +767,48 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         }
                     }
 
+                    bool useNode20InUnsupportedSystem = AgentKnobs.UseNode20InUnsupportedSystem.GetValue(executionContext).AsBoolean();
+
+                    if(!useNode20InUnsupportedSystem)
+                    {
+                        var node20 = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), NodeHandler.Node20Folder, "bin", $"node{IOUtil.ExeExtension}"));
+
+                        string node20TestCmd = $"bash -c \"{node20} -v\"";
+                        List<string> nodeInfo = await DockerExec(executionContext, container.ContainerId, node20TestCmd, noExceptionOnError: true);
+                        if (nodeInfo.Count > 0)
+                        {
+                            foreach(var nodeInfoLine in nodeInfo)
+                            {
+                                // detect example error from node 20 attempting to run on Ubuntu18:
+                                // /__a/externals/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__a/externals/node20/bin/node)
+                                // /__a/externals/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__a/externals/node20/bin/node)
+                                // /__a/externals/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /__a/externals/node20/bin/node)
+                                if(nodeInfoLine.Contains("version `GLIBC_2.28' not found")
+                                    || nodeInfoLine.Contains("version `GLIBC_2.25' not found")
+                                    || nodeInfoLine.Contains("version `GLIBC_2.27' not found"))
+                                {
+                                    executionContext.Debug($"GLIBC error found executing node -v; setting NeedsNode16Redirect: {nodeInfoLine}");
+                                    executionContext.Warning($"The container operating system doesn't support Node20. Using Node16 instead. " +
+                                                "Please upgrade the operating system of the container to ensure compatibility with Node20 tasks: " +
+                                                "https://github.com/nodesource/distributions");
+                                                        
+                                    container.NeedsNode16Redirect = true;
+                                }
+                            }
+                        }
+                    }
+
                     if (!string.IsNullOrEmpty(containerUserName))
                     {
                         container.CurrentUserName = containerUserName;
+                    }
+
+                    if(!useNode20InUnsupportedSystem)
+                    {
+                        if(container.NeedsNode16Redirect)
+                        {
+                            container.CustomNodePath = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node16", "bin", $"node{IOUtil.ExeExtension}"));
+                        }
                     }
                 }
             }
@@ -909,7 +949,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        private async Task<List<string>> DockerExec(IExecutionContext context, string containerId, string command)
+        private async Task<List<string>> DockerExec(IExecutionContext context, string containerId, string command, bool noExceptionOnError=false)
         {
             Trace.Info($"Docker-exec is going to execute: `{command}`; container id: `{containerId}`");
             List<string> output = new List<string>();
@@ -927,7 +967,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             if (exitCode != 0)
             {
                 Trace.Error(message);
-                throw new InvalidOperationException(message);
+                if(!noExceptionOnError)
+                {
+                    throw new InvalidOperationException(message);
+                }
             }
             Trace.Info(message);
             return output;

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -55,11 +55,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private const string nodeFolder = "node";
         private const string node10Folder = "node10";
         private const string node16Folder = "node16";
-        private const string node20Folder = "node20";
+        internal static readonly string Node20Folder = "node20";
         private const string nodeLTS = node16Folder;
         private const string useNodeKnobLtsKey = "LTS";
         private const string useNodeKnobUpgradeKey = "UPGRADE";
-        private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, node20Folder };
+        private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, Node20Folder };
         private static Regex _vstsTaskLibVersionNeedsFix = new Regex("^[0-2]\\.[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static string[] _extensionsNode6 ={
             "if (process.versions.node && process.versions.node.match(/^5\\./)) {",
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             else if (taskHasNode20Data)
             {
                 Trace.Info($"Task.json has node20 handler data: {taskHasNode20Data}");
-                nodeFolder = NodeHandler.node20Folder;
+                nodeFolder = NodeHandler.Node20Folder;
             }
             else if (taskHasNode16Data)
             {
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             } 
             else if (useNode20) {
                 Trace.Info($"Found UseNode20 knob, using node20 for node tasks {useNode20}");
-                nodeFolder = NodeHandler.node20Folder;
+                nodeFolder = NodeHandler.Node20Folder;
             }
 
             if (useNode16)

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -54,12 +54,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private readonly INodeHandlerHelper nodeHandlerHelper;
         private const string nodeFolder = "node";
         private const string node10Folder = "node10";
-        private const string node16Folder = "node16";
+        internal static readonly string Node16Folder = "node16";
         internal static readonly string Node20Folder = "node20";
-        private const string nodeLTS = node16Folder;
+        private static readonly string nodeLTS = Node16Folder;
         private const string useNodeKnobLtsKey = "LTS";
         private const string useNodeKnobUpgradeKey = "UPGRADE";
-        private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, Node20Folder };
+        private string[] possibleNodeFolders = { nodeFolder, node10Folder, Node16Folder, Node20Folder };
         private static Regex _vstsTaskLibVersionNeedsFix = new Regex("^[0-2]\\.[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static string[] _extensionsNode6 ={
             "if (process.versions.node && process.versions.node.match(/^5\\./)) {",
@@ -238,7 +238,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                              "Please upgrade the operating system of this host to ensure compatibility with Node20 tasks: " +
                              "https://github.com/nodesource/distributions");
                 Trace.Info($"Task.json has node20 handler data: {taskHasNode20Data}, but it's running in a unsupported system version. Using node16 for node tasks.");
-                nodeFolder = NodeHandler.node16Folder;
+                nodeFolder = NodeHandler.Node16Folder;
             }
             else if (taskHasNode20Data)
             {
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             else if (taskHasNode16Data)
             {
                 Trace.Info($"Task.json has node16 handler data: {taskHasNode16Data}");
-                nodeFolder = NodeHandler.node16Folder;
+                nodeFolder = NodeHandler.Node16Folder;
             }
             else if (taskHasNode10Data)
             {
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                              "Please upgrade the operating system of this host to ensure compatibility with Node20 tasks: " +
                              "https://github.com/nodesource/distributions");
                 Trace.Info($"Found UseNode20 knob, but it's running in a unsupported system version. Using node16 for node tasks.");
-                nodeFolder = NodeHandler.node16Folder;
+                nodeFolder = NodeHandler.Node16Folder;
             } 
             else if (useNode20) {
                 Trace.Info($"Found UseNode20 knob, using node20 for node tasks {useNode20}");
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (useNode16)
             {
                 Trace.Info($"Found UseNode16 knob, using node16 for node tasks {useNode16}");
-                nodeFolder = NodeHandler.node16Folder;
+                nodeFolder = NodeHandler.Node16Folder;
             }
 
             if (useNode10)


### PR DESCRIPTION
Implemented workaround to unblock Ubuntu 18 containers by falling back to Node16