### PR TITLE
Fix OSArchitecture for osx-arm64

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -36,6 +36,18 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz"
     },
     {
+        "name": "vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz",
+        "platform": "osx-arm64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz"
+    },
+    {
+        "name": "pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz",
+        "platform": "osx-arm64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz"
+    },
+    {
         "name": "vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-x64",
         "version": "<AGENT_VERSION>",

--- a/assets.json
+++ b/assets.json
@@ -76,11 +76,5 @@
         "platform": "linux-musl-x64",
         "version": "<AGENT_VERSION>",
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz"
-    },
-    {
-        "name": "pipelines-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz",
-        "platform": "linux-musl-x64",
-        "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz"
     }
 ]

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -82,7 +82,7 @@ See [notes](docs/node6.md) on Node version support for more details.
 | Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64   | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |

--- a/src/Common.props
+++ b/src/Common.props
@@ -37,8 +37,11 @@
     <OSArchitecture>X86</OSArchitecture>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_OSX'">
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_OSX' AND '$(PackageRuntime)' == 'osx-x64'">
     <OSArchitecture>X64</OSArchitecture>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_OSX' AND '$(PackageRuntime)' == 'osx-arm64'">
+    <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-x64'">

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-if ($pwd -notlike '*tfsgheus20' ) {
+if ($pwd -notlike '*tfsgheus20') {
 
     # primary packages
 


### PR DESCRIPTION
***Description:*** Correctly define the `OSArchitecture` value for the `osx-arm64` Package Runtime.

Also, `pipelines-agent-linux-musl-x64` is removed from `assets.json` since it does not exist.

Also, changes from [this PR](https://github.com/microsoft/azure-pipelines-agent/pull/4510) were cherry-picked.