### PR TITLE
Add proper exception handling for Telemetery/FeatureFlag enpoints

### DIFF
--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -25,7 +25,6 @@ namespace Agent.Listener.Configuration
         /// <param name="featureFlagName">The name of the feature flag to get the status of.</param>
         /// <param name="traceWriter">Trace writer for output</param>
         /// <returns>The status of the feature flag.</returns>
-        /// <exception cref="VssUnauthorizedException">Thrown if token is not suitable for retriving feature flag status</exception>
         /// <exception cref="InvalidOperationException">Thrown if agent is not configured</exception>
         public Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter, CancellationToken ctk = default);
 
@@ -55,6 +54,10 @@ namespace Agent.Listener.Configuration
                 return await client.GetFeatureFlagByNameAsync(featureFlagName, checkFeatureExists: false);
             } catch (VssServiceException e) {
                 Trace.Warning("Unable to retrieve feature flag status: " + e.ToString());
+                return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
+            } catch (VssUnauthorizedException exception)
+            {
+                Trace.Warning("Unable to retrieve feature flag with following exception: " + exception.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
             }
         }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -55,9 +55,8 @@ namespace Agent.Listener.Configuration
             } catch (VssServiceException e) {
                 Trace.Warning("Unable to retrieve feature flag status: " + e.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
-            } catch (VssUnauthorizedException exception)
-            {
-                Trace.Warning("Unable to retrieve feature flag with following exception: " + exception.ToString());
+            } catch (VssUnauthorizedException e) {
+                Trace.Warning("Unable to retrieve feature flag with following exception: " + e.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
             }
         }

--- a/src/Agent.Listener/Telemetry/TelemetryPublisher.cs
+++ b/src/Agent.Listener/Telemetry/TelemetryPublisher.cs
@@ -81,7 +81,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Telemetry
 
                 using var vsConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, Trace, agentCertManager.SkipServerCertificateValidation);
                 _ciService.Initialize(vsConnection);
-                await PublishEventsAsync(context, ciEvent);
+                /// This endpoint is not accepting data on some old Azure DevOps OnPremise versions
+                try
+                {
+                    await PublishEventsAsync(context, ciEvent);
+                } catch (VssUnauthorizedException)
+                {
+                    Trace.Warning("Unable to publish telemetry data");
+                }
+                
 
             }
             // We never want to break pipelines in case of telemetry failure.

--- a/src/Agent.Listener/Telemetry/TelemetryPublisher.cs
+++ b/src/Agent.Listener/Telemetry/TelemetryPublisher.cs
@@ -101,7 +101,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Telemetry
 
         private async Task PublishEventsAsync(IHostContext context, CustomerIntelligenceEvent ciEvent)
         {
-            await _ciService.PublishEventsAsync(new CustomerIntelligenceEvent[] { ciEvent });
+            try
+            {
+                await _ciService.PublishEventsAsync(new CustomerIntelligenceEvent[] { ciEvent });
+            } catch (VssUnauthorizedException) {
+                Trace.Warning("Unable to publish telemetry data");
+            }
         }
     }
     internal static class WellKnownEventTrackProperties


### PR DESCRIPTION
**Description**
Some endpoints is not available for access from agent on OnPrem this PR is adding error handling for Azure DevOps OnPrem

**ADO WI**: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2129113

**Testing**
In progress

Related issues: #4562, #4566

