### PR TITLE
For node20 fallback on host, check for glibc instead of OS version check

### DIFF
--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -90,10 +90,9 @@ namespace Agent.Sdk
         public string CurrentUserId { get; set; }
         public string CurrentGroupName { get; set; }
         public string CurrentGroupId { get; set; }
-        public bool NeedsNode16Redirect { get; set; }
-
         public bool IsJobContainer { get; set; }
         public bool MapDockerSocket { get; set; }
+        public bool NeedsNode16Redirect { get; set; }
         public PlatformUtil.OS ImageOS
         {
             get

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -102,21 +102,6 @@ namespace Agent.Sdk
             }
         }
 
-        public static bool RunningOnRHEL7
-        {
-            get
-            {
-                if (!(detectedRHEL7 is null))
-                {
-                    return (bool)detectedRHEL7;
-                }
-
-                DetectRHEL7();
-
-                return (bool)detectedRHEL7;
-            }
-        }
-
         public static string GetSystemId()
         {
             return PlatformUtil.HostOS switch
@@ -162,34 +147,6 @@ namespace Agent.Sdk
                     catch (IOException)
                     {
                         // IOException indicates we couldn't read that file; probably not RHEL6
-                    }
-                }
-            }
-        }
-
-        private static void DetectRHEL7()
-        {
-            lock (detectedRHEL7lock)
-            {
-                if (!RunningOnLinux || !File.Exists("/etc/redhat-release"))
-                {
-                    detectedRHEL7 = false;
-                }
-                else
-                {
-                    detectedRHEL7 = false;
-                    try
-                    {
-                        string redhatVersion = File.ReadAllText("/etc/redhat-release");
-                        if (redhatVersion.StartsWith("CentOS release 7.")
-                            || redhatVersion.StartsWith("Red Hat Enterprise Linux Server release 7."))
-                        {
-                            detectedRHEL7 = true;
-                        }
-                    }
-                    catch (IOException)
-                    {
-                        // IOException indicates we couldn't read that file; probably not RHEL7
                     }
                 }
             }
@@ -314,8 +271,6 @@ namespace Agent.Sdk
 
         private static bool? detectedRHEL6 = null;
         private static object detectedRHEL6lock = new object();
-        private static bool? detectedRHEL7 = null;
-        private static object detectedRHEL7lock = new object();
 
         public static Architecture HostArchitecture
         {

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -797,6 +797,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                 );
                             }
                         }
+
+                        if (container.NeedsNode16Redirect)
+                        {
+                            container.CustomNodePath = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), NodeHandler.Node16Folder, "bin", $"node{IOUtil.ExeExtension}"));
+                        }
                     }
 
                     if (!string.IsNullOrEmpty(containerUserName))
@@ -804,13 +809,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         container.CurrentUserName = containerUserName;
                     }
 
-                    if(!useNode20InUnsupportedSystem)
-                    {
-                        if(container.NeedsNode16Redirect)
-                        {
-                            container.CustomNodePath = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), NodeHandler.Node16Folder, "bin", $"node{IOUtil.ExeExtension}"));
-                        }
-                    }
                 }
             }
         }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -783,12 +783,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                             if (container.NeedsNode16Redirect)
                             {
-
                                 PublishTelemetry(
                                     executionContext,
                                     new Dictionary<string, string>
                                     {
-                                        {  "Container: NeedsNode16Redirect", container.NeedsNode16Redirect.ToString() }
+                                        {  "ContainerNode20to16Fallback", container.NeedsNode16Redirect.ToString() }
                                     }
                                 );
                             }

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -778,10 +778,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                         container.NeedsNode16Redirect = WorkerUtilities.IsCommandResultGlibcError(executionContext, nodeVersionOutput, out string nodeInfoLine);
 
-                        executionContext.Debug($"GLIBC error found executing node -v; setting NeedsNode16Redirect: {nodeInfoLine}");
-                        executionContext.Warning($"The container operating system doesn't support Node20. Using Node16 instead. " +
-                                    "Please upgrade the operating system of the container to ensure compatibility with Node20 tasks: " +
-                                    "https://github.com/nodesource/distributions");
+                        if (container.NeedsNode16Redirect)
+                        {
+                            executionContext.Debug($"GLIBC error found executing node -v; setting NeedsNode16Redirect: {nodeInfoLine}");
+                            executionContext.Warning($"The container operating system doesn't support Node20. Using Node16 instead. " +
+                                        "Please upgrade the operating system of the container to ensure compatibility with Node20 tasks: " +
+                                        "https://github.com/nodesource/distributions");
+                        }
                     }
 
                     if (!string.IsNullOrEmpty(containerUserName))

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -783,10 +783,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
                             if (container.NeedsNode16Redirect)
                             {
-                                executionContext.Debug($"GLIBC error found executing node -v; setting NeedsNode16Redirect: {nodeInfoLine}");
-                                executionContext.Warning($"The container operating system doesn't support Node20. Using Node16 instead. " +
-                                            "Please upgrade the operating system of the container to ensure compatibility with Node20 tasks: " +
-                                            "https://github.com/nodesource/distributions");
 
                                 PublishTelemetry(
                                     executionContext,
@@ -798,17 +794,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             }
                         }
 
-                        if (container.NeedsNode16Redirect)
-                        {
-                            container.CustomNodePath = container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), NodeHandler.Node16Folder, "bin", $"node{IOUtil.ExeExtension}"));
-                        }
                     }
 
                     if (!string.IsNullOrEmpty(containerUserName))
                     {
                         container.CurrentUserName = containerUserName;
                     }
-
                 }
             }
         }

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -382,13 +382,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             if (inContainer)
             {
                 ExecutionContext.Warning($"The container operating system doesn't support Node20. Using Node16 instead. " +
-                                "Please upgrade the operating system of the container to ensure compatibility with Node20 tasks: " +
+                                "Please upgrade the operating system of the container to remain compatible with future updates of tasks: " +
                                 "https://github.com/nodesource/distributions");
             }
             else
             {
                 ExecutionContext.Warning($"The agent operating system doesn't support Node20. Using Node16 instead. " +
-                            "Please upgrade the operating system of the agent to ensure compatibility with Node20 tasks: " +
+                            "Please upgrade the operating system of the agent to remain compatible with future updates of tasks: " +
                             "https://github.com/nodesource/distributions");
             }
         }

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -81,6 +81,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             "   return str1 === str;",
             "};"
         };
+        private bool? supportsNode20;
 
         public NodeHandler()
         {
@@ -174,12 +175,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
                 if (PlatformUtil.HostOS == PlatformUtil.OS.Linux && !UseNode20InUnsupportedSystem)
                 {
-                    node20ResultsInGlibCError = await CheckIfNode20ResultsInGlibCError();
-
-                    PublishTelemetry(new Dictionary<string, string>
+                    if (supportsNode20.HasValue)
                     {
-                        {  "Host: node20ResultsInGlibCError", node20ResultsInGlibCError.ToString() }
-                    });
+                        node20ResultsInGlibCError = supportsNode20.Value;
+                    }
+                    else
+                    {
+                        node20ResultsInGlibCError = await CheckIfNode20ResultsInGlibCError();
+
+                        PublishTelemetry(new Dictionary<string, string>
+                        {
+                            {  "Host: node20ResultsInGlibCError", node20ResultsInGlibCError.ToString() }
+                        });
+
+                        supportsNode20 = node20ResultsInGlibCError;
+                    }
                 }
 
                 file = GetNodeLocation(node20ResultsInGlibCError);

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -439,7 +439,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
         private async Task<List<string>> ExecuteCommandAsync(IExecutionContext context, string command, string arg, bool requireZeroExitCode, bool showOutputOnFailureOnly)
         {
-            context.Command($"{command} {arg}");
+            string commandLog = $"{command} {arg}";
+            if (!showOutputOnFailureOnly)
+            {
+                context.Command(commandLog);
+            }
 
             List<string> outputs = new List<string>();
             object outputLock = new object();
@@ -477,6 +481,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
             if ((showOutputOnFailureOnly && exitCode != 0) || !showOutputOnFailureOnly)
             {
+                if (showOutputOnFailureOnly)
+                {
+                    context.Command(commandLog);
+                }
+
                 foreach (var outputLine in outputs)
                 {
                     context.Output(outputLine);

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
                         PublishTelemetry(new Dictionary<string, string>
                         {
-                            {  "Host: node20ResultsInGlibCError", node20ResultsInGlibCErrorHost.ToString() }
+                            {  "HostNode20to16Fallback", node20ResultsInGlibCErrorHost.ToString() }
                         });
 
                         supportsNode20 = node20ResultsInGlibCErrorHost;

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -437,7 +437,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         }
 
 
-        private async Task<List<string>> ExecuteCommandAsync(IExecutionContext context, string command, string arg)
+        private async Task<List<string>> ExecuteCommandAsync(IExecutionContext context, string command, string arg, bool requireZeroExitCode = true)
         {
             context.Command($"{command} {arg}");
 
@@ -471,7 +471,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                             fileName: command,
                             arguments: arg,
                             environment: null,
-                            requireExitCodeZero: true,
+                            requireExitCodeZero: requireZeroExitCode,
                             outputEncoding: null,
                             cancellationToken: CancellationToken.None);
 

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -195,11 +195,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 ContainerInfo container = (ExecutionContext.StepTarget() as ContainerInfo);
                 if (container == null)
                 {
-                    file = GetNodeLocation(node20ResultsInGlibCErrorHost);
+                    file = GetNodeLocation(node20ResultsInGlibCErrorHost, inContainer: false);
                 }
                 else
                 {
-                    file = GetNodeLocation(container.NeedsNode16Redirect);
+                    file = GetNodeLocation(container.NeedsNode16Redirect, inContainer: true);
                 }
 
                 ExecutionContext.Debug("Using node path: " + file);
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             return node20ResultsInGlibCError;
         }
 
-        public string GetNodeLocation(bool node20ResultsInGlibCError)
+        public string GetNodeLocation(bool node20ResultsInGlibCError, bool inContainer)
         {
             bool useNode10 = AgentKnobs.UseNode10.GetValue(ExecutionContext).AsBoolean();
             bool useNode16 = AgentKnobs.UseNode16.GetValue(ExecutionContext).AsBoolean();
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 if (node20ResultsInGlibCError)
                 {
                     nodeFolder = NodeHandler.Node16Folder;
-                    Node16FallbackWarning();
+                    Node16FallbackWarning(inContainer);
                 }
                 else
                 {
@@ -312,11 +312,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 if(node20ResultsInGlibCError)
                 {
                     nodeFolder = NodeHandler.Node16Folder;
-
-                    ExecutionContext.Warning($"The agent operating system doesn't support Node20. Using Node16 instead. " +
-                                "Please upgrade the operating system of the agent to ensure compatibility with Node20 tasks: " +
-                                "https://github.com/nodesource/distributions");
-                } 
+                    Node16FallbackWarning(inContainer);
+                }
                 else
                 {
                     nodeFolder = NodeHandler.Node20_1Folder;
@@ -380,12 +377,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             return nodeHandlerHelper.GetNodeFolderPath(nodeFolder, HostContext);
         }
 
-        private void Node16FallbackWarning()
+        private void Node16FallbackWarning(bool inContainer)
         {
-            //ExecutionContext.Debug($"GLIBC error found executing node -v; needs Node16 redirect: {nodeInfoLine}");
-            ExecutionContext.Warning($"The agent operating system doesn't support Node20. Using Node16 instead. " +
-                        "Please upgrade the operating system of the agent to ensure compatibility with Node20 tasks: " +
-                        "https://github.com/nodesource/distributions");
+            if (inContainer)
+            {
+                ExecutionContext.Warning($"The container operating system doesn't support Node20. Using Node16 instead. " +
+                                "Please upgrade the operating system of the container to ensure compatibility with Node20 tasks: " +
+                                "https://github.com/nodesource/distributions");
+            }
+            else
+            {
+                ExecutionContext.Warning($"The agent operating system doesn't support Node20. Using Node16 instead. " +
+                            "Please upgrade the operating system of the agent to ensure compatibility with Node20 tasks: " +
+                            "https://github.com/nodesource/distributions");
+            }
         }
 
         private void OnDataReceived(object sender, ProcessDataReceivedEventArgs e)

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -170,10 +170,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             }
             else
             {
-                bool UseNode20InUnsupportedSystem = AgentKnobs.UseNode20InUnsupportedSystem.GetValue(ExecutionContext).AsBoolean();
+                bool useNode20InUnsupportedSystem = AgentKnobs.UseNode20InUnsupportedSystem.GetValue(ExecutionContext).AsBoolean();
                 bool node20ResultsInGlibCErrorHost = false;
 
-                if (PlatformUtil.HostOS == PlatformUtil.OS.Linux && !UseNode20InUnsupportedSystem)
+                if (PlatformUtil.HostOS == PlatformUtil.OS.Linux && !useNode20InUnsupportedSystem)
                 {
                     if (supportsNode20.HasValue)
                     {

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -183,10 +183,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                     {
                         node20ResultsInGlibCErrorHost = await CheckIfNode20ResultsInGlibCError();
 
-                        PublishTelemetry(new Dictionary<string, string>
-                        {
-                            {  "HostNode20to16Fallback", node20ResultsInGlibCErrorHost.ToString() }
-                        });
+                        ExecutionContext.EmitHostNode20FallbackTelemetry(node20ResultsInGlibCErrorHost);
 
                         supportsNode20 = node20ResultsInGlibCErrorHost;
                     }
@@ -458,7 +455,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 }
             }
         }
-
 
         private async Task<List<string>> ExecuteCommandAsync(IExecutionContext context, string command, string arg, bool requireZeroExitCode, bool showOutputOnFailureOnly)
         {

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -238,7 +238,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private async Task<bool> CheckIfNode20ResultsInGlibCError()
         {
             var node20 = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), NodeHandler.Node20_1Folder, "bin", $"node{IOUtil.ExeExtension}");
-            List<string> nodeVersionOutput = await ExecuteCommandAsync(ExecutionContext, node20, "-v");
+            List<string> nodeVersionOutput = await ExecuteCommandAsync(ExecutionContext, node20, "-v", requireZeroExitCode: false);
             var node20ResultsInGlibCError = WorkerUtilities.IsCommandResultGlibcError(ExecutionContext, nodeVersionOutput, out string nodeInfoLine);
 
             return node20ResultsInGlibCError;

--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -131,5 +131,31 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 workspaceOptions: message.Workspace,
                 steps: message.Steps);
         }
+
+        internal static bool IsCommandResultGlibcError(IExecutionContext executionContext, List<string> nodeVersionOutput, out string nodeInfoLineOut)
+        {
+            nodeInfoLineOut = "";
+
+            if (nodeVersionOutput.Count > 0)
+            {
+                foreach (var nodeInfoLine in nodeVersionOutput)
+                {
+                    // detect example error from node 20 attempting to run on Ubuntu18:
+                    // /__a/externals/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__a/externals/node20/bin/node)
+                    // /__a/externals/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__a/externals/node20/bin/node)
+                    // /__a/externals/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /__a/externals/node20/bin/node)
+                    if (nodeInfoLine.Contains("version `GLIBC_2.28' not found")
+                        || nodeInfoLine.Contains("version `GLIBC_2.25' not found")
+                        || nodeInfoLine.Contains("version `GLIBC_2.27' not found"))
+                    {
+                        nodeInfoLineOut = nodeInfoLine;
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Test/L0/NodeHandlerL0.cs
+++ b/src/Test/L0/NodeHandlerL0.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     nodeVersion = "node10"; // version 6 does not exist on Alpine
                 }
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     nodeVersion,
                     "bin",
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     _ => throw new Exception("Invalid node version"),
                 };
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     nodeVersion,
                     "bin",
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     nodeHandler.ExecutionContext = CreateTestExecutionContext(thc);
                     nodeHandler.Data = new Node10HandlerData();
 
-                    string actualLocation = nodeHandler.GetNodeLocation();
+                    string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                     string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                         "node10",
                         "bin",
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "node10",
                     "bin",
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "node10",
                     "bin",
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "node16",
                     "bin",
@@ -255,7 +255,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation());
+                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false));
             }
         }
 
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation());
+                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false));
             }
         }
 
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "nextAvailableNode1",
                     "bin",
@@ -356,7 +356,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation();
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "nextAvailableNode2",
                     "bin",
@@ -395,7 +395,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation());
+                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false));
             }
         }
 

--- a/src/Test/L0/NodeHandlerL0.cs
+++ b/src/Test/L0/NodeHandlerL0.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     nodeVersion = "node10"; // version 6 does not exist on Alpine
                 }
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     nodeVersion,
                     "bin",
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     _ => throw new Exception("Invalid node version"),
                 };
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     nodeVersion,
                     "bin",
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     nodeHandler.ExecutionContext = CreateTestExecutionContext(thc);
                     nodeHandler.Data = new Node10HandlerData();
 
-                    string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                    string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                     string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                         "node10",
                         "bin",
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "node10",
                     "bin",
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "node10",
                     "bin",
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "node16",
                     "bin",
@@ -255,7 +255,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false));
+                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false));
             }
         }
 
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false));
+                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false));
             }
         }
 
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "nextAvailableNode1",
                     "bin",
@@ -356,7 +356,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false);
+                string actualLocation = nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false);
                 string expectedLocation = Path.Combine(thc.GetDirectory(WellKnownDirectory.Externals),
                     "nextAvailableNode2",
                     "bin",
@@ -395,7 +395,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 nodeHandler.ExecutionContext = CreateTestExecutionContext(thc, variables);
                 nodeHandler.Data = new Node10HandlerData();
 
-                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError:false));
+                Assert.Throws<FileNotFoundException>(() => nodeHandler.GetNodeLocation(node20ResultsInGlibCError: false, inContainer: false));
             }
         }
 


### PR DESCRIPTION
For systems tha don't support node20, we need to fall back to node 16

Originally, we implemented a OS version check for checking the version on the host to apply the node fallback (#4520 ).  Then, for containers, we checked the error result from node -v (#4470)

This change makes the host check consistent with the container check by having host check for a error result from node -v to determine if fallback is needed.

Related PRs: #4520 #4470

Todo:
  - [x] Testing using container (Ubuntu 18 on Ubuntu 20)
  - [x] Testing on Ubuntu 18 host
  - [x] Consider reporting node20 check result for container (currently only reports on host)
  - [x] Ensure Windows docker scenario