### PR TITLE
Agent's git should not use HTTP/2.0 (use HTTP/1.1 instead)

### DIFF
--- a/src/Agent.Worker/Build/GitSourceProvider.cs
+++ b/src/Agent.Worker/Build/GitSourceProvider.cs
@@ -657,6 +657,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
                 executionContext.Warning("Unable turn off git auto garbage collection, git fetch operation may trigger auto garbage collection which will affect the performance of fetching.");
             }
 
+            // Force Git to HTTP/1.1. Otherwise IIS will reject large pushes to Azure Repos due to the large content-length header
+            // This is caused by these header limits - https://docs.microsoft.com/en-us/iis/configuration/system.webserver/security/requestfiltering/requestlimits/headerlimits/
+            int exitCode_configHttp = await _gitCommandManager.GitConfig(executionContext, targetPath, "http.version", "HTTP/1.1");
+            if (exitCode_configHttp != 0)
+            {
+                executionContext.Warning($"Forcing Git to HTTP/1.1 failed with exit code: {exitCode_configHttp}");
+            }
+
             SetGitFeatureFlagsConfiguration(executionContext, _gitCommandManager, targetPath);
 
             // always remove any possible left extraheader setting from git config.


### PR DESCRIPTION
**Description**
Added http.version for Build/GitSourceProvider which is used for checkout repo in releases, similar to [Agent.Plugins/GitSourceProvider.cs](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Plugins/GitSourceProvider.cs#L726) which is used for the yml checkout.


**Related WI**: 2140175

**Testing**:
Tested in local organization