### PR TITLE
[AgentWorker.PageLogger] - Ignore endgroup tag when counting lines

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/Logging.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Logging.cs
@@ -73,11 +73,11 @@ namespace Microsoft.VisualStudio.Services.Agent
                 Create();
             }
 
-            if (message.Contains(groupStartTag))
+            if (message.Contains(groupStartTag, StringComparison.OrdinalIgnoreCase))
             {
                 _groupOpened = true;
             } 
-            if (_groupOpened && message.Contains(groupEndTag))
+            if (_groupOpened && message.Contains(groupEndTag, StringComparison.OrdinalIgnoreCase))
             {
                 // Ignore group end tag only if group was opened, otherwise it is a normal message 
                 // because in web console ##[endgroup] becomes empty line without ##[group] tag

--- a/src/Test/L0/PagingLoggerL0.cs
+++ b/src/Test/L0/PagingLoggerL0.cs
@@ -25,9 +25,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
         messagemessagemessagemessage
         XPLATmessagemessagemessagemessagemessagemessagemessagemessage";
         private const string LogDataUpperCaseGroup = @"messagemessagemessagemes
-        ##[group]sage
+        ##[GROUP]sage
         messagemessagemessagemessage
-        ##[endgroup]
+        ##[ENDGROUP]
         XPLATmessagemessagemessagemessagemessagemessagemessagemessage";
         private const int PagesToWrite = 2;
         private Mock<IJobServerQueue> _jobServerQueue;

--- a/src/Test/L0/PagingLoggerL0.cs
+++ b/src/Test/L0/PagingLoggerL0.cs
@@ -24,6 +24,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
         ##[group]sage
         messagemessagemessagemessage
         XPLATmessagemessagemessagemessagemessagemessagemessagemessage";
+        private const string LogDataUpperCaseGroup = @"messagemessagemessagemes
+        ##[group]sage
+        messagemessagemessagemessage
+        ##[endgroup]
+        XPLATmessagemessagemessagemessagemessagemessagemessagemessage";
         private const int PagesToWrite = 2;
         private Mock<IJobServerQueue> _jobServerQueue;
 
@@ -311,6 +316,52 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                     while (bytesSent < totalBytes)
                     {
                         pagingLogger.Write(LogDataWithoutCloseGroup);
+                        bytesSent += logDataSize;
+                        expectedLines += lineCnt;
+                    }
+                    pagingLogger.End();
+
+                    //Assert
+                    _jobServerQueue.Verify(x => x.QueueFileUpload(timeLineId, timeLineRecordId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true), Times.AtLeast(PagesToWrite));
+                    Assert.Equal(pagingLogger.TotalLines, expectedLines);
+                }
+            }
+            finally
+            {
+                //cleanup
+                CleanLogFolder();
+            }
+        }
+    
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void CalculateLineNumbersWithUpperCaseGroupTag()
+        {
+            CleanLogFolder();
+
+            try
+            {
+                //Arrange
+                using (var hc = new TestHostContext(this))
+                using (var pagingLogger = new PagingLogger())
+                {
+                    hc.SetSingleton<IJobServerQueue>(_jobServerQueue.Object);
+                    pagingLogger.Initialize(hc);
+                    Guid timeLineId = Guid.NewGuid();
+                    Guid timeLineRecordId = Guid.NewGuid();
+                    int totalBytes = PagesToWrite * PagingLogger.PageSize;
+                    int logDataSize = System.Text.Encoding.UTF8.GetByteCount(LogDataUpperCaseGroup);
+               
+                    //Act
+                    int bytesSent = 0;
+                    int expectedLines = 0;
+                    // -1 because ##[endgroup] should be ignored since it's not shown in UI and not counted in line numbers
+                    int lineCnt = LogDataUpperCaseGroup.Split('\n').Length - 1;
+                    pagingLogger.Setup(timeLineId, timeLineRecordId);
+                    while (bytesSent < totalBytes)
+                    {
+                        pagingLogger.Write(LogDataUpperCaseGroup);
                         bytesSent += logDataSize;
                         expectedLines += lineCnt;
                     }


### PR DESCRIPTION
**Issue:** 
The agent counts lines incorrectly when the group tag has uppercase

**Changes:**
- Added case insensitive search
- Added tests for the new logic

**Related WI:** 2125343

**Tested:**
Tested locally with different tags 