### PR TITLE
Handle filter option for treeless or blobless git fetches

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -238,38 +238,42 @@ namespace Agent.Plugins.Repository
 
             // parse filter and only include valid options
             List<string> filters = new List<String>();
-            List<string> splitFilter = fetchFilter.Split('+').Where(filter => !String.IsNullOrWhiteSpace(filter)).ToList();
 
-            foreach (string filter in splitFilter)
+            if (AgentKnobs.UseFetchFilterInCheckoutTask.GetValue(context).AsBoolean())
             {
-                List<string> parsedFilter = filter.Split(':')
-                    .Where(filter => !String.IsNullOrWhiteSpace(filter))
-                    .Select(filter => filter.Trim())
-                    .ToList();
+                List<string> splitFilter = fetchFilter.Split('+').Where(filter => !String.IsNullOrWhiteSpace(filter)).ToList();
 
-                if (parsedFilter.Count == 2)
+                foreach (string filter in splitFilter)
                 {
-                    switch (parsedFilter[0].ToLower())
+                    List<string> parsedFilter = filter.Split(':')
+                        .Where(filter => !String.IsNullOrWhiteSpace(filter))
+                        .Select(filter => filter.Trim())
+                        .ToList();
+
+                    if (parsedFilter.Count == 2)
                     {
-                        case "tree":
-                            // currently only supporting treeless filter
-                            if (int.TryParse(parsedFilter[1], out int treeSize) && treeSize == 0)
-                            {
-                                filters.Add($"{parsedFilter[0]}:{treeSize}");
-                            }
-                            break;
+                        switch (parsedFilter[0].ToLower())
+                        {
+                            case "tree":
+                                // currently only supporting treeless filter
+                                if (int.TryParse(parsedFilter[1], out int treeSize) && treeSize == 0)
+                                {
+                                    filters.Add($"{parsedFilter[0]}:{treeSize}");
+                                }
+                                break;
 
-                        case "blob":
-                            // currently only supporting blobless filter
-                            if (parsedFilter[1].Equals("none", StringComparison.OrdinalIgnoreCase))
-                            {
-                                filters.Add($"{parsedFilter[0]}:{parsedFilter[1]}");
-                            }
-                            break;
+                            case "blob":
+                                // currently only supporting blobless filter
+                                if (parsedFilter[1].Equals("none", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    filters.Add($"{parsedFilter[0]}:{parsedFilter[1]}");
+                                }
+                                break;
 
-                        default:
-                            // either invalid or unsupported git object
-                            break;
+                            default:
+                                // either invalid or unsupported git object
+                                break;
+                        }
                     }
                 }
             }

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -198,7 +198,7 @@ namespace Agent.Plugins.Repository
         }
 
         // git fetch --tags --prune --progress --no-recurse-submodules [--depth=15] origin [+refs/pull/*:refs/remote/pull/*]
-        public async Task<int> GitFetch(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, bool fetchTags, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
+        public async Task<int> GitFetch(AgentTaskPluginExecutionContext context, string repositoryPath, string remoteName, int fetchDepth, string fetchFilter, bool fetchTags, List<string> refSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {
             context.Debug($"Fetch git repository at: {repositoryPath} remote: {remoteName}.");
             if (refSpec != null && refSpec.Count > 0)
@@ -236,8 +236,46 @@ namespace Agent.Plugins.Repository
             // add --unshallow to convert the shallow repository to a complete repository
             string depth = fetchDepth > 0 ? $"--depth={fetchDepth}" : (File.Exists(Path.Combine(repositoryPath, ".git", "shallow")) ? "--unshallow" : string.Empty);
 
+            // parse filter and only include valid options
+            List<string> filters = new List<String>();
+            List<string> splitFilter = fetchFilter.Split('+').Where(filter => !String.IsNullOrWhiteSpace(filter)).ToList();
+
+            foreach (string filter in splitFilter)
+            {
+                List<string> parsedFilter = filter.Split(':')
+                    .Where(filter => !String.IsNullOrWhiteSpace(filter))
+                    .Select(filter => filter.Trim())
+                    .ToList();
+
+                if (parsedFilter.Count == 2)
+                {
+                    switch (parsedFilter[0].ToLower())
+                    {
+                        case "tree":
+                            // currently only supporting treeless filter
+                            if (int.TryParse(parsedFilter[1], out int treeSize) && treeSize == 0)
+                            {
+                                filters.Add($"{parsedFilter[0]}:{treeSize}");
+                            }
+                            break;
+
+                        case "blob":
+                            // currently only supporting blobless filter
+                            if (parsedFilter[1].Equals("none", StringComparison.OrdinalIgnoreCase))
+                            {
+                                filters.Add($"{parsedFilter[0]}:{parsedFilter[1]}");
+                            }
+                            break;
+
+                        default:
+                            // either invalid or unsupported git object
+                            break;
+                    }
+                }
+            }
+
             //define options for fetch
-            string options = $"{forceTag} {tags} --prune {pruneTags} {progress} --no-recurse-submodules {remoteName} {depth} {string.Join(" ", refSpec)}";
+            string options = $"{forceTag} {tags} --prune {pruneTags} {progress} --no-recurse-submodules {remoteName} {depth} {String.Join(" ", filters.Select(filter => "--filter=" + filter))} {string.Join(" ", refSpec)}";
             int retryCount = 0;
             int fetchExitCode = 0;
             while (retryCount < 3)
@@ -257,6 +295,8 @@ namespace Agent.Plugins.Repository
                     { "RefSpec", string.Join(" ", refSpec) },
                     { "RemoteName", remoteName },
                     { "FetchDepth", $"{fetchDepth}" },
+                    { "FetchFilter", $"{String.Join(" ", filters)}" },
+                    { "FetchTags", $"{fetchTags}" },
                     { "ExitCode", $"{fetchExitCode}" },
                     { "Options", options }
                 });

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -340,6 +340,8 @@ namespace Agent.Plugins.Repository
             // default fetchTags to true unless it's specifically set to false
             bool fetchTags = StringUtil.ConvertToBoolean(executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags), true);
 
+            string fetchFilter = executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter);
+
             executionContext.Debug($"repository url={repositoryUrl}");
             executionContext.Debug($"targetPath={targetPath}");
             executionContext.Debug($"sourceBranch={sourceBranch}");
@@ -349,6 +351,7 @@ namespace Agent.Plugins.Repository
             executionContext.Debug($"checkoutNestedSubmodules={checkoutNestedSubmodules}");
             executionContext.Debug($"exposeCred={exposeCred}");
             executionContext.Debug($"fetchDepth={fetchDepth}");
+            executionContext.Debug($"fetchFilter={fetchFilter}");
             executionContext.Debug($"fetchTags={fetchTags}");
             executionContext.Debug($"gitLfsSupport={gitLfsSupport}");
             executionContext.Debug($"acceptUntrustedCerts={acceptUntrustedCerts}");
@@ -865,6 +868,7 @@ namespace Agent.Plugins.Repository
             string refFetchedByCommit = null;
 
             executionContext.Debug($"fetchDepth : {fetchDepth}");
+            executionContext.Debug($"fetchFilter : {fetchFilter}");
             executionContext.Debug($"fetchByCommit : {fetchByCommit}");
             executionContext.Debug($"sourceVersion : {sourceVersion}");
             executionContext.Debug($"fetchTags : {fetchTags}");
@@ -895,7 +899,7 @@ namespace Agent.Plugins.Repository
                 }
             }
 
-            int exitCode_fetch = await gitCommandManager.GitFetch(executionContext, targetPath, "origin", fetchDepth, fetchTags, additionalFetchSpecs, string.Join(" ", additionalFetchArgs), cancellationToken);
+            int exitCode_fetch = await gitCommandManager.GitFetch(executionContext, targetPath, "origin", fetchDepth, fetchFilter, fetchTags, additionalFetchSpecs, string.Join(" ", additionalFetchArgs), cancellationToken);
             if (exitCode_fetch != 0)
             {
                 throw new InvalidOperationException($"Git fetch failed with exit code: {exitCode_fetch}");
@@ -907,7 +911,7 @@ namespace Agent.Plugins.Repository
             if (fetchByCommit && !string.IsNullOrEmpty(sourceVersion))
             {
                 List<string> commitFetchSpecs = new List<string>() { $"+{sourceVersion}" };
-                exitCode_fetch = await gitCommandManager.GitFetch(executionContext, targetPath, "origin", fetchDepth, fetchTags, commitFetchSpecs, string.Join(" ", additionalFetchArgs), cancellationToken);
+                exitCode_fetch = await gitCommandManager.GitFetch(executionContext, targetPath, "origin", fetchDepth, fetchFilter, fetchTags, commitFetchSpecs, string.Join(" ", additionalFetchArgs), cancellationToken);
                 if (exitCode_fetch != 0)
                 {
                     throw new InvalidOperationException($"Git fetch failed with exit code: {exitCode_fetch}");

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -454,7 +454,7 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AGENT_DISABLE_NODE6_TASKS"),
             new EnvironmentKnobSource("AGENT_DISABLE_NODE6_TASKS"),
             new BuiltInDefaultKnobSource("false"));
-       
+
         public static readonly Knob DisableTeePluginRemoval = new Knob(
             nameof(DisableTeePluginRemoval),
             "Disables removing TEE plugin after using it during checkout.",
@@ -600,7 +600,7 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AZP_AGENT_MOUNT_WORKSPACE"),
             new EnvironmentKnobSource("AZP_AGENT_MOUNT_WORKSPACE"),
             new BuiltInDefaultKnobSource("false"));
-      
+
         public static readonly Knob EnableNewSecretMasker = new Knob(
             nameof(EnableNewSecretMasker),
             "If true, the agent will use new SecretMasker with additional filters & performance enhancements",
@@ -619,6 +619,12 @@ namespace Agent.Sdk.Knob
             "If true, agent will log the task name in user agent.",
             new RuntimeKnobSource("AZP_AGENT_LOG_TASKNAME_IN_USERAGENT"),
             new EnvironmentKnobSource("AZP_AGENT_LOG_TASKNAME_IN_USERAGENT"),
+            new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob UseFetchFilterInCheckoutTask = new Knob(
+            nameof(UseFetchFilterInCheckoutTask),
+            "If true, agent will use fetch filter in checkout task.",
+            new RuntimeKnobSource("AGENT_USE_FETCH_FILTER_IN_CHECKOUT_TASK"),
             new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Common.props
+++ b/src/Common.props
@@ -11,7 +11,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.234-private</VssApiVersion>
+    <VssApiVersion>0.5.235-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
     <InvariantGlobalization>false</InvariantGlobalization>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>

--- a/src/Test/L0/Plugin/RepositoryPluginL0.cs
+++ b/src/Test/L0/Plugin/RepositoryPluginL0.cs
@@ -44,10 +44,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
                         { Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules, "submodules value" },
                     });
 
+                _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter] = "fetch filter value";
+                _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags] = "fetch tags value";
+
                 await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
 
                 Assert.Equal("clean value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Clean]);
                 Assert.Equal("fetch depth value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchDepth]);
+                Assert.Equal("fetch filter value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter]);
+                Assert.Equal("fetch tags value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags]);
                 Assert.Equal("lfs value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Lfs]);
                 Assert.Equal("persist credentials value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.PersistCredentials]);
                 Assert.Equal("submodules value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules]);
@@ -74,10 +79,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
                         { "SUBmodules", "submodules value" },
                     });
 
+                _executionContext.Inputs["FETCHfilter"] = "fetch filter value";
+                _executionContext.Inputs["FETCHtags"] = "fetch tags value";
+
                 await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
 
                 Assert.Equal("clean value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Clean]);
                 Assert.Equal("fetch depth value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchDepth]);
+                Assert.Equal("fetch filter value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter]);
+                Assert.Equal("fetch tags value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags]);
                 Assert.Equal("lfs value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Lfs]);
                 Assert.Equal("persist credentials value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.PersistCredentials]);
                 Assert.Equal("submodules value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules]);
@@ -170,10 +180,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
                         { "unexpected", "unexpected value" },
                     });
 
+                _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter] = "fetch filter value";
+                _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags] = "fetch tags value";
+
                 await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
 
                 Assert.Equal("clean value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Clean]);
                 Assert.Equal("fetch depth value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchDepth]);
+                Assert.Equal("fetch filter value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter]);
+                Assert.Equal("fetch tags value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags]);
                 Assert.Equal("lfs value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Lfs]);
                 Assert.Equal("persist credentials value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.PersistCredentials]);
                 Assert.Equal("submodules value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules]);
@@ -201,10 +216,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
                         { Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules, "submodules value" },
                     });
 
+                _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter] = "fetch filter value";
+                _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags] = "fetch tags value";
+
                 await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
 
                 Assert.Equal("clean value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Clean]);
                 Assert.Equal("fetch depth value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchDepth]);
+                Assert.Equal("fetch filter value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter]);
+                Assert.Equal("fetch tags value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.FetchTags]);
                 Assert.Equal("lfs value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Lfs]);
                 Assert.Equal("persist credentials value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.PersistCredentials]);
                 Assert.Equal("submodules value", _executionContext.Inputs[Pipelines.PipelineConstants.CheckoutTaskInputs.Submodules]);
@@ -279,7 +299,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
                 Endpoints = new List<ServiceEndpoint>(),
                 Inputs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
-                   
+
                 },
                 Repositories = new List<Pipelines.RepositoryResource>(),
                 Variables = new Dictionary<string, VariableValue>(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Agent updates to parse the `fetchFilter` YAML property in the checkout task and add the `--filter` option for treeless/blobless fetches. Unexpected values will be ignored. For future-proofing and handling multiple filter options down the line, the expected input is a + delimited filters list.

Since we're currently only supporting treeless blobless fetches, the expected YAML input would be the following:
- Treeless:
```
- checkout: repo
  fetchFilter: tree:0
```

- Blobless
```
- checkout: repo
  fetchFilter: blob:none
```