### PR TITLE
Add SessionConflict return code

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -327,9 +327,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             {
                 Trace.Info(nameof(RunAsync));
                 _listener = HostContext.GetService<IMessageListener>();
-                if (!await _listener.CreateSessionAsync(HostContext.AgentShutdownToken))
+                int returnCode = await _listener.CreateSessionAsync(HostContext.AgentShutdownToken);
+                if (returnCode != Constants.Agent.ReturnCode.Success)
                 {
-                    return Constants.Agent.ReturnCode.TerminatedError;
+                    return returnCode;
                 }
 
                 HostContext.WritePerfCounter("SessionCreated");

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -209,6 +209,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 public const int RetryableError = 2;
                 public const int AgentUpdating = 3;
                 public const int RunOnceAgentUpdating = 4;
+                public const int SessionConflict = 5;
             }
 
             public static class AgentConfigurationProvider

--- a/src/Test/L0/Listener/AgentL0.cs
+++ b/src/Test/L0/Listener/AgentL0.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 _configStore.Setup(x => x.IsServiceConfigured()).Returns(configureAsService);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(false));
+                     .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.TerminatedError));
 
                 agent.Initialize(hc);
                 await agent.ExecuteCommand(command);
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                     .Returns(false);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(false));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.TerminatedError));
 
                 agent.Initialize(hc);
                 await agent.ExecuteCommand(command);
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                     .Returns(false);
 
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(false));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.TerminatedError));
 
                 agent.Initialize(hc);
                 await agent.ExecuteCommand(command);
@@ -330,7 +330,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -435,7 +435,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -537,7 +537,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {
@@ -766,7 +766,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 _configurationManager.Setup(x => x.IsConfigured())
                     .Returns(true);
                 _messageListener.Setup(x => x.CreateSessionAsync(It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult<bool>(true));
+                    .Returns(Task.FromResult<int>(Constants.Agent.ReturnCode.Success));
                 _messageListener.Setup(x => x.GetNextMessageAsync(It.IsAny<CancellationToken>()))
                     .Returns(async () =>
                         {

--- a/src/Test/L0/Listener/MessageListenerL0.cs
+++ b/src/Test/L0/Listener/MessageListenerL0.cs
@@ -88,11 +88,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 MessageListener listener = new MessageListener();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
                 trace.Info("result: {0}", result);
 
                 // Assert.
-                Assert.True(result);
+                Assert.Equal(Constants.Agent.ReturnCode.Success, result);
                 _agentServer
                     .Verify(x => x.CreateAgentSessionAsync(
                         _settings.PoolId,
@@ -132,8 +132,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 MessageListener listener = new MessageListener();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.True(result);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Agent.ReturnCode.Success, result);
 
                 _agentServer
                     .Setup(x => x.DeleteAgentSessionAsync(
@@ -179,8 +179,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Listener
                 MessageListener listener = new MessageListener();
                 listener.Initialize(tc);
 
-                bool result = await listener.CreateSessionAsync(tokenSource.Token);
-                Assert.True(result);
+                int result = await listener.CreateSessionAsync(tokenSource.Token);
+                Assert.Equal(Constants.Agent.ReturnCode.Success, result);
 
                 var arMessages = new TaskAgentMessage[]
                 {


### PR DESCRIPTION
Bubbles up a new return code `SessionConflict` to allow MMS/hosted compute to handle this case differently than other failures.