### PR TITLE
Change pool for Create PRs stage

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -270,7 +270,7 @@ extends:
         - Verify_release
         condition: and(succeeded(), not(${{ parameters.onlyGitHubRelease }}))
         pool:
-          vmImage: ubuntu-latest
+          name: 1ES-Shared-Hosted-Pool_Linux-Mariner-2
         jobs:
         ################################################################################
         - job: create_ado_prs


### PR DESCRIPTION
Changed pool name to `1ES-Shared-Hosted-Pool_Linux-Mariner-2`.

Fixes the issue when machine runs out of disk space when trying to clone the ADO repos:

![image](https://github.com/microsoft/azure-pipelines-agent/assets/107044793/d87757d8-d54c-4930-bdd7-27db388d3273)
 