### PR TITLE
Add possibility to get info from /usr/lib/os-release file.

### DIFF
--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -27,6 +27,8 @@ namespace Agent.Sdk
         private static OperatingSystem[] net6SupportedSystems;
         private static HttpClient httpClient = new HttpClient();
 
+        private static readonly string[] linuxReleaseFilePaths = new string[2] { "/etc/os-release", "/usr/lib/os-release" };
+
         // System.Runtime.InteropServices.OSPlatform is a struct, so it is
         // not suitable for switch statements.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1717: Only FlagsAttribute enums should have plural names")]
@@ -156,14 +158,8 @@ namespace Agent.Sdk
         {
             if (RunningOnLinux)
             {
-                if (File.Exists("/etc/os-release"))
-                {
-                    return "/etc/os-release";
-                }
-                else if (File.Exists("/usr/lib/os-release"))
-                {
-                    return "/usr/lib/os-release";
-                }
+                string releaseFilePath = linuxReleaseFilePaths.FirstOrDefault(x => File.Exists(x), null);
+                return releaseFilePath;
             }
 
             return null;

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -152,13 +152,33 @@ namespace Agent.Sdk
             }
         }
 
+        private static string GetLinuxReleaseFilePath()
+        {
+            if (RunningOnLinux)
+            {
+                if (File.Exists("/etc/os-release"))
+                {
+                    return "/etc/os-release";
+                }
+                else if (File.Exists("/usr/lib/os-release"))
+                {
+                    return "/usr/lib/os-release";
+                }
+            }
+
+            return null;
+        }
+
         private static string GetLinuxId()
         {
-            if (RunningOnLinux && File.Exists("/etc/os-release"))
+
+            string filePath = GetLinuxReleaseFilePath();
+
+            if (RunningOnLinux && filePath != null)
             {
                 Regex linuxIdRegex = new Regex("^ID\\s*=\\s*\"?(?<id>[0-9a-z._-]+)\"?");
 
-                using (StreamReader reader = new StreamReader("/etc/os-release"))
+                using (StreamReader reader = new StreamReader(filePath))
                 {
                     while (!reader.EndOfStream)
                     {
@@ -178,11 +198,14 @@ namespace Agent.Sdk
 
         private static string GetLinuxName()
         {
-            if (RunningOnLinux && File.Exists("/etc/os-release"))
+
+            string filePath = GetLinuxReleaseFilePath();
+
+            if (RunningOnLinux && filePath != null)
             {
                 Regex linuxVersionIdRegex = new Regex("^VERSION_ID\\s*=\\s*\"?(?<id>[0-9a-z._-]+)\"?");
 
-                using (StreamReader reader = new StreamReader("/etc/os-release"))
+                using (StreamReader reader = new StreamReader(filePath))
                 {
                     while (!reader.EndOfStream)
                     {
@@ -446,7 +469,7 @@ namespace Agent.Sdk
         {
             if (name == null && version == null)
             {
-                throw new Exception("You need to provide at least one not-nullable parameter");
+                throw new ArgumentNullException("You need to provide at least one not-nullable parameter");
             }
 
             if (name != null)
@@ -516,7 +539,7 @@ namespace Agent.Sdk
 
             if (!parsedVersionRegexMatch.Success)
             {
-                throw new Exception($"String {version} can't be parsed");
+                throw new FormatException($"String {version} can't be parsed");
             }
 
             string versionString = string.Format(

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -645,17 +645,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 publishTelemetryCmd.Initialize(HostContext);
                 publishTelemetryCmd.ProcessCommand(ExecutionContext, cmd);
             }
-            catch (Exception ex)            
+            catch (Exception ex) when (ex is FormatException || ex is ArgumentNullException || ex is NullReferenceException)
             {                    
-                if (ex is FormatException || ex is ArgumentNullException || ex is NullReferenceException)
-                {
-                    ExecutionContext.Debug($"ExecutionHandler telemetry wasn't published, because one of the variables has unexpected value.");
-                    ExecutionContext.Debug(ex.ToString());
-                }
-                else
-                {
-                    throw;
-                }
+                ExecutionContext.Debug($"ExecutionHandler telemetry wasn't published, because one of the variables has unexpected value.");
+                ExecutionContext.Debug(ex.ToString());
             }
         }
     }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -646,7 +646,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 publishTelemetryCmd.ProcessCommand(ExecutionContext, cmd);
             }
             catch (Exception ex) when (ex is FormatException || ex is ArgumentNullException || ex is NullReferenceException)
-            {                    
+            {
                 ExecutionContext.Debug($"ExecutionHandler telemetry wasn't published, because one of the variables has unexpected value.");
                 ExecutionContext.Debug(ex.ToString());
             }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -645,10 +645,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 publishTelemetryCmd.Initialize(HostContext);
                 publishTelemetryCmd.ProcessCommand(ExecutionContext, cmd);
             }
-            catch (NullReferenceException ex)
-            {
-                ExecutionContext.Debug($"ExecutionHandler telemetry wasn't published, because one of the variables is null");
-                ExecutionContext.Debug(ex.ToString());
+            catch (Exception ex)            
+            {                    
+                if (ex is FormatException || ex is ArgumentNullException || ex is NullReferenceException)
+                {
+                    ExecutionContext.Debug($"ExecutionHandler telemetry wasn't published, because one of the variables has unexpected value.");
+                    ExecutionContext.Debug(ex.ToString());
+                }
+                else
+                {
+                    throw;
+                }
             }
         }
     }

--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -54,8 +54,15 @@ function print_rhel6depricationmessage()
 
 if [ -e /etc/os-release ]
 then
+    filepath='/etc/os-release'
+else 
+    filepath='/usr/lib/os-release'
+fi
+
+if [ -e $filepath ]
+then
     echo "--------OS Information--------"
-    cat /etc/os-release
+    cat $filepath
     echo "------------------------------"
 
     if [ -e /etc/debian_version ]
@@ -249,10 +256,10 @@ then
         fi
     else
         # we might on OpenSUSE
-        OSTYPE=$(grep ^ID_LIKE /etc/os-release | cut -f2 -d=)
+        OSTYPE=$(grep ^ID_LIKE $filepath | cut -f2 -d=)
         if [ -z $OSTYPE ]
         then
-            OSTYPE=$(grep ^ID /etc/os-release | cut -f2 -d=)
+            OSTYPE=$(grep ^ID $filepath | cut -f2 -d=)
         fi
         echo $OSTYPE
 
@@ -306,7 +313,7 @@ then
                 exit 1
             fi
         else
-            echo "Can't detect current OS type based on /etc/os-release."
+            echo "Can't detect current OS type based on $filepath."
             print_errormessage
             exit 1
         fi


### PR DESCRIPTION
**Describtion**:
As in Linux specs, the release information might be placed not only in /etc/os-release but in /usr/lib/os-release [as well](https://www.linux.org/docs/man5/os-release.html), and the file /etc/os-release might not exist(e.g. fresh arch linux I'm my case).
The PR allows taking VERSION_ID and ID from /usr/lib/os-release if /etc/os-release is not presented. 
 Fixed failed step if the version is not provided for telemetry publishing

**Related WI**: 2048785

**Testing**:
Testing locally on Arch Linux with missing /etc/os-release link