### PR TITLE
Add the tailored deprecation message in addition to the common deprecation message

### DIFF
--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -351,6 +351,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
 
                 executionContext.Warning(deprecationMessage);
+
+                var tailoredDeprecationMessage = taskJson["tailoredDeprecationMessage"];
+
+                if (tailoredDeprecationMessage != null)
+                {
+                    executionContext.Warning(tailoredDeprecationMessage.ToString());
+                }
             }
         }
 

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -326,14 +326,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 string friendlyName = taskJson["friendlyName"].Value<string>();
                 int majorVersion = new Version(task.Version).Major;
-                string deprecationMessage = StringUtil.Loc("DeprecationMessage", friendlyName, majorVersion, task.Name);
+                string commonDeprecationMessage = StringUtil.Loc("DeprecationMessage", friendlyName, majorVersion, task.Name);
                 var removalDate = taskJson["removalDate"];
 
                 if (removalDate != null)
                 {
                     string whitespace = " ";
                     string removalDateString = removalDate.Value<DateTime>().ToString("MMMM d, yyyy");
-                    deprecationMessage += whitespace + StringUtil.Loc("DeprecationMessageRemovalDate", removalDateString);
+                    commonDeprecationMessage += whitespace + StringUtil.Loc("DeprecationMessageRemovalDate", removalDateString);
                     var helpUrl = taskJson["helpUrl"];
 
                     if (helpUrl != null)
@@ -345,14 +345,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         if (helpUrlString.StartsWith(urlPrefix))
                         {
                             string versionHelpUrl = $"{helpUrlString}-v{majorVersion}".Replace(urlPrefix, $"https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/");
-                            deprecationMessage += whitespace + StringUtil.Loc("DeprecationMessageHelpUrl", versionHelpUrl);
+                            commonDeprecationMessage += whitespace + StringUtil.Loc("DeprecationMessageHelpUrl", versionHelpUrl);
                         }
                     }
                 }
 
-                executionContext.Warning(deprecationMessage);
+                executionContext.Warning(commonDeprecationMessage);
 
-                var tailoredDeprecationMessage = taskJson["tailoredDeprecationMessage"];
+                var tailoredDeprecationMessage = taskJson["deprecationMessage"];
 
                 if (tailoredDeprecationMessage != null)
                 {


### PR DESCRIPTION
***Description:*** If the task is deprecated and this message exists in the task.json file, it will be added to the common deprecation warning. Suggested to display this message as a separate warning for better visibility.

![image](https://github.com/microsoft/azure-pipelines-agent/assets/61472718/b64502e6-ef04-49e2-82bd-1f7d9ba9df48)

![image](https://github.com/microsoft/azure-pipelines-agent/assets/61472718/662f5da4-9d0f-4a30-a27d-35d07f1622d4)
