### PR TITLE
Increasing PTR Timeout for Legacy Workflow

### DIFF
--- a/src/Agent.Worker/TestResults/Legacy/TestRunPublisher.cs
+++ b/src/Agent.Worker/TestResults/Legacy/TestRunPublisher.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
     {
         #region Private
         const int BATCH_SIZE = 1000;
-        const int PUBLISH_TIMEOUT = 300;
+        const int PUBLISH_TIMEOUT = 600;
         const int TCM_MAX_FILECONTENT_SIZE = 100 * 1024 * 1024; //100 MB
         const int TCM_MAX_FILESIZE = 75 * 1024 * 1024; // 75 MB
         private IExecutionContext _executionContext;


### PR DESCRIPTION
Increasing PTR Timeout for Legacy Workflow to mitigate a Live Site Issue

ICM link --> https://portal.microsofticm.com/imp/v3/incidents/details/460326977/home

Issue: Publish Test Result task intermittently fails due to timeout
<img width="1021" alt="image" src="https://github.com/microsoft/azure-pipelines-agent/assets/100841140/780bd300-0826-454d-a0ab-1d37132d755b">
