### PR TITLE
[AgentWorker.PageLogger] - Ignore endgroup tag when counting lines

### DIFF
--- a/src/Agent.Worker/WorkerCommandManager.cs
+++ b/src/Agent.Worker/WorkerCommandManager.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     return false;
                 }
 
-                // process logging command in serialize oreder.
+                // process logging command in serialize order.
                 lock (_commandSerializeLock)
                 {
                     try


### PR DESCRIPTION
**Description**
- Added tests for the new logic
- Added logic to ignore endgroup tag when counting lines for the error/warning highlight as it's not shown in the UI it shouldn't be counted

**Testing**
Tested via pipeline and added unit tests

**Related Issue**: WI 2125343 