### PR TITLE
Enable publishing attachments for JUnit test results

### DIFF
--- a/src/Agent.Worker/TestResults/Parser.cs
+++ b/src/Agent.Worker/TestResults/Parser.cs
@@ -72,7 +72,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         protected override ITestResultParser GetTestResultParser(IExecutionContext executionContext)
         {
             var traceListener = new CommandTraceListener(executionContext);
-            return new JUnitResultParser(traceListener);
+            var featureFlagService = executionContext.GetHostContext().GetService<IFeatureFlagService>();
+            var enableJunitAttachments = featureFlagService.GetFeatureFlagState(TestResultsConstants.JUnitTestCaseAttachmentsEnabled, TestResultsConstants.TCMServiceInstanceGuid);
+            return new JUnitResultParser(traceListener, false, enableJunitAttachments);
         }
     }
 

--- a/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
+++ b/src/Agent.Worker/TestResults/Utils/TestResultsConstants.cs
@@ -22,5 +22,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
         public const string EnableFlakyCheckInAgentFeatureFlag = "TestManagement.Agent.PTR.EnableFlakyCheck";
 
         public static readonly string EnableXUnitHeirarchicalParsing = "TestManagement.PublishTestResultsTask.EnableXUnitHeirarchicalParsing";
+
+        public static readonly string JUnitTestCaseAttachmentsEnabled = "TestManagement.Server.JUnitTestCaseAttachmentsEnabled";
     }
 }


### PR DESCRIPTION
Enables a feature that is already available for Windows agents when running the exeFlow using TestResultsPublisher.exe.

This feature is controlled by the `TestManagement.Server.JUnitTestCaseAttachmentsEnabled` feature flag defined in the TCM service.
