### PR TITLE
Revert "Implemented option to store token in named container"

### DIFF
--- a/src/Agent.Listener/Configuration.Windows/RSAEncryptedFileKeyManager.cs
+++ b/src/Agent.Listener/Configuration.Windows/RSAEncryptedFileKeyManager.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.Services.Agent.Util;
-using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.VisualStudio.Services.Agent.Util;
 
 namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 {
@@ -14,61 +13,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         private string _keyFile;
         private IHostContext _context;
 
-        public RSACryptoServiceProvider CreateKey(bool enableAgentKeyStoreInNamedContainer)
-        {
-            if (enableAgentKeyStoreInNamedContainer)
-            {
-                return CreateKeyStoreKeyInNamedContainer();
-            }
-            else
-            {
-                return CreateKeyStoreKeyInFile();
-            }
-        }
-
-        private RSACryptoServiceProvider CreateKeyStoreKeyInNamedContainer()
-        {
-            RSACryptoServiceProvider rsa;
-            if (!File.Exists(_keyFile))
-            {
-                Trace.Info("Creating new RSA key using 2048-bit key length");
-
-                CspParameters Params = new CspParameters();
-                Params.KeyContainerName = "AgentKeyContainer" + Guid.NewGuid().ToString();
-                Params.Flags |= CspProviderFlags.UseNonExportableKey | CspProviderFlags.UseMachineKeyStore;
-                rsa = new RSACryptoServiceProvider(2048, Params);
-
-                // Now write the parameters to disk
-                SaveParameters(default(RSAParameters), Params.KeyContainerName);                
-                Trace.Info("Successfully saved containerName to file {0} in container {1}", _keyFile, Params.KeyContainerName);
-            }
-            else
-            {
-                Trace.Info("Found existing RSA key parameters file {0}", _keyFile);
-
-                var result = LoadParameters();
-
-                if(string.IsNullOrEmpty(result.containerName))
-                {
-                    Trace.Info("Container name not present; reading RSA key from file");
-                    return CreateKeyStoreKeyInFile();
-                }
-
-                CspParameters Params = new CspParameters();
-                Params.KeyContainerName = result.containerName;
-                Params.Flags |= CspProviderFlags.UseNonExportableKey | CspProviderFlags.UseMachineKeyStore;
-                rsa = new RSACryptoServiceProvider(Params);
-            }
-
-            return rsa;
-
-            // References:
-            // https://stackoverflow.com/questions/2274596/how-to-store-a-public-key-in-a-machine-level-rsa-key-container
-            // https://social.msdn.microsoft.com/Forums/en-US/e3902420-3a82-42cf-a4a3-de230ebcea56/how-to-store-a-public-key-in-a-machinelevel-rsa-key-container?forum=netfxbcl
-            // https://security.stackexchange.com/questions/234477/windows-certificates-where-is-private-key-located
-        }
-
-        private RSACryptoServiceProvider CreateKeyStoreKeyInFile()
+        public RSACryptoServiceProvider CreateKey()
         {
             RSACryptoServiceProvider rsa = null;
             if (!File.Exists(_keyFile))
@@ -78,23 +23,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 rsa = new RSACryptoServiceProvider(2048);
 
                 // Now write the parameters to disk
-                SaveParameters(rsa.ExportParameters(true), string.Empty);
+                SaveParameters(rsa.ExportParameters(true));
                 Trace.Info("Successfully saved RSA key parameters to file {0}", _keyFile);
             }
             else
             {
                 Trace.Info("Found existing RSA key parameters file {0}", _keyFile);
 
-                var result = LoadParameters();
-
-                if(!string.IsNullOrEmpty(result.containerName))
-                {
-                    Trace.Info("Keyfile has ContainerName, so we must read from named container");
-                    return CreateKeyStoreKeyInNamedContainer();
-                }
-
                 rsa = new RSACryptoServiceProvider();
-                rsa.ImportParameters(result.rsaParameters);
+                rsa.ImportParameters(LoadParameters());
             }
 
             return rsa;
@@ -109,19 +46,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
         }
 
-        public RSACryptoServiceProvider GetKey(bool enableAgentKeyStoreInNamedContainer)
-        {
-            if (enableAgentKeyStoreInNamedContainer)
-            {
-                return GetKeyFromNamedContainer();
-            }
-            else
-            {
-                return GetKeyFromFile();
-            }
-        }
-
-        private RSACryptoServiceProvider GetKeyFromNamedContainer()
+        public RSACryptoServiceProvider GetKey()
         {
             if (!File.Exists(_keyFile))
             {
@@ -129,54 +54,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
 
             Trace.Info("Loading RSA key parameters from file {0}", _keyFile);
-
-            var result = LoadParameters();
-
-            if (string.IsNullOrEmpty(result.containerName))
-            {
-                return GetKeyFromFile();
-            }
-
-            CspParameters Params = new CspParameters();
-            Params.KeyContainerName = result.containerName;
-            Params.Flags |= CspProviderFlags.UseNonExportableKey | CspProviderFlags.UseMachineKeyStore;
-            var rsa = new RSACryptoServiceProvider(Params);
-            return rsa;
-        }
-
-        private RSACryptoServiceProvider GetKeyFromFile()
-        {
-            if (!File.Exists(_keyFile))
-            {
-                throw new CryptographicException(StringUtil.Loc("RSAKeyFileNotFound", _keyFile));
-            }
-
-            Trace.Info("Loading RSA key parameters from file {0}", _keyFile);
-
-            var result = LoadParameters();
-
-            if(!string.IsNullOrEmpty(result.containerName))
-            {
-                Trace.Info("Keyfile has ContainerName, reading from NamedContainer");
-                return GetKeyFromNamedContainer();
-            }
 
             var rsa = new RSACryptoServiceProvider();
-            rsa.ImportParameters(result.rsaParameters);
+            rsa.ImportParameters(LoadParameters());
             return rsa;
         }
 
-        private (string containerName, RSAParameters rsaParameters) LoadParameters()
+        private RSAParameters LoadParameters()
         {
             var encryptedBytes = File.ReadAllBytes(_keyFile);
             var parametersString = Encoding.UTF8.GetString(ProtectedData.Unprotect(encryptedBytes, null, DataProtectionScope.LocalMachine));
-            var deserialized = StringUtil.ConvertFromJson<RSAParametersSerializable>(parametersString);
-            return (deserialized.ContainerName, deserialized.RSAParameters);
+            return StringUtil.ConvertFromJson<RSAParametersSerializable>(parametersString).RSAParameters;
         }
 
-        private void SaveParameters(RSAParameters parameters, string containerName)
+        private void SaveParameters(RSAParameters parameters)
         {
-            var parametersString = StringUtil.ConvertToJson(new RSAParametersSerializable(containerName, parameters));
+            var parametersString = StringUtil.ConvertToJson(new RSAParametersSerializable(parameters));
             var encryptedBytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(parametersString), null, DataProtectionScope.LocalMachine);
             File.WriteAllBytes(_keyFile, encryptedBytes);
             File.SetAttributes(_keyFile, File.GetAttributes(_keyFile) | FileAttributes.Hidden);

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -178,12 +178,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                     _term.WriteError(StringUtil.Loc("FailedToConnect"));
                 }
             }
-            
+
             // We want to use the native CSP of the platform for storage, so we use the RSACSP directly
             RSAParameters publicKey;
             var keyManager = HostContext.GetService<IRSAKeyManager>();
-            var enableAgentKeyStoreInNamedContainer = await keyManager.GetStoreAgentTokenInNamedContainerFF(HostContext, Trace, agentSettings, creds);
-            using (var rsa = keyManager.CreateKey(enableAgentKeyStoreInNamedContainer))
+            using (var rsa = keyManager.CreateKey())
             {
                 publicKey = rsa.ExportParameters(false);
             }

--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -28,7 +28,6 @@ namespace Agent.Listener.Configuration
         /// <exception cref="InvalidOperationException">Thrown if agent is not configured</exception>
         public Task<FeatureFlag> GetFeatureFlagAsync(IHostContext context, string featureFlagName, ITraceWriter traceWriter, CancellationToken ctk = default);
 
-        public Task<FeatureFlag> GetFeatureFlagWithCred(IHostContext context, string featureFlagName, ITraceWriter traceWriter, AgentSettings settings, VssCredentials creds, CancellationToken ctk = default);
     }
     
     public class FeatureFlagProvider : AgentService, IFeatureFlagProvider
@@ -41,33 +40,22 @@ namespace Agent.Listener.Configuration
             ArgUtil.NotNull(featureFlagName, nameof(featureFlagName));
 
             var credMgr = context.GetService<ICredentialManager>();
-            VssCredentials creds = credMgr.LoadCredentials();
             var configManager = context.GetService<IConfigurationManager>();
-            AgentSettings settings = configManager.LoadSettings();
-
-            return await GetFeatureFlagWithCred(context, featureFlagName, traceWriter, settings, creds, ctk);
-        }
-
-        public async Task<FeatureFlag> GetFeatureFlagWithCred(IHostContext context, string featureFlagName,
-            ITraceWriter traceWriter, AgentSettings settings, VssCredentials creds, CancellationToken ctk)
-        {
             var agentCertManager = context.GetService<IAgentCertificateManager>();
 
+            VssCredentials creds = credMgr.LoadCredentials();
             ArgUtil.NotNull(creds, nameof(creds));
 
+            AgentSettings settings = configManager.LoadSettings();
             using var vssConnection = VssUtil.CreateConnection(new Uri(settings.ServerUrl), creds, traceWriter, agentCertManager.SkipServerCertificateValidation);
             var client = vssConnection.GetClient<FeatureAvailabilityHttpClient>();
             try
             {
-                return await client.GetFeatureFlagByNameAsync(featureFlagName, checkFeatureExists: false, ctk);
-            }
-            catch (VssServiceException e)
-            {
+                return await client.GetFeatureFlagByNameAsync(featureFlagName, checkFeatureExists: false);
+            } catch (VssServiceException e) {
                 Trace.Warning("Unable to retrieve feature flag status: " + e.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
-            }
-            catch (VssUnauthorizedException e)
-            {
+            } catch (VssUnauthorizedException e) {
                 Trace.Warning("Unable to retrieve feature flag with following exception: " + e.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
             }

--- a/src/Agent.Listener/Configuration/IRSAKeyManager.cs
+++ b/src/Agent.Listener/Configuration/IRSAKeyManager.cs
@@ -1,15 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Agent.Listener.Configuration;
-using Agent.Sdk.Knob;
-using Microsoft.VisualStudio.Services.Agent.Util;
-using Microsoft.VisualStudio.Services.Common;
 using System;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 {
@@ -27,7 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         /// key is returned to the caller.
         /// </summary>
         /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the agent</returns>
-        RSACryptoServiceProvider CreateKey(bool enableAgentKeyStoreInNamedContainer);
+        RSACryptoServiceProvider CreateKey();
 
         /// <summary>
         /// Deletes the RSA key managed by the key manager.
@@ -39,23 +33,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         /// </summary>
         /// <returns>An <c>RSACryptoServiceProvider</c> instance representing the key for the agent</returns>
         /// <exception cref="CryptographicException">No key exists in the store</exception>
-        RSACryptoServiceProvider GetKey(bool enableAgentKeyStoreInNamedContainer);
-    }
-
-    public static class IRSAKeyManagerExtensions
-    {
-        public static async Task<bool> GetStoreAgentTokenInNamedContainerFF(this IRSAKeyManager rsaKeyManager, IHostContext hostContext, global::Agent.Sdk.ITraceWriter trace, AgentSettings agentSettings, VssCredentials creds, CancellationToken cancellationToken = default)
-        {
-            if(AgentKnobs.StoreAgentKeyInCSPContainer.GetValue(UtilKnobValueContext.Instance()).AsBoolean())
-            {
-                return true;
-            }
-
-            var featureFlagProvider = hostContext.GetService<IFeatureFlagProvider>();
-            var enableAgentKeyStoreInNamedContainer = (await featureFlagProvider.GetFeatureFlagWithCred(hostContext, "DistributedTask.Agent.StoreAgentTokenInNamedContainer", trace, agentSettings, creds, cancellationToken)).EffectiveState == "On";
-
-            return enableAgentKeyStoreInNamedContainer;
-        }
+        RSACryptoServiceProvider GetKey();
     }
 
     // Newtonsoft 10 is not working properly with dotnet RSAParameters class
@@ -66,7 +44,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
     [Serializable]
     internal class RSAParametersSerializable : ISerializable
     {
-        private string _containerName;
         private RSAParameters _rsaParameters;
 
         public RSAParameters RSAParameters
@@ -77,17 +54,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
         }
 
-        public RSAParametersSerializable(string containerName, RSAParameters rsaParameters)
+        public RSAParametersSerializable(RSAParameters rsaParameters)
         {
-            _containerName = containerName;
             _rsaParameters = rsaParameters;
         }
 
         private RSAParametersSerializable()
         {
         }
-
-        public string ContainerName { get { return _containerName; } set { _containerName = value; } }
 
         public byte[] D { get { return _rsaParameters.D; } set { _rsaParameters.D = value; } }
 
@@ -107,8 +81,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
         public RSAParametersSerializable(SerializationInfo information, StreamingContext context)
         {
-            _containerName = (string)information.GetValue("ContainerName", typeof(string));
-
             _rsaParameters = new RSAParameters()
             {
                 D = (byte[])information.GetValue("d", typeof(byte[])),
@@ -124,7 +96,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue("ContainerName", _containerName);
             info.AddValue("d", _rsaParameters.D);
             info.AddValue("dp", _rsaParameters.DP);
             info.AddValue("dq", _rsaParameters.DQ);

--- a/src/Agent.Listener/Configuration/OAuthCredential.cs
+++ b/src/Agent.Listener/Configuration/OAuthCredential.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             // We expect the key to be in the machine store at this point. Configuration should have set all of
             // this up correctly so we can use the key to generate access tokens.
             var keyManager = context.GetService<IRSAKeyManager>();
-            var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey(enableAgentKeyStoreInNamedContainer: true));
+            var signingCredentials = VssSigningCredentials.Create(() => keyManager.GetKey());
             var clientCredential = new VssOAuthJwtBearerClientCredential(clientId, authorizationUrl, signingCredentials);
             var agentCredential = new VssOAuthCredential(new Uri(oathEndpointUrl, UriKind.Absolute), VssOAuthGrant.ClientCredentials, clientCredential);
 

--- a/src/Agent.Listener/Configuration/RSAFileKeyManager.cs
+++ b/src/Agent.Listener/Configuration/RSAFileKeyManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
         private string _keyFile;
         private IHostContext _context;
 
-        public RSACryptoServiceProvider CreateKey(bool enableAgentKeyStoreInNamedContainer)
+        public RSACryptoServiceProvider CreateKey()
         {
             RSACryptoServiceProvider rsa = null;
             if (!File.Exists(_keyFile))
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 rsa = new RSACryptoServiceProvider(2048);
 
                 // Now write the parameters to disk
-                IOUtil.SaveObject(new RSAParametersSerializable("", rsa.ExportParameters(true)), _keyFile);
+                IOUtil.SaveObject(new RSAParametersSerializable(rsa.ExportParameters(true)), _keyFile);
                 Trace.Info("Successfully saved RSA key parameters to file {0}", _keyFile);
 
                 // Try to lock down the credentials_key file to the owner/group
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
         }
 
-        public RSACryptoServiceProvider GetKey(bool enableAgentKeyStoreInNamedContainer)
+        public RSACryptoServiceProvider GetKey()
         {
             if (!File.Exists(_keyFile))
             {

--- a/src/Agent.Listener/MessageListener.cs
+++ b/src/Agent.Listener/MessageListener.cs
@@ -38,7 +38,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         private IAgentServer _agentServer;
         private TaskAgentSession _session;
         private TimeSpan _getNextMessageRetryInterval;
-        private bool _storeAgentKeyInCSPContainer;
         private readonly TimeSpan _sessionCreationRetryInterval = TimeSpan.FromSeconds(30);
         private readonly TimeSpan _sessionConflictRetryLimit = TimeSpan.FromMinutes(4);
         private readonly TimeSpan _clockSkewRetryLimit = TimeSpan.FromMinutes(30);
@@ -99,9 +98,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                                                         _settings.PoolId,
                                                         taskAgentSession,
                                                         token);
-
-                    var keyManager = HostContext.GetService<IRSAKeyManager>();
-                    _storeAgentKeyInCSPContainer = await keyManager.GetStoreAgentTokenInNamedContainerFF(HostContext, Trace, _settings, creds);
 
                     Trace.Info($"Session created.");
                     if (encounteringError)
@@ -321,7 +317,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             {
                 // The agent session encryption key uses the AES symmetric algorithm
                 var keyManager = HostContext.GetService<IRSAKeyManager>();
-                using (var rsa = keyManager.GetKey(_storeAgentKeyInCSPContainer))
+                using (var rsa = keyManager.GetKey())
                 {
                     return aes.CreateDecryptor(rsa.Decrypt(_session.EncryptionKey.Value, RSAEncryptionPadding.OaepSHA1), message.IV);
                 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -592,11 +592,5 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AZP_AGENT_DOCKER_INIT_OPTION"),
             new EnvironmentKnobSource("AZP_AGENT_DOCKER_INIT_OPTION"),
             new BuiltInDefaultKnobSource("false"));
-
-        public static readonly Knob StoreAgentKeyInCSPContainer = new Knob(
-            nameof(StoreAgentKeyInCSPContainer),
-            "Store agent key in named container (Windows).",
-            new EnvironmentKnobSource("STORE_AGENT_KEY_IN_CSP_CONTAINER"),
-            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
+++ b/src/Test/L0/Listener/Configuration/ConfigurationManagerL0.cs
@@ -17,9 +17,6 @@ using System.Threading.Tasks;
 using Xunit;
 using Microsoft.VisualStudio.Services.Location;
 using Microsoft.VisualStudio.Services.Common;
-using Agent.Listener.Configuration;
-using Agent.Sdk;
-using System.Threading;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
 {
@@ -41,7 +38,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
         private Mock<IMacOSServiceControlManager> _macServiceControlManager;
 
         private Mock<IRSAKeyManager> _rsaKeyManager;
-        private Mock<IFeatureFlagProvider> _featureFlagProvider;
         private ICapabilitiesManager _capabilitiesManager;
         private DeploymentGroupAgentConfigProvider _deploymentGroupAgentConfigProvider;
         private string _expectedToken = "expectedToken";
@@ -79,7 +75,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
             _linuxServiceControlManager = new Mock<ILinuxServiceControlManager>();
             _macServiceControlManager = new Mock<IMacOSServiceControlManager>();
             _capabilitiesManager = new CapabilitiesManager();
-            _featureFlagProvider = new Mock<IFeatureFlagProvider>();
 
             var expectedAgent = new TaskAgent(_expectedAgentName) { Id = 1 };
             var expectedDeploymentMachine = new DeploymentMachine() { Agent = expectedAgent, Id = _expectedDeploymentMachineId };
@@ -131,9 +126,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
 
             rsa = new RSACryptoServiceProvider(2048);
 
-            _rsaKeyManager.Setup(x => x.CreateKey(It.IsAny<bool>())).Returns(rsa);
-
-            _featureFlagProvider.Setup(x => x.GetFeatureFlagWithCred(It.IsAny<IHostContext>(), It.IsAny<string>(), It.IsAny<ITraceWriter>(), It.IsAny<AgentSettings>(), It.IsAny<VssCredentials>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new FeatureAvailability.FeatureFlag("", "", "", "Off", "Off")));
+            _rsaKeyManager.Setup(x => x.CreateKey()).Returns(rsa);
         }
 
         private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
@@ -156,7 +149,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener.Configuration
             tc.SetSingleton<IMacOSServiceControlManager>(_macServiceControlManager.Object);
 
             tc.SetSingleton<IRSAKeyManager>(_rsaKeyManager.Object);
-            tc.SetSingleton<IFeatureFlagProvider>(_featureFlagProvider.Object);
 
             return tc;
         }

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Agent.Listener.Configuration;
-using Agent.Sdk;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Listener;
 using Microsoft.VisualStudio.Services.Agent.Capabilities;
 using Microsoft.VisualStudio.Services.Agent.Listener.Configuration;
-using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using System;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Xunit;
 using System.Threading;
@@ -20,16 +16,13 @@ using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
 {
-    public sealed class MessageListenerL0 : IDisposable
+    public sealed class MessageListenerL0
     {
         private AgentSettings _settings;
         private Mock<IConfigurationManager> _config;
         private Mock<IAgentServer> _agentServer;
         private Mock<ICredentialManager> _credMgr;
         private Mock<ICapabilitiesManager> _capabilitiesManager;
-        private Mock<IFeatureFlagProvider> _featureFlagProvider;
-        private Mock<IRSAKeyManager> _rsaKeyManager;
-        private readonly RSACryptoServiceProvider rsa;
 
         public MessageListenerL0()
         {
@@ -39,14 +32,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
             _agentServer = new Mock<IAgentServer>();
             _credMgr = new Mock<ICredentialManager>();
             _capabilitiesManager = new Mock<ICapabilitiesManager>();
-            _featureFlagProvider = new Mock<IFeatureFlagProvider>();
-            _rsaKeyManager = new Mock<IRSAKeyManager>();
-
-            _featureFlagProvider.Setup(x => x.GetFeatureFlagAsync(It.IsAny<IHostContext>(), It.IsAny<string>(), It.IsAny<ITraceWriter>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new FeatureAvailability.FeatureFlag("", "", "", "Off", "Off")));
-            _featureFlagProvider.Setup(x => x.GetFeatureFlagWithCred(It.IsAny<IHostContext>(), It.IsAny<string>(), It.IsAny<ITraceWriter>(), It.IsAny<AgentSettings>(), It.IsAny<VssCredentials>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new FeatureAvailability.FeatureFlag("", "", "", "Off", "Off")));
-
-            rsa = new RSACryptoServiceProvider(2048);
-            _rsaKeyManager.Setup(x => x.CreateKey(It.IsAny<bool>())).Returns(rsa);
         }
 
         private TestHostContext CreateTestContext([CallerMemberName] String testName = "")
@@ -56,8 +41,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
             tc.SetSingleton<IAgentServer>(_agentServer.Object);
             tc.SetSingleton<ICredentialManager>(_credMgr.Object);
             tc.SetSingleton<ICapabilitiesManager>(_capabilitiesManager.Object);
-            tc.SetSingleton<IFeatureFlagProvider>(_featureFlagProvider.Object);
-            tc.SetSingleton<IRSAKeyManager>(_rsaKeyManager.Object);
             return tc;
         }
 
@@ -227,11 +210,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                     .Verify(x => x.GetAgentMessageAsync(
                         _settings.PoolId, expectedSession.SessionId, It.IsAny<long?>(), tokenSource.Token), Times.Exactly(arMessages.Length));
             }
-        }
-
-        public void Dispose()
-        {
-            rsa.Dispose();
         }
     }
 }


### PR DESCRIPTION
This PR Reverts microsoft/azure-pipelines-agent#4607 due to agent configuration issue on latest ubuntu20/22:
```
[2024-02-01 17:51:16Z WARN VisualStudioServices] Basic issued token provider instance 31092027 requires an interactive prompt which is not allowed by the current settings
[2024-02-01 17:51:16Z ERR  VisualStudioServices] GET request to https://dev.azure.com/***/_apis/distributedtask/pools is not authorized. Details: VS30063: You are not authorized to access https://dev.azure.com/.
[2024-02-01 17:51:16Z INFO CommandSettings] Flag 'unattended': 'False'
[2024-02-01 17:51:16Z ERR  Terminal] WRITE ERROR (exception):
[2024-02-01 17:51:16Z ERR  Terminal] Microsoft.VisualStudio.Services.Common.VssUnauthorizedException: VS30063: You are not authorized to access https://dev.azure.com/.
```