### PR TITLE
Added retry for Install unzip step

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -109,6 +109,7 @@ jobs:
   - ${{ if and(eq(parameters.arch, 'arm64'), ne(parameters.os, 'osx')) }}:
     - script: sudo apt-get update && sudo apt-get -y install unzip
       displayName: Install unzip
+      retryCountOnTaskFailure: 5
 
   # Build agent layout
   - script: ${{ variables.devCommand }} layout Release ${{ parameters.os }}-${{ parameters.arch }}


### PR DESCRIPTION
Sometimes Install unzip step fails due to intermittent issues. Retries should prevent such flakiness.
WI: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2101829#5571765