### PR TITLE
Support variables where case is preserved

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -388,7 +388,7 @@ namespace Agent.Plugins.Repository
             foreach (var variable in executionContext.Variables)
             {
                 // Add the variable using the formatted name.
-                string formattedKey = VarUtil.ConvertToEnvVariableFormat(variable.Key);
+                string formattedKey = VarUtil.ConvertToEnvVariableFormat(variable.Key, preserveCase: false);
                 gitEnv[formattedKey] = variable.Value?.Value ?? string.Empty;
             }
 

--- a/src/Agent.Worker/Build/GitCommandManager.cs
+++ b/src/Agent.Worker/Build/GitCommandManager.cs
@@ -749,10 +749,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             }
 
             // Add the public variables.
-            foreach (KeyValuePair<string, string> pair in context.Variables.Public)
+            foreach (Variable variable in context.Variables.Public)
             {
                 // Add the variable using the formatted name.
-                string formattedKey = VarUtil.ConvertToEnvVariableFormat(pair.Key);
+                string formattedName = VarUtil.ConvertToEnvVariableFormat(variable.Name, variable.PreserveCase);
 
                 // Skip any GIT_TRACE variable since GIT_TRACE will affect ouput from every git command.
                 // This will fail the parse logic for detect git version, remote url, etc.
@@ -761,12 +761,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 //      git version
                 //      11:39:58.295959 git.c:371               trace: built-in: git 'version'
                 //      git version 2.11.1.windows.1
-                if (formattedKey == "GIT_TRACE" || formattedKey.StartsWith("GIT_TRACE_"))
+                if (formattedName == "GIT_TRACE" || formattedName.StartsWith("GIT_TRACE_"))
                 {
                     continue;
                 }
 
-                _gitEnv[formattedKey] = pair.Value ?? string.Empty;
+                _gitEnv[formattedName] = variable.Value ?? string.Empty;
             }
 
             return _gitEnv;

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         // timeline record update methods
         void Start(string currentOperation = null);
         TaskResult Complete(TaskResult? result = null, string currentOperation = null, string resultCode = null);
-        void SetVariable(string name, string value, bool isSecret = false, bool isOutput = false, bool isFilePath = false, bool isReadOnly = false);
+        void SetVariable(string name, string value, bool isSecret = false, bool isOutput = false, bool isFilePath = false, bool isReadOnly = false, bool preserveCase = false);
         void SetTimeout(TimeSpan? timeout);
         void AddIssue(Issue issue);
         void Progress(int percentage, string currentOperation = null);
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return Result.Value;
         }
 
-        public void SetVariable(string name, string value, bool isSecret = false, bool isOutput = false, bool isFilePath = false, bool isReadOnly = false)
+        public void SetVariable(string name, string value, bool isSecret = false, bool isOutput = false, bool isFilePath = false, bool isReadOnly = false, bool preserveCase = false)
         {
             ArgUtil.NotNullOrEmpty(name, nameof(name));
 
@@ -353,11 +353,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 _jobServerQueue.QueueTimelineRecordUpdate(_mainTimelineId, _record);
 
                 ArgUtil.NotNullOrEmpty(_record.RefName, nameof(_record.RefName));
-                Variables.Set($"{_record.RefName}.{name}", value, secret: isSecret, readOnly: (isOutput || isReadOnly));
+                Variables.Set($"{_record.RefName}.{name}", value, secret: isSecret, readOnly: (isOutput || isReadOnly), preserveCase: preserveCase);
             }
             else
             {
-                Variables.Set(name, value, secret: isSecret, readOnly: isReadOnly);
+                Variables.Set(name, value, secret: isSecret, readOnly: isReadOnly, preserveCase: preserveCase);
             }
         }
 

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                     foreach (KeyValuePair<string, string> pair in endpoint.Authorization.Parameters)
                     {
                         AddEnvironmentVariable(
-                            key: $"ENDPOINT_AUTH_PARAMETER_{partialKey}_{VarUtil.ConvertToEnvVariableFormat(pair.Key)}",
+                            key: $"ENDPOINT_AUTH_PARAMETER_{partialKey}_{VarUtil.ConvertToEnvVariableFormat(pair.Key, preserveCase: false)}",
                             value: pair.Value);
                     }
                 }
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                         foreach (KeyValuePair<string, string> pair in endpoint.Data)
                         {
                             AddEnvironmentVariable(
-                                key: $"ENDPOINT_DATA_{partialKey}_{VarUtil.ConvertToEnvVariableFormat(pair.Key)}",
+                                key: $"ENDPOINT_DATA_{partialKey}_{VarUtil.ConvertToEnvVariableFormat(pair.Key, preserveCase: false)}",
                                 value: pair.Value);
                         }
                     }
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             foreach (KeyValuePair<string, string> pair in Inputs)
             {
                 AddEnvironmentVariable(
-                    key: $"INPUT_{VarUtil.ConvertToEnvVariableFormat(pair.Key)}",
+                    key: $"INPUT_{VarUtil.ConvertToEnvVariableFormat(pair.Key, preserveCase: false)}",
                     value: pair.Value);
             }
         }

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -185,20 +185,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
             // Add the public variables.
             var names = new List<string>();
-            foreach (KeyValuePair<string, string> pair in RuntimeVariables.Public)
+            foreach (Variable variable in RuntimeVariables.Public)
             {
                 // Add "agent.jobstatus" using the unformatted name and formatted name.
-                if (string.Equals(pair.Key, Constants.Variables.Agent.JobStatus, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(variable.Name, Constants.Variables.Agent.JobStatus, StringComparison.OrdinalIgnoreCase))
                 {
-                    AddEnvironmentVariable(pair.Key, pair.Value);
+                    AddEnvironmentVariable(variable.Name, variable.Value);
                 }
 
                 // Add the variable using the formatted name.
-                string formattedKey = VarUtil.ConvertToEnvVariableFormat(pair.Key);
-                AddEnvironmentVariable(formattedKey, pair.Value);
+                string formattedName = VarUtil.ConvertToEnvVariableFormat(variable.Name, variable.PreserveCase);
+                AddEnvironmentVariable(formattedName, variable.Value);
 
                 // Store the name.
-                names.Add(pair.Key ?? string.Empty);
+                names.Add(variable.Name ?? string.Empty);
             }
 
             // Add the public variable names.
@@ -211,14 +211,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             {
                 // Add the secret variables.
                 var secretNames = new List<string>();
-                foreach (KeyValuePair<string, string> pair in RuntimeVariables.Private)
+                foreach (Variable variable in RuntimeVariables.Private)
                 {
                     // Add the variable using the formatted name.
-                    string formattedKey = VarUtil.ConvertToEnvVariableFormat(pair.Key);
-                    AddEnvironmentVariable($"SECRET_{formattedKey}", pair.Value);
+                    string formattedName = VarUtil.ConvertToEnvVariableFormat(variable.Name, variable.PreserveCase);
+                    AddEnvironmentVariable($"SECRET_{formattedName}", variable.Value);
 
                     // Store the name.
-                    secretNames.Add(pair.Key ?? string.Empty);
+                    secretNames.Add(variable.Name ?? string.Empty);
                 }
 
                 // Add the secret variable names.
@@ -248,18 +248,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             Trace.Entering();
             ArgUtil.NotNull(ExecutionContext.TaskVariables, nameof(ExecutionContext.TaskVariables));
 
-            foreach (KeyValuePair<string, string> pair in ExecutionContext.TaskVariables.Public)
+            foreach (Variable variable in ExecutionContext.TaskVariables.Public)
             {
                 // Add the variable using the formatted name.
-                string formattedKey = VarUtil.ConvertToEnvVariableFormat(pair.Key);
-                AddEnvironmentVariable($"VSTS_TASKVARIABLE_{formattedKey}", pair.Value);
+                string formattedKey = VarUtil.ConvertToEnvVariableFormat(variable.Name, variable.PreserveCase);
+                AddEnvironmentVariable($"VSTS_TASKVARIABLE_{formattedKey}", variable.Value);
             }
 
-            foreach (KeyValuePair<string, string> pair in ExecutionContext.TaskVariables.Private)
+            foreach (Variable variable in ExecutionContext.TaskVariables.Private)
             {
                 // Add the variable using the formatted name.
-                string formattedKey = VarUtil.ConvertToEnvVariableFormat(pair.Key);
-                AddEnvironmentVariable($"VSTS_TASKVARIABLE_{formattedKey}", pair.Value);
+                string formattedKey = VarUtil.ConvertToEnvVariableFormat(variable.Name, variable.PreserveCase);
+                AddEnvironmentVariable($"VSTS_TASKVARIABLE_{formattedKey}", variable.Value);
             }
         }
 

--- a/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
+++ b/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
@@ -347,13 +347,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             // push all variable.
             foreach (var variable in ExecutionContext.Variables.Public.Concat(ExecutionContext.Variables.Private))
             {
-                AddEnvironmentVariable("VSTSPSHOSTVAR_" + variable.Key, variable.Value);
+                AddEnvironmentVariable("VSTSPSHOSTVAR_" + variable.Name, variable.Value);
             }
 
             // push all public variable.
             foreach (var variable in ExecutionContext.Variables.Public)
             {
-                AddEnvironmentVariable("VSTSPSHOSTPUBVAR_" + variable.Key, variable.Value);
+                AddEnvironmentVariable("VSTSPSHOSTPUBVAR_" + variable.Name, variable.Value);
             }
 
             // push all endpoints

--- a/src/Agent.Worker/Handlers/PowerShellExeHandler.cs
+++ b/src/Agent.Worker/Handlers/PowerShellExeHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             // Add the access token to the environment variables, if the access token is set.
             if (!string.IsNullOrEmpty(AccessToken))
             {
-                string formattedKey = VarUtil.ConvertToEnvVariableFormat(Constants.Variables.System.AccessToken);
+                string formattedKey = VarUtil.ConvertToEnvVariableFormat(Constants.Variables.System.AccessToken, preserveCase: false);
                 AddEnvironmentVariable(formattedKey, AccessToken);
             }
 

--- a/src/Agent.Worker/Handlers/ProcessHandler.cs
+++ b/src/Agent.Worker/Handlers/ProcessHandler.cs
@@ -272,7 +272,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private void GenerateScriptFile(string cmdExe, string command, string arguments)
         {
             var scriptId = Guid.NewGuid().ToString();
-            string inputArgsEnvVarName = VarUtil.ConvertToEnvVariableFormat("AGENT_PH_ARGS_" + scriptId[..8]);
+            string inputArgsEnvVarName = VarUtil.ConvertToEnvVariableFormat("AGENT_PH_ARGS_" + scriptId[..8], preserveCase: false);
 
             System.Environment.SetEnvironmentVariable(inputArgsEnvVarName, arguments);
 

--- a/src/Agent.Worker/Release/AgentUtilities.cs
+++ b/src/Agent.Worker/Release/AgentUtilities.cs
@@ -12,21 +12,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
     public static class AgentUtilities
     {
         // Move this to Agent.Common.Util
-        public static string GetPrintableEnvironmentVariables(IEnumerable<KeyValuePair<string, string>> variables)
+        public static string GetPrintableEnvironmentVariables(IEnumerable<Variable> variables)
         {
             StringBuilder builder = new StringBuilder();
 
             if (variables != null)
             {
-                var sortedVariables = variables.OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase);
-                foreach (var pair in sortedVariables)
+                var sortedVariables = variables.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase);
+                foreach (var variable in sortedVariables)
                 {
-                    string varName = VarUtil.ConvertToEnvVariableFormat(pair.Key);
+                    string varName = VarUtil.ConvertToEnvVariableFormat(variable.Name, variable.PreserveCase);
                     builder.AppendFormat(
                         "{0}\t\t\t\t[{1}] --> [{2}]",
                         Environment.NewLine,
                         varName,
-                        pair.Value);
+                        variable.Value);
                 }
             }
 

--- a/src/Agent.Worker/TaskCommandExtension.cs
+++ b/src/Agent.Worker/TaskCommandExtension.cs
@@ -599,6 +599,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Boolean.TryParse(isReadOnlyValue, out isReadOnly);
             }
 
+            String preserveCaseValue;
+            Boolean preserveCase = false;
+            if (eventProperties.TryGetValue(TaskSetVariableEventProperties.PreserveCase, out preserveCaseValue))
+            {
+                Boolean.TryParse(preserveCaseValue, out preserveCase);
+            }
+
             if (context.Variables.IsReadOnly(name))
             {
                 // Check FF. If it is on then throw, otherwise warn
@@ -631,7 +638,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             var checker = context.GetHostContext().GetService<ITaskRestrictionsChecker>();
             if (checker.CheckSettableVariable(context, name))
             {
-                context.SetVariable(name, data, isSecret: isSecret, isOutput: isOutput, isReadOnly: isReadOnly);
+                context.SetVariable(name, data, isSecret: isSecret, isOutput: isOutput, isReadOnly: isReadOnly, preserveCase: preserveCase);
             }
         }
     }
@@ -686,6 +693,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 Boolean.TryParse(isReadOnlyValue, out isReadOnly);
             }
 
+            String preserveCaseValue;
+            Boolean preserveCase = false;
+            if (eventProperties.TryGetValue(TaskSetVariableEventProperties.PreserveCase, out preserveCaseValue))
+            {
+                Boolean.TryParse(preserveCaseValue, out preserveCase);
+            }
+
             if (context.TaskVariables.IsReadOnly(name))
             {
                 // Check FF. If it is on then throw, otherwise warn
@@ -710,7 +724,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
             }
 
-            context.TaskVariables.Set(name, data, secret: isSecret, readOnly: isReadOnly);
+            context.TaskVariables.Set(name, data, secret: isSecret, readOnly: isReadOnly, preserveCase: preserveCase);
         }
     }
 
@@ -827,6 +841,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public static readonly String IsSecret = "issecret";
         public static readonly String IsOutput = "isoutput";
         public static readonly String IsReadOnly = "isreadonly";
+        public static readonly String PreserveCase = "preservecase";
     }
 
     internal static class TaskCompleteEventProperties

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -6,10 +6,8 @@ using Agent.Sdk.Knob;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Threading;
 using Microsoft.TeamFoundation.DistributedTask.Expressions;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
@@ -157,11 +155,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         Dictionary<string, VariableValue> variableCopy = new Dictionary<string, VariableValue>(StringComparer.OrdinalIgnoreCase);
                         foreach (var publicVar in ExecutionContext.Variables.Public)
                         {
-                            variableCopy[publicVar.Key] = new VariableValue(stepTarget.TranslateToHostPath(publicVar.Value));
+                            variableCopy[publicVar.Name] = new VariableValue(stepTarget.TranslateToHostPath(publicVar.Value));
                         }
                         foreach (var secretVar in ExecutionContext.Variables.Private)
                         {
-                            variableCopy[secretVar.Key] = new VariableValue(stepTarget.TranslateToHostPath(secretVar.Value), true);
+                            variableCopy[secretVar.Name] = new VariableValue(stepTarget.TranslateToHostPath(secretVar.Value), true);
                         }
 
                         List<string> expansionWarnings;

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 return _expanded.Values
                     .Where(x => !x.Secret)
-                    .Select(x => new Variable(x.Name, DefaultStringTranslator(x.Value), x.Secret, x.ReadOnly, x.PreserveCase));
+                    .Select(x => new Variable(x.Name, StringTranslator(x.Value), x.Secret, x.ReadOnly, x.PreserveCase));
             }
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 return _expanded.Values
                     .Where(x => x.Secret)
-                    .Select(x => new Variable(x.Name, DefaultStringTranslator(x.Value), x.Secret, x.ReadOnly, x.PreserveCase));
+                    .Select(x => new Variable(x.Name, StringTranslator(x.Value), x.Secret, x.ReadOnly, x.PreserveCase));
             }
         }
 

--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -11,9 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Agent.Sdk.SecretMasking;
 using BuildWebApi = Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.TeamFoundation.DistributedTask.Logging;
 using Newtonsoft.Json.Linq;
-using Agent.Sdk.Util;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker
 {
@@ -60,23 +58,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return val;
         }
 
-        public IEnumerable<KeyValuePair<string, string>> Public
+        public IEnumerable<Variable> Public
         {
             get
             {
                 return _expanded.Values
                     .Where(x => !x.Secret)
-                    .Select(x => new KeyValuePair<string, string>(x.Name, StringTranslator(x.Value)));
+                    .Select(x => new Variable(x.Name, DefaultStringTranslator(x.Value), x.Secret, x.ReadOnly, x.PreserveCase));
             }
         }
 
-        public IEnumerable<KeyValuePair<string, string>> Private
+        public IEnumerable<Variable> Private
         {
             get
             {
                 return _expanded.Values
                     .Where(x => x.Secret)
-                    .Select(x => new KeyValuePair<string, string>(x.Name, StringTranslator(x.Value)));
+                    .Select(x => new Variable(x.Name, DefaultStringTranslator(x.Value), x.Secret, x.ReadOnly, x.PreserveCase));
             }
         }
 
@@ -102,7 +100,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 if (!string.IsNullOrWhiteSpace(variable.Key))
                 {
-                    variables.Add(new Variable(variable.Key, variable.Value.Value, variable.Value.IsSecret, variable.Value.IsReadOnly));
+                    variables.Add(new Variable(variable.Key, variable.Value.Value, variable.Value.IsSecret, variable.Value.IsReadOnly, preserveCase: false));
                 }
             }
 
@@ -407,7 +405,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
         }
 
-        public void Set(string name, string val, bool secret = false, bool readOnly = false)
+        public void Set(string name, string val, bool secret = false, bool readOnly = false, bool preserveCase = false)
         {
             // Validate the args.
             ArgUtil.NotNullOrEmpty(name, nameof(name));
@@ -440,7 +438,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 // Store the value as-is to the expanded dictionary and the non-expanded dictionary.
                 // It is not expected that the caller needs to store an non-expanded value and then
                 // retrieve the expanded value in the same context.
-                var variable = new Variable(name, val, secret, readOnly);
+                var variable = new Variable(name, val, secret, readOnly, preserveCase);
                 _expanded[name] = variable;
                 _nonexpanded[name] = variable;
                 _trace.Verbose($"Set '{name}' = '{val}'");
@@ -492,6 +490,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 {
                     bool secret = _nonexpanded[name].Secret;
                     bool readOnly = _nonexpanded[name].ReadOnly;
+                    bool preserveCase = _nonexpanded[name].PreserveCase;
                     _trace.Verbose($"Processing expansion for variable: '{name}'");
 
                     // This algorithm handles recursive replacement using a stack.
@@ -593,7 +592,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                 }
 
                                 // Set the expanded value.
-                                expanded[state.Name] = new Variable(state.Name, state.Value, secret, readOnly);
+                                expanded[state.Name] = new Variable(state.Name, state.Value, secret, readOnly, preserveCase);
                                 _trace.Verbose($"Set '{state.Name}' = '{state.Value}'");
                             }
 
@@ -632,11 +631,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             foreach (var var in this.Public)
             {
-                target[var.Key] = translation(var.Value);
+                target[var.Name] = translation(var.Value);
             }
             foreach (var var in this.Private)
             {
-                target[var.Key] = new VariableValue(translation(var.Value), true);
+                target[var.Name] = new VariableValue(translation(var.Value), true);
             }
         }
 
@@ -672,14 +671,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         public bool Secret { get; private set; }
         public string Value { get; private set; }
         public bool ReadOnly { get; private set; }
+        public bool PreserveCase { get; private set; }
 
-        public Variable(string name, string value, bool secret, bool readOnly)
+        public Variable(string name, string value, bool secret, bool readOnly, bool preserveCase)
         {
             ArgUtil.NotNullOrEmpty(name, nameof(name));
             Name = name;
             Value = value ?? string.Empty;
             Secret = secret;
             ReadOnly = readOnly;
+            PreserveCase = preserveCase;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Services.Agent/Util/VarUtil.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Util/VarUtil.cs
@@ -70,10 +70,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         /// Example: env.var -> ENV_VAR
         /// </summary>
         /// <param name="value"></param>
+        /// <param name="preserveCase"></param>
         /// <returns></returns>
-        public static string ConvertToEnvVariableFormat(string value)
+        public static string ConvertToEnvVariableFormat(string value, bool preserveCase = false)
         {
-            return value?.Replace('.', '_').Replace(' ', '_').ToUpperInvariant() ?? string.Empty;
+            string envVar = value?.Replace('.', '_').Replace(' ', '_') ?? string.Empty;
+            return preserveCase ? envVar : envVar.ToUpperInvariant();
         }
 
         public static JToken ExpandEnvironmentVariables(IHostContext context, JToken target)

--- a/src/Microsoft.VisualStudio.Services.Agent/Util/VarUtil.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Util/VarUtil.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         /// <param name="value"></param>
         /// <param name="preserveCase"></param>
         /// <returns></returns>
-        public static string ConvertToEnvVariableFormat(string value, bool preserveCase = false)
+        public static string ConvertToEnvVariableFormat(string value, bool preserveCase)
         {
             string envVar = value?.Replace('.', '_').Replace(' ', '_') ?? string.Empty;
             return preserveCase ? envVar : envVar.ToUpperInvariant();

--- a/src/Test/L0/Util/VarUtilL0.cs
+++ b/src/Test/L0/Util/VarUtilL0.cs
@@ -9,19 +9,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
     public class VarUtilL0
     {
         [Theory]
-        [InlineData("test.value1", "TEST_VALUE1")]
-        [InlineData("test value2", "TEST_VALUE2")]
-        [InlineData("tesT vaLue.3", "TEST_VALUE_3")]
-        [InlineData(".tesT vaLue 4", "_TEST_VALUE_4")]
-        [InlineData("TEST_VALUE_5", "TEST_VALUE_5")]
-        [InlineData(".. TEST   VALUE. 6", "___TEST___VALUE__6")]
-        [InlineData(null, "")]
-        [InlineData("", "")]
-        [InlineData(" ", "_")]
-        [InlineData(".", "_")]
-        public void TestConverterToEnvVariableFormat(string input, string expected)
+        [InlineData("test.value1", "TEST_VALUE1", false)]
+        [InlineData("test value2", "TEST_VALUE2", false)]
+        [InlineData("tesT vaLue.3", "TEST_VALUE_3", false)]
+        [InlineData(".tesT vaLue 4", "_TEST_VALUE_4", false)]
+        [InlineData("TEST_VALUE_5", "TEST_VALUE_5", false)]
+        [InlineData(".. TEST   VALUE. 6", "___TEST___VALUE__6", false)]
+        [InlineData(null, "", false)]
+        [InlineData("", "", false)]
+        [InlineData(" ", "_", false)]
+        [InlineData(".", "_", false)]
+        [InlineData("TestValue", "TestValue", true)]
+        [InlineData("Test.Value", "Test_Value", true)]
+        public void TestConverterToEnvVariableFormat(string input, string expected, bool preserveCase)
         {
-            var result = VarUtil.ConvertToEnvVariableFormat(input);
+            var result = VarUtil.ConvertToEnvVariableFormat(input, preserveCase);
 
             Assert.Equal(expected, result);
         }

--- a/src/Test/L0/Worker/Build/BuildJobExtensionL0.cs
+++ b/src/Test/L0/Worker/Build/BuildJobExtensionL0.cs
@@ -182,8 +182,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
             _ec.Setup(x => x.JobSettings).Returns(jobSettings);
 
             _ec.Setup(x =>
-                x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
-                .Callback((string varName, string varValue, bool isSecret, bool isOutput, bool isFilePath, bool isReadOnly) => { _variables.Set(varName, varValue, false); });
+                x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Callback((string varName, string varValue, bool isSecret, bool isOutput, bool isFilePath, bool isReadOnly, bool preserveCase) => { _variables.Set(varName, varValue, false); });
 
             _extensionManager.Setup(x => x.GetExtensions<ISourceProvider>())
                 .Returns(new List<ISourceProvider> { _sourceProvider.Object });

--- a/src/Test/L0/Worker/PluginInternalUpdateRepositoryPathCommandL0.cs
+++ b/src/Test/L0/Worker/PluginInternalUpdateRepositoryPathCommandL0.cs
@@ -169,8 +169,8 @@ namespace Test.L0.Worker
             _ec.Setup(x => x.Variables).Returns(_variables);
             _ec.Setup(x => x.Repositories).Returns(_repositories);
             _ec.Setup(x => x.GetHostContext()).Returns(hc);
-            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
-                .Callback<string, string, bool, bool, bool, bool>((name, value, secret, b2, b3, readOnly) => _variables.Set(name, value, secret, readOnly));
+            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Callback<string, string, bool, bool, bool, bool, bool>((name, value, secret, b2, b3, readOnly, preserveCase) => _variables.Set(name, value, secret, readOnly, preserveCase));
 
             if (isMultiCheckout)
             {

--- a/src/Test/L0/Worker/Release/AgentUtlitiesL0.cs
+++ b/src/Test/L0/Worker/Release/AgentUtlitiesL0.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using Microsoft.VisualStudio.Services.Agent.Worker;
 using Microsoft.VisualStudio.Services.Agent.Worker.Release;
 
 using Xunit;
@@ -17,16 +17,16 @@ namespace Test.L0.Worker.Release
         [Trait("Category", "Common")]
         public void VetGetPrintableEnvironmentVariables()
         {
-            List<KeyValuePair<string, string>> variables = new List<KeyValuePair<string, string>>
-                                                                      {
-                                                                          new KeyValuePair<string, string>("key.B", "value1"),
-                                                                          new KeyValuePair<string, string>("key A", "value2"),
-                                                                          new KeyValuePair<string, string>("keyC", "value3")
-                                                                      };
+            List<Variable> variables = new List<Variable>
+            {
+                new Variable("key.B", "value1", secret: false, readOnly: false, preserveCase: false),
+                new Variable("key A", "value2", secret: false, readOnly: false, preserveCase: false),
+                new Variable("keyC", "value3", secret: false, readOnly: false, preserveCase: false),
+            };
             string expectedResult =
-                $"{Environment.NewLine}\t\t\t\t[{FormatVariable(variables[1].Key)}] --> [{variables[1].Value}]"
-                + $"{Environment.NewLine}\t\t\t\t[{FormatVariable(variables[0].Key)}] --> [{variables[0].Value}]"
-                + $"{Environment.NewLine}\t\t\t\t[{FormatVariable(variables[2].Key)}] --> [{variables[2].Value}]";
+                $"{Environment.NewLine}\t\t\t\t[{FormatVariable(variables[1].Name)}] --> [{variables[1].Value}]"
+                + $"{Environment.NewLine}\t\t\t\t[{FormatVariable(variables[0].Name)}] --> [{variables[0].Value}]"
+                + $"{Environment.NewLine}\t\t\t\t[{FormatVariable(variables[2].Name)}] --> [{variables[2].Value}]";
 
             string result = AgentUtilities.GetPrintableEnvironmentVariables(variables);
             Assert.Equal(expectedResult, result);

--- a/src/Test/L0/Worker/Release/ReleaseJobExtensionL0.cs
+++ b/src/Test/L0/Worker/Release/ReleaseJobExtensionL0.cs
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Release
             hc.SetSingleton(_extensionManager.Object);
             hc.SetSingleton(_configurationStore.Object);
             _ec.Setup(x => x.Variables).Returns(_variables);
-            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>())).Callback((string varName, string varValue, bool isSecret, bool isOutput, bool isFilePath, bool isReadOnly) => { _variables.Set(varName, varValue, false); });
+            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>())).Callback((string varName, string varValue, bool isSecret, bool isOutput, bool isFilePath, bool isReadOnly, bool preserveCase) => { _variables.Set(varName, varValue, false); });
             _extensionManager.Setup(x => x.GetExtensions<ISourceProvider>())
                 .Returns(new List<ISourceProvider> { _sourceProvider.Object });
             _sourceProvider.Setup(x => x.RepositoryType).Returns(RepositoryTypes.TfsGit);

--- a/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
+++ b/src/Test/L0/Worker/SetVariableRestrictionsL0.cs
@@ -266,8 +266,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             _ec.Setup(x => x.Restrictions).Returns(new List<TaskRestrictions>());
             _ec.Setup(x => x.GetHostContext()).Returns(hc);
             _ec.Setup(x => x.Variables).Returns(_variables);
-            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
-                .Callback<string, string, bool, bool, bool, bool>((name, value, secret, b2, b3, readOnly) => _variables.Set(name, value, secret, readOnly));
+            _ec.Setup(x => x.SetVariable(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Callback<string, string, bool, bool, bool, bool, bool>((name, value, secret, b2, b3, readOnly, preserveCase) => _variables.Set(name, value, secret, readOnly, preserveCase));
             _ec.Setup(x => x.AddIssue(It.IsAny<Issue>()))
                 .Callback<Issue>((issue) =>
                     {

--- a/src/Test/L0/Worker/VariablesL0.cs
+++ b/src/Test/L0/Worker/VariablesL0.cs
@@ -30,12 +30,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var variables = new Variables(hc, copy, out warnings);
 
                 // Act.
-                KeyValuePair<string, string>[] publicVariables = variables.Public.ToArray();
+                Variable[] publicVariables = variables.Public.ToArray();
 
                 // Assert.
                 Assert.Equal(0, warnings.Count);
                 Assert.Equal(1, publicVariables.Length);
-                Assert.Equal("MyPublicVariable", publicVariables[0].Key);
+                Assert.Equal("MyPublicVariable", publicVariables[0].Name);
                 Assert.Equal("My public value", publicVariables[0].Value);
                 Assert.Equal("My secret value", variables.Get("MySecretName"));
             }
@@ -391,12 +391,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 var variables = new Variables(hc, copy, out warnings);
 
                 // Act.
-                KeyValuePair<string, string>[] publicVariables = variables.Public.ToArray();
+                Variable[] publicVariables = variables.Public.ToArray();
 
                 // Assert.
                 Assert.Equal(0, warnings.Count);
                 Assert.Equal(1, publicVariables.Length);
-                Assert.Equal("MyPublicVariable", publicVariables[0].Key);
+                Assert.Equal("MyPublicVariable", publicVariables[0].Name);
                 Assert.Equal("My public value", publicVariables[0].Value);
             }
         }


### PR DESCRIPTION
By default, the agent will convert set variables to uppercase when creating the environment variables for child processes. This change adds optional support to preserve the casing used on a variable.

Environment variable lookup differs by platform and on Linux/Mac environment variables are case-sensitive. Normally this works without issue, but there are corner cases where the env var being read is not all upper case and users need to manually map these in. While a task's environment variable configuration can be used to work around this, if there are many tasks that need this set managing these can become cumbersome. And with auto-injected tasks or pipeline templates it may not be possible to modify the pipeline source to set environment variables correctly. In general, there's no global mechanism to control how environment variables are mapped into child processes, and certainly no mechanism for tasks to do this at runtime.

https://github.com/microsoft/azure-pipelines-agent/issues/805 https://github.com/microsoft/azure-pipelines-agent/issues/1645 https://github.com/microsoft/azure-pipelines-agent/issues/3514