### PR TITLE
Remove VSTS-task-lib from agent

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -527,13 +527,6 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_DISABLE_CLEAN_REPO_DEFAULT_VALUE"),
             new BuiltInDefaultKnobSource("false"));
 
-        public static readonly Knob IgnoreVSTSTaskLib = new Knob(
-            nameof(IgnoreVSTSTaskLib),
-            "Ignores the VSTSTaskLib folder when copying tasks.",
-            new RuntimeKnobSource("AZP_AGENT_IGNORE_VSTSTASKLIB"),
-            new EnvironmentKnobSource("AZP_AGENT_IGNORE_VSTSTASKLIB"),
-            new BuiltInDefaultKnobSource("false"));
-
         public static readonly Knob AllowWorkDirectoryRepositories = new Knob(
             nameof(AllowWorkDirectoryRepositories),
             "Allows repositories to be checked out below work directory level on self hosted agents.",

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -60,25 +60,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private const string useNodeKnobLtsKey = "LTS";
         private const string useNodeKnobUpgradeKey = "UPGRADE";
         private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, node20_1Folder };
-        private static Regex _vstsTaskLibVersionNeedsFix = new Regex("^[0-2]\\.[0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static string[] _extensionsNode6 ={
-            "if (process.versions.node && process.versions.node.match(/^5\\./)) {",
-            "   String.prototype.startsWith = function (str) {",
-            "       return this.slice(0, str.length) == str;",
-            "   };",
-            "   String.prototype.endsWith = function (str) {",
-            "       return this.slice(-str.length) == str;",
-            "   };",
-            "};",
-            "String.prototype.isEqual = function (ignoreCase, str) {",
-            "   var str1 = this;",
-            "   if (ignoreCase) {",
-            "       str1 = str1.toLowerCase();",
-            "       str = str.toLowerCase();",
-            "       }",
-            "   return str1 === str;",
-            "};"
-        };
 
         public NodeHandler()
         {

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -101,8 +101,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             ArgUtil.NotNull(Inputs, nameof(Inputs));
             ArgUtil.Directory(TaskDirectory, nameof(TaskDirectory));
 
-
-
             // Update the env dictionary.
             AddInputsToEnvironment();
             AddEndpointsToEnvironment();

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private static readonly string nodeLTS = Node16Folder;
         private const string useNodeKnobLtsKey = "LTS";
         private const string useNodeKnobUpgradeKey = "UPGRADE";
-        private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, node20_1Folder };
+        private string[] possibleNodeFolders = { nodeFolder, node10Folder, Node16Folder, Node20_1Folder };
 
         public NodeHandler()
         {

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -101,18 +101,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             ArgUtil.NotNull(Inputs, nameof(Inputs));
             ArgUtil.Directory(TaskDirectory, nameof(TaskDirectory));
 
-            if (!PlatformUtil.RunningOnWindows && !AgentKnobs.IgnoreVSTSTaskLib.GetValue(ExecutionContext).AsBoolean())
-            {
-                // Ensure compat vso-task-lib exist at the root of _work folder
-                // This will make vsts-agent work against 2015 RTM/QU1 TFS, since tasks in those version doesn't package with task lib
-                // Put the 0.5.5 version vso-task-lib into the root of _work/node_modules folder, so tasks are able to find those lib.
-                if (!File.Exists(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib", "package.json")))
-                {
-                    string vsoTaskLibFromExternal = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "vso-task-lib");
-                    string compatVsoTaskLibInWork = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib");
-                    IOUtil.CopyDirectory(vsoTaskLibFromExternal, compatVsoTaskLibInWork, ExecutionContext.CancellationToken);
-                }
-            }
+
 
             // Update the env dictionary.
             AddInputsToEnvironment();
@@ -137,23 +126,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 {
                     workingDirectory = HostContext.GetDirectory(WellKnownDirectory.Work);
                 }
-            }
-
-            // fix vsts-task-lib for node 6.x
-            // vsts-task-lib 0.6/0.7/0.8/0.9/2.0-preview implemented String.prototype.startsWith and String.prototype.endsWith since Node 5.x doesn't have them.
-            // however the implementation is added in node 6.x, the implementation in vsts-task-lib is different.
-            // node 6.x's implementation takes 2 parameters str.endsWith(searchString[, length]) / str.startsWith(searchString[, length])
-            // the implementation vsts-task-lib had only takes one parameter str.endsWith(searchString) / str.startsWith(searchString).
-            // as long as vsts-task-lib be loaded into memory, it will overwrite the implementation node 6.x has,
-            // so any script that use the second parameter (length) will encounter unexpected result.
-            // to avoid customer hit this error, we will modify the file (extensions.js) under vsts-task-lib module folder when customer choose to use Node 6.x
-            if (!AgentKnobs.IgnoreVSTSTaskLib.GetValue(ExecutionContext).AsBoolean())
-            {
-                Trace.Info("Inspect node_modules folder, make sure vsts-task-lib doesn't overwrite String.startsWith/endsWith.");
-                FixVstsTaskLibModule();
-            } else
-            {
-                Trace.Info("AZP_AGENT_IGNORE_VSTSTASKLIB enabled, ignoring fix");
             }
 
             StepHost.OutputDataReceived += OnDataReceived;
@@ -370,56 +342,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 return false;
             }
             return true;
-        }
-
-        private void FixVstsTaskLibModule()
-        {
-            // to avoid modify node_module all the time, we write a .node6 file to indicate we finsihed scan and modify.
-            // the current task is good for node 6.x
-            if (File.Exists(TaskDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + ".node6"))
-            {
-                Trace.Info("This task has already been scanned and corrected, no more operation needed.");
-            }
-            else
-            {
-                Trace.Info("Scan node_modules folder, looking for vsts-task-lib\\extensions.js");
-                try
-                {
-                    foreach (var file in new DirectoryInfo(TaskDirectory).EnumerateFiles("extensions.js", SearchOption.AllDirectories))
-                    {
-                        if (string.Equals(file.Directory.Name, "vsts-task-lib", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(file.Directory.Name, "vso-task-lib", StringComparison.OrdinalIgnoreCase))
-                        {
-                            if (File.Exists(Path.Combine(file.DirectoryName, "package.json")))
-                            {
-                                // read package.json, we only do the fix for 0.x->2.x
-                                JObject packageJson = JObject.Parse(File.ReadAllText(Path.Combine(file.DirectoryName, "package.json")));
-
-                                JToken versionToken;
-                                if (packageJson.TryGetValue("version", StringComparison.OrdinalIgnoreCase, out versionToken))
-                                {
-                                    if (_vstsTaskLibVersionNeedsFix.IsMatch(versionToken.ToString()))
-                                    {
-                                        Trace.Info($"Fix extensions.js file at '{file.FullName}'. The vsts-task-lib version is '{versionToken.ToString()}'");
-
-                                        // take backup of the original file
-                                        File.Copy(file.FullName, Path.Combine(file.DirectoryName, "extensions.js.vstsnode5"));
-                                        File.WriteAllLines(file.FullName, _extensionsNode6);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    File.WriteAllText(TaskDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + ".node6", string.Empty);
-                    Trace.Info("Finished scan and correct extensions.js under vsts-task-lib");
-                }
-                catch (Exception ex)
-                {
-                    Trace.Error("Unable to scan and correct potential bug in extensions.js of vsts-task-lib.");
-                    Trace.Error(ex);
-                }
-            }
         }
     }
 }

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -61,7 +61,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private const string useNodeKnobUpgradeKey = "UPGRADE";
         private string[] possibleNodeFolders = { nodeFolder, node10Folder, node16Folder, node20_1Folder };
 
-
         public NodeHandler()
         {
             this.nodeHandlerHelper = new NodeHandlerHelper();


### PR DESCRIPTION
**Description:**
This PR is removing vsts-task-lib from nodehandler, which is previously used on old task.

**Testing**
This changes was tested for few months using feature flag without any issues.

**Workitem**: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2098491
