### PR TITLE
Added backcompat fallback to enable DownloadBuildArtifactsV1 to work with AzDO service update when older agents deployed

### DIFF
--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -64,6 +64,13 @@ namespace Agent.Plugins.BuildArtifacts
         }
     }
 
+    // Create a new version as we changed functionality for FileID https://portal.microsofticm.com/imp/v3/incidents/details/462028809/home
+    // For backcompat with older agents, tasks will use the node (v0) task code using AgentPluginWithFallback
+    public class DownloadBuildArtifactTaskV1_0_1 : DownloadBuildArtifactTaskV1_0_0
+    {
+
+    }
+
     // Can be invoked from a build run or a release run should a build be set as the artifact. 
     public class DownloadBuildArtifactTaskV1_0_0 : BuildArtifactTaskPluginBaseV1
     {

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -592,5 +592,12 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AZP_AGENT_DOCKER_INIT_OPTION"),
             new EnvironmentKnobSource("AZP_AGENT_DOCKER_INIT_OPTION"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static Knob DisableAgentPluginWithFallbackHandler = new Knob(
+            nameof(AddDockerInitOption),
+            "If true, the agent will not recognize AgentPluginWithFallback execution handler in tasks (e.g. for testing that fallback works as expected, simulating an older agent that doesn't support the plugin).",
+            new RuntimeKnobSource("DISABLE_AGENT_PLUGIN_WITH_FALLBACK_HANDLER"),
+            new EnvironmentKnobSource("DISABLE_AGENT_PLUGIN_WITH_FALLBACK_HANDLER"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/AgentPluginManager.cs
+++ b/src/Agent.Worker/AgentPluginManager.cs
@@ -20,13 +20,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     {
         List<string> GetTaskPlugins(Guid taskId);
         Task RunPluginTaskAsync(IExecutionContext context, string plugin, Dictionary<string, string> inputs, Dictionary<string, string> environment, Variables runtimeVariables, EventHandler<ProcessDataReceivedEventArgs> outputHandler);
+        bool IsTaskPluginSupported(string plugin);
     }
 
     public class AgentPluginManager : AgentService, IAgentPluginManager
     {
         private readonly Dictionary<Guid, List<string>> _supportedTasks = new Dictionary<Guid, List<string>>();
 
-        protected static readonly HashSet<string> _taskPlugins = new HashSet<string>()
+        protected readonly HashSet<string> _taskPlugins = new HashSet<string>
         {
             "Agent.Plugins.Repository.CheckoutTask, Agent.Plugins",
             "Agent.Plugins.Repository.CleanupTask, Agent.Plugins",
@@ -42,7 +43,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_3, Agent.Plugins",
             "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV2_0_0, Agent.Plugins",
             "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV0_140_0, Agent.Plugins",
-            "Agent.Plugins.BuildArtifacts.DownloadBuildArtifactTaskV1_0_0, Agent.Plugins",            
+            "Agent.Plugins.BuildArtifacts.DownloadBuildArtifactTaskV1_0_0, Agent.Plugins",
             "Agent.Plugins.BuildArtifacts.DownloadBuildArtifactTaskV1_0_1, Agent.Plugins"
         };
 
@@ -131,7 +132,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return pluginContext;
         }
 
-        public static bool IsTaskPluginSupported(string plugin)
+        public bool IsTaskPluginSupported(string plugin)
         {
             ArgUtil.NotNullOrEmpty(plugin, nameof(plugin));
 

--- a/src/Agent.Worker/AgentPluginManager.cs
+++ b/src/Agent.Worker/AgentPluginManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
     {
         private readonly Dictionary<Guid, List<string>> _supportedTasks = new Dictionary<Guid, List<string>>();
 
-        protected readonly HashSet<string> _taskPlugins = new HashSet<string>()
+        protected static readonly HashSet<string> _taskPlugins = new HashSet<string>()
         {
             "Agent.Plugins.Repository.CheckoutTask, Agent.Plugins",
             "Agent.Plugins.Repository.CleanupTask, Agent.Plugins",
@@ -42,7 +42,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV1_1_3, Agent.Plugins",
             "Agent.Plugins.PipelineArtifact.DownloadPipelineArtifactTaskV2_0_0, Agent.Plugins",
             "Agent.Plugins.PipelineArtifact.PublishPipelineArtifactTaskV0_140_0, Agent.Plugins",
-            "Agent.Plugins.BuildArtifacts.DownloadBuildArtifactTaskV1_0_0, Agent.Plugins"
+            "Agent.Plugins.BuildArtifacts.DownloadBuildArtifactTaskV1_0_0, Agent.Plugins",            
+            "Agent.Plugins.BuildArtifacts.DownloadBuildArtifactTaskV1_0_1, Agent.Plugins"
         };
 
         public override void Initialize(IHostContext hostContext)
@@ -130,12 +131,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return pluginContext;
         }
 
+        public static bool IsTaskPluginSupported(string plugin)
+        {
+            ArgUtil.NotNullOrEmpty(plugin, nameof(plugin));
+
+            // Only allow plugins we defined
+            return _taskPlugins.Contains(plugin);
+        }
+
         public async Task RunPluginTaskAsync(IExecutionContext context, string plugin, Dictionary<string, string> inputs, Dictionary<string, string> environment, Variables runtimeVariables, EventHandler<ProcessDataReceivedEventArgs> outputHandler)
         {
             ArgUtil.NotNullOrEmpty(plugin, nameof(plugin));
 
             // Only allow plugins we defined
-            if (!_taskPlugins.Contains(plugin))
+            if (!IsTaskPluginSupported(plugin))
             {
                 throw new NotSupportedException(plugin);
             }

--- a/src/Agent.Worker/Handlers/HandlerFactory.cs
+++ b/src/Agent.Worker/Handlers/HandlerFactory.cs
@@ -53,6 +53,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             ArgUtil.NotNull(runtimeVariables, nameof(runtimeVariables));
             ArgUtil.NotNull(taskDirectory, nameof(taskDirectory));
 
+            var disableAgentPluginWithFallbackHandler =  AgentKnobs.DisableAgentPluginWithFallbackHandler.GetValue(executionContext).AsBoolean();
+
             // Create the handler.
             IHandler handler;
             if (data is BaseNodeHandlerData)
@@ -113,6 +115,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 // Agent plugin
                 handler = HostContext.CreateService<IAgentPluginHandler>();
                 (handler as IAgentPluginHandler).Data = data as AgentPluginHandlerData;
+            }
+            else if(!disableAgentPluginWithFallbackHandler && data is AgentPluginWithFallbackHandlerData)
+            {
+                handler = HostContext.CreateService<IAgentPluginHandler>();
+                (handler as IAgentPluginHandler).Data = data as AgentPluginWithFallbackHandlerData;
             }
             else
             {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -455,6 +455,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         private PowerShellExeHandlerData _powerShellExe;
         private ProcessHandlerData _process;
         private AgentPluginHandlerData _agentPlugin;
+        private AgentPluginWithFallbackHandlerData _agentPluginFallback;
 
         [JsonIgnore]
         public List<HandlerData> All => _all;
@@ -615,6 +616,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             set
             {
                 _agentPlugin = value;
+                Add(value);
+            }
+        }
+
+        public AgentPluginWithFallbackHandlerData AgentPluginWithFallback
+        {
+            get
+            {
+                return _agentPluginFallback;
+            }
+
+            set
+            {
+                _agentPluginFallback = value;
                 Add(value);
             }
         }
@@ -916,8 +931,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         }
     }
 
-    public sealed class AgentPluginHandlerData : HandlerData
+    public class AgentPluginHandlerData : HandlerData
     {
         public override int Priority => 0;
+    }
+
+    public class AgentPluginWithFallbackHandlerData : AgentPluginHandlerData
+    {
     }
 }

--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -524,7 +524,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             }
             else
             {
-                var agentPluginsWithFallbackHandlersWherePluginNotSupported = currentExecution.All.Where(x => x is AgentPluginWithFallbackHandlerData && !AgentPluginManager.IsTaskPluginSupported(x.Target));
+                var agentPluginManager = HostContext.GetService<IAgentPluginManager>();
+
+                var agentPluginsWithFallbackHandlersWherePluginNotSupported = currentExecution.All.Where(x => x is AgentPluginWithFallbackHandlerData && !agentPluginManager.IsTaskPluginSupported(x.Target));
                 exclude = new HashSet<HandlerData>(agentPluginsWithFallbackHandlersWherePluginNotSupported);
             }
 

--- a/src/Test/L0/Worker/FakeAgentPluginManagerL0.cs
+++ b/src/Test/L0/Worker/FakeAgentPluginManagerL0.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.Services.Agent.Worker;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
+{
+    internal class FakeAgentPluginManagerL0 : AgentPluginManager
+    {
+        public override void Initialize(IHostContext hostContext)
+        {
+            // do nothing
+        }
+    }
+}

--- a/src/Test/L0/Worker/TaskRunnerL0.cs
+++ b/src/Test/L0/Worker/TaskRunnerL0.cs
@@ -95,6 +95,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             {
                 using (TestHostContext hc = CreateTestContext(test.Name))
                 {
+                    hc.SetSingleton<IAgentPluginManager>(new FakeAgentPluginManagerL0());
                     test.RunTest(hc);
                 }
             }
@@ -132,6 +133,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             {
                 using (TestHostContext hc = CreateTestContext(test.Name))
                 {
+                    hc.SetSingleton<IAgentPluginManager>(new FakeAgentPluginManagerL0());
                     test.RunTest(hc);
                 }
             }
@@ -171,6 +173,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 variables.Add("agent.preferPowerShellOnContainers", "true");
                 using (TestHostContext hc = CreateTestContext(test.Name))
                 {
+                    hc.SetSingleton<IAgentPluginManager>(new FakeAgentPluginManagerL0());
+
                     test.RunTest(hc, variables);
                     Environment.SetEnvironmentVariable("AGENT_PREFER_POWERSHELL_ON_CONTAINERS", "true");
                     test.RunTest(hc);


### PR DESCRIPTION
See also: https://github.com/microsoft/azure-pipelines-tasks/pull/19538

[AB#2148951](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2148951)