### PR TITLE
Fixed unit test file names in the TestLogs directory

### DIFF
--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -50,14 +50,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             _testName = testName;
 
             // Trim the test assembly's root namespace from the test class's full name.
-            _suiteName = testClass.GetType().FullName.Substring(
-                startIndex: typeof(Tests.TestHostContext).FullName.LastIndexOf(nameof(TestHostContext)));
-            _suiteName = _suiteName.Replace(".", "_");
+            _suiteName = testClass.GetType().FullName.Replace(
+                typeof(TestHostContext).Namespace,
+                string.Empty,
+                StringComparison.OrdinalIgnoreCase);
+
+            if (_suiteName.StartsWith("."))
+            {
+                _suiteName = _suiteName[1..];
+            }
+
+            _suiteName = _suiteName.Replace(".", "_", StringComparison.OrdinalIgnoreCase);
 
             // Setup the trace manager.
-            TraceFileName = Path.Combine(
-                Path.Combine(TestUtil.GetSrcPath(), "Test", "TestLogs"),
-                $"trace_{_suiteName}_{_testName}.log");
+            TraceFileName = Path.Combine(TestUtil.GetSrcPath(), "Test", "TestLogs", $"trace_{_suiteName}_{_testName}.log");
+
             if (File.Exists(TraceFileName))
             {
                 File.Delete(TraceFileName);


### PR DESCRIPTION
There is a problem with file names in the agent TestLogs directory when the agent creates them.

WI: 2151620