### PR TITLE
Remove the support matrix from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Written for .NET Core in C#.
 ## Supported Usage
 
 This agent can be used for both Azure Pipelines and Azure DevOps Server (Team Foundation Server).
-Support is extended to all on-premise solutions [based on their lifecycle (including extended support)](https://learn.microsoft.com/en-us/lifecycle/products/).
+Support is extended to all on-premise solutions [based on their lifecycle (including extended support)](https://learn.microsoft.com/lifecycle/products/).
 
 The only exception is the Windows version of the agent for TFS 2015 since it is distributed along with a separate Node-based agent.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Written for .NET Core in C#.
 ## Supported Usage
 
 This agent can be used for both Azure Pipelines and Azure DevOps Server (Team Foundation Server).
-Support is extended to all on-premise solutions based on their lifecycle (including extended support).
+Support is extended to all on-premise solutions [based on their lifecycle (including extended support)](https://learn.microsoft.com/en-us/lifecycle/products/).
 
 The only exception is the Windows version of the agent for TFS 2015 since it is distributed along with a separate Node-based agent.
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,10 @@ Written for .NET Core in C#.
 
 ## Supported Usage
 
-This agent can be used for Azure Pipelines, Azure DevOps Server 2019+, and TFS 2017+.
-It also replaces the Node-based agent for TFS 2015.
+This agent can be used for both Azure Pipelines and Azure DevOps Server (Team Foundation Server).
+Support is extended to all on-premises solutions based on their lifecycle (including extended support).
 
-| Scenario | Mac/Linux | Windows | Comment |
-|:-------------:|:-----:|:-----:|:-----:|
-| Azure Pipelines      |  Yes  | Yes   |
-| TFS2015 (onprem)   |  Yes  | No    | Windows use agent with 2015 |
-| TFS2017 (onprem)   |  Yes  | Yes    |  |
-| TFS2018 (onprem)   |  Yes  | Yes    |  |
+The only exception is the Windows version of the agent for TFS 2015 since it is distributed along with a separate Node-based agent.
 
 ## Latest and Pre-release labels for releases
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Written for .NET Core in C#.
 ## Supported Usage
 
 This agent can be used for both Azure Pipelines and Azure DevOps Server (Team Foundation Server).
-Support is extended to all on-premises solutions based on their lifecycle (including extended support).
+Support is extended to all on-premise solutions based on their lifecycle (including extended support).
 
 The only exception is the Windows version of the agent for TFS 2015 since it is distributed along with a separate Node-based agent.
 


### PR DESCRIPTION
We need to remove the support matrix from readme.md to avoid stale info and refer to the support lifecycle instead.