### PR TITLE
Cleanup Agent Knob for Pipeline Artifacts

### DIFF
--- a/src/Agent.Plugins/Artifact/FileContainerProvider.cs
+++ b/src/Agent.Plugins/Artifact/FileContainerProvider.cs
@@ -161,6 +161,7 @@ namespace Agent.Plugins
                 {
                     BlobstoreClientSettings clientSettings = await BlobstoreClientSettings.GetClientSettingsAsync(
                         connection,
+                        context,
                         Microsoft.VisualStudio.Services.BlobStore.WebApi.Contracts.Client.BuildArtifact,
                         tracer,
                         cancellationToken);

--- a/src/Agent.Plugins/Artifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/Artifact/PipelineArtifactServer.cs
@@ -47,6 +47,7 @@ namespace Agent.Plugins
             VssConnection connection = context.VssConnection;
             var clientSettings = await BlobstoreClientSettings.GetClientSettingsAsync(
                 connection,
+                context,
                 Microsoft.VisualStudio.Services.BlobStore.WebApi.Contracts.Client.PipelineArtifact,
                 tracer,
                 cancellationToken);
@@ -63,7 +64,6 @@ namespace Agent.Plugins
                     DedupManifestArtifactClientFactory.Instance.GetDedupStoreClientMaxParallelism(context),
                     domainId,
                     clientSettings,
-                    context,
                     cancellationToken);
 
             using (clientTelemetry)

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -345,7 +345,7 @@ namespace Agent.Sdk.Knob
             "Enables large chunk size for pipeline artifacts.",
             new EnvironmentKnobSource("AGENT_ENABLE_PIPELINEARTIFACT_LARGE_CHUNK_SIZE"),
             new RuntimeKnobSource("AGENT_ENABLE_PIPELINEARTIFACT_LARGE_CHUNK_SIZE"),
-            new BuiltInDefaultKnobSource("false"));
+            new BuiltInDefaultKnobSource("true")); // This flag is on everywhere and should be on by default now
 
         public static readonly Knob PermissionsCheckFailsafe = new Knob(
             nameof(PermissionsCheckFailsafe),

--- a/src/Agent.Worker/Build/FileContainerServer.cs
+++ b/src/Agent.Worker/Build/FileContainerServer.cs
@@ -361,6 +361,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
                 var clientSettings = await BlobstoreClientSettings.GetClientSettingsAsync(
                         _connection,
+                        context,
                         Microsoft.VisualStudio.Services.BlobStore.WebApi.Contracts.Client.BuildArtifact,
                         DedupManifestArtifactClientFactory.CreateArtifactsTracer(verbose, tracer),
                         token);

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/DedupManifestArtifactClientFactory.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/DedupManifestArtifactClientFactory.cs
@@ -39,7 +39,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             int maxParallelism,
             IDomainId domainId,
             BlobstoreClientSettings clientSettings,
-            AgentTaskPluginExecutionContext context,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -112,6 +111,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
         {
             var clientSettings = await BlobstoreClientSettings.GetClientSettingsAsync(
                 connection,
+                context,
                 client,
                 CreateArtifactsTracer(verbose, traceOutput),
                 cancellationToken);
@@ -123,7 +123,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
                     DedupManifestArtifactClientFactory.Instance.GetDedupStoreClientMaxParallelism(context),
                     domainId,
                     clientSettings,
-                    context,
                     cancellationToken);
         }
 
@@ -134,7 +133,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             int maxParallelism,
             IDomainId domainId,
             BlobstoreClientSettings clientSettings,
-            AgentTaskPluginExecutionContext context,
             CancellationToken cancellationToken)
         {
             const int maxRetries = 5;
@@ -150,7 +148,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             IDedupStoreHttpClient dedupStoreHttpClient = GetDedupStoreHttpClient(connection, domainId, maxRetries, tracer, cancellationToken);
 
             var telemetry = new BlobStoreClientTelemetry(tracer, dedupStoreHttpClient.BaseAddress);
-            HashType hashType= clientSettings.GetClientHashType(context);
+
+            HashType hashType = clientSettings.GetClientHashType();
 
             if (hashType == BuildXL.Cache.ContentStore.Hashing.HashType.Dedup1024K)
             {

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/DedupManifestArtifactClientFactory.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/DedupManifestArtifactClientFactory.cs
@@ -164,7 +164,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             return (new DedupManifestArtifactClient(telemetry, dedupClient, tracer), telemetry);
         }
 
-        private static IDedupStoreHttpClient GetDedupStoreHttpClient(VssConnection connection, IDomainId domainId, int maxRetries, IAppTraceSource tracer, CancellationToken cancellationToken)
+        private static IDedupStoreHttpClient GetDedupStoreHttpClient(
+            VssConnection connection, 
+            IDomainId domainId, 
+            int maxRetries, 
+            IAppTraceSource tracer, 
+            CancellationToken cancellationToken)
         {
             ArtifactHttpClientFactory factory = new ArtifactHttpClientFactory(
                 connection.Credentials,
@@ -196,6 +201,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
                 });
             return dedupStoreHttpClient;
         }
+        
         public (DedupStoreClient client, BlobStoreClientTelemetryTfs telemetry) CreateDedupClient(
             VssConnection connection,
             IDomainId domainId,

--- a/src/Microsoft.VisualStudio.Services.Agent/JobServer.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/JobServer.cs
@@ -175,6 +175,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             int maxParallelism = HostContext.GetService<IConfigurationStore>().GetSettings().MaxDedupParallelism;
             var clientSettings = await BlobstoreClientSettings.GetClientSettingsAsync(
                 _connection, 
+                context: null,
                 client: null, 
                 DedupManifestArtifactClientFactory.CreateArtifactsTracer(verbose, (str) => Trace.Info(str)), cancellationToken);
             var (dedupClient, clientTelemetry) = DedupManifestArtifactClientFactory.Instance

--- a/src/Test/L0/Plugin/TestFileShareProvider/MockDedupManifestArtifactClientFactory.cs
+++ b/src/Test/L0/Plugin/TestFileShareProvider/MockDedupManifestArtifactClientFactory.cs
@@ -44,7 +44,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             int maxParallelism,
             IDomainId domainId,
             BlobstoreClientSettings clientSettings,
-            AgentTaskPluginExecutionContext context,
             CancellationToken cancellationToken)
         {
             telemetrySender = new TestTelemetrySender();


### PR DESCRIPTION
1) Make the BlobstoreClientSettings constructor take an IKnobValueContext so we can centralize handling agent knobs instead of sprinkling it into the class methods.
2) Remove now unneeded method parameters from DedupManifestClientFactory and BlobstoreClientSettings
3) Default the AgentEnablePipelineArtifactLargeChunkSize knob to true 