### PR TITLE
Change CI timeout to the default value (10 minutes)

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -94,7 +94,7 @@ stages:
               --projectUrl "$(CANARY_PROJECT_URL)" \
               --pipelineId "$(CANARY_PIPELINE_ID)" \
               --token "$(CANARY_PAT)" \
-              --templateParameters "{ \"branch\": \"${branch}\", \"template_timeout\": 3 }"
+              --templateParameters "{ \"branch\": \"${branch}\" }"
         displayName: Test Proxy Agent
 
   # Windows (x64)


### PR DESCRIPTION
***Description:*** We have to increase the timeout for the agent end-to-end test in the CI since tests for artifacts tasks have been added to it. The timeout is set to the default value (10 minutes).
