### PR TITLE
Added check for existing agent versions in scheduled releases

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -86,9 +86,14 @@ extends:
                 while ($true) {
                   $agentVersion = "$majorAndMinorVersion.$patchVersion"
                   git ls-remote --exit-code --heads origin refs/heads/releases/$agentVersion
-                  if ($LASTEXITCODE -eq 2) {
-                      $LASTEXITCODE = 0
-                      break
+                  if ($LASTEXITCODE -ne 0) {
+                    if ($LASTEXITCODE -eq 2) {
+                        $LASTEXITCODE = 0
+                        break
+                    }
+                    else {
+                        Write-Error "git ls-remote failed with exit code $LASTEXITCODE" -ErrorAction Stop
+                    }
                   }
                   $patchVersion++
                 }

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -80,7 +80,18 @@ extends:
 
             if ($isRelease) {
               if ($isScheduledRelease) {
-                $agentVersion = "3.$($currentSprint.sprint).0"
+                $majorAndMinorVersion = "3.$($currentSprint.sprint)"
+                $patchVersion = 0
+                ## Looking for a free patch version
+                while ($true) {
+                  $agentVersion = "$majorAndMinorVersion.$patchVersion"
+                  git ls-remote --exit-code --heads origin refs/heads/releases/$agentVersion
+                  if ($LASTEXITCODE -eq 2) {
+                      $LASTEXITCODE = 0
+                      break
+                  }
+                  $patchVersion++
+                }
               } else {
                 $agentVersion = "${{ parameters.version }}"
                 if ($agentVersion -eq 'NotSet') {


### PR DESCRIPTION
Looking through agent release branches to find unused patch branch to prevent conflicts when agent was manually released in the current sprint.
WI: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2101829