### PR TITLE
Add explicit OOM error handling for Nodehandler

### DIFF
--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -215,6 +215,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 outputEncoding = Encoding.UTF8;
             }
 
+            var enableResourceUtilizationWarnings = AgentKnobs.EnableResourceUtilizationWarnings.GetValue(ExecutionContext).AsBoolean();
+
             try
             {
                 // Execute the process. Exit code 0 should always be returned.
@@ -242,6 +244,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 {
                     await step;
                 }
+            }
+            catch (ProcessExitCodeException ex)
+            {
+                if (enableResourceUtilizationWarnings && ex.ExitCode == 137)
+                {
+                    ExecutionContext.Error(StringUtil.Loc("AgentOutOfMemoryFailure"));
+                }
+
+                throw;
             }
             finally
             {
@@ -305,7 +316,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             {
                 Trace.Info($"Found UseNode20_1 knob, using node20_1 for node tasks {useNode20_1} node20ResultsInGlibCError = {node20ResultsInGlibCError}");
 
-                if(node20ResultsInGlibCError)
+                if (node20ResultsInGlibCError)
                 {
                     nodeFolder = NodeHandler.Node16Folder;
                     Node16FallbackWarning(inContainer);

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -18,6 +18,7 @@
   "AgentMachinePoolNameLabel": "agent pool",
   "AgentName": "agent name",
   "AgentNameLog": "Agent name: '{0}'",
+  "AgentOutOfMemoryFailure": "The agent worker exited with code 137, which means it ran out of memory. Make sure the agent (container) host has sufficient memory configured.",
   "AgentReplaced": "Successfully replaced the agent",
   "agentRootFolderCheckError": "Unable to check access rules of the agent root folder. Please examine the log for more details.",
   "agentRootFolderInsecure": "Security warning! The group {0} has access to write/modify the agent folder. Please examine the log for more details.",


### PR DESCRIPTION
This PR adds explicit message for Out of memory exception.

**Changes:**
- Additional catch for 137 error code is added to `Nodehandler` that shows explicit error message.

**Testing:**
Validated on Ubuntu 22.04

**How it was tested:**
Details in related WI
![image](https://github.com/microsoft/azure-pipelines-agent/assets/47208721/692d64a0-a7d1-46d1-ba47-4fd7bccca6fb)

**Related WI:** 2129366