### PR TITLE
Move agent release notifications to separate stage

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -306,20 +306,37 @@ extends:
               PAT: $(AdoPAT)
               USEREMAIL: $(Email)
 
-        - job: SendNotifications
-          displayName: Send notifications
-          dependsOn: create_ado_prs
+      - stage: S_Notifications
+        displayName: Notifications
+        dependsOn:
+        - Verify_release
+        - CreatePRs
+        condition: always()
+        pool:
+          vmImage: ubuntu-latest
+        jobs:
+        - job: j_SendPRsNotifications
+          displayName: Send Release PRs notifications
           variables:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
-          condition: and(succeeded(), eq(variables.IsRelease, 'True'))
+            AdoPrId: $[ stageDependencies.CreatePRs.create_ado_prs.outputs['s_CreateAdoPrs.AdoPrId'] ]
+            AdoPrLink: $[ stageDependencies.CreatePRs.create_ado_prs.outputs['s_CreateAdoPrs.AdoPrLink'] ]
+            CcPrId: $[ stageDependencies.CreatePRs.create_ado_prs.outputs['s_CreateAdoPrs.CcPrId'] ]
+            CcPrLink: $[ stageDependencies.CreatePRs.create_ado_prs.outputs['s_CreateAdoPrs.CcPrLink'] ]
+          condition: |
+            and(
+              eq(variables.IsRelease, 'True'),
+              not(${{ parameters.onlyGitHubRelease }})
+            )
           steps:
-          - pwsh: release\Send-PRsNotification.ps1
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: ./release/Send-PRsNotification.ps1
             displayName: Send MS Teams notification
-            # We only want to send a notification if this is a scheduled release
-            condition: eq(variables['build.reason'], 'Schedule')
             env:
-              ADO_PR_ID: $[ dependencies.create_ado_prs.outputs['s_CreateAdoPrs.AdoPrId'] ]
-              ADO_PR_LINK: $[ dependencies.create_ado_prs.outputs['s_CreateAdoPrs.AdoPrLink'] ]
-              CC_PR_ID: $[ dependencies.create_ado_prs.outputs['s_CreateAdoPrs.CcPrId'] ]
-              CC_PR_LINK: $[ dependencies.create_ado_prs.outputs['s_CreateAdoPrs.CcPrLink'] ]
-              MS_TEAMS_WEBHOOK: $(MsTeamsWebhook)
+              TEAMS_WEBHOOK: $(MsTeamsWebhook)
+              ADO_PR_ID: $(AdoPrId)
+              ADO_PR_LINK: $(AdoPrLink)
+              CC_PR_ID: $(CcPrId)
+              CC_PR_LINK: $(CcPrLink)


### PR DESCRIPTION
Moved notifications to separate stage to make it independent from `CreatePRs`.
This allows us to receive notifications if a release pipeline failed at an earlier stage than `CreatePRs`.

Also, now we'll receive PRs notification even if it's a manual release run.

WI: [2120784](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2120784)
