### PR TITLE
Build the agent `linux-musl-arm64`

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -51,6 +51,9 @@ parameters:
 - name: alpine_x64
   type: boolean
   default: true
+- name: alpine_arm64
+  type: boolean
+  default: true
 - name: macOS_x64
   type: boolean
   default: true
@@ -234,6 +237,26 @@ extends:
             #container: alpine
             os: linux-musl
             arch: x64
+            branch: ${{ parameters.branch }}
+            unitTests: ${{ parameters.test }}
+            functionalTests: false
+            sign: false
+            publishArtifacts: ${{ parameters.publishArtifacts }}
+            buildAlternatePackage: false
+
+  # Alpine (ARM64)
+      - ${{ if parameters.alpine_arm64 }}:
+        - template: /.azure-pipelines/build-jobs.yml@self
+          parameters:
+            jobName: build_alpine_arm64
+            displayName: Alpine (ARM64)
+            pool:
+              name: 1ES-ABTT-Shared-ARM-64-Pool
+              vmImage: abtt-mariner_arm64
+              os: linux
+            # container: # arm64v8/alpine (N/A)
+            os: linux-musl
+            arch: arm64
             branch: ${{ parameters.branch }}
             unitTests: ${{ parameters.test }}
             functionalTests: false

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -30,6 +30,10 @@ parameters:
   type: boolean
   displayName: Alpine (x64)
   default: true
+- name: alpine_arm64
+  type: boolean
+  displayName: Alpine (ARM64)
+  default: false
 - name: macOS_x64
   type: boolean
   displayName: macOS (x64)
@@ -59,5 +63,6 @@ extends:
     linux_arm: ${{ parameters.linux_arm }}
     linux_arm64: ${{ parameters.linux_arm64 }}
     alpine_x64: ${{ parameters.alpine_x64 }}
+    alpine_arm64: ${{ parameters.alpine_arm64 }}
     macOS_x64: ${{ parameters.macOS_x64 }}
     macOS_arm64: ${{ parameters.macOS_arm64 }}

--- a/assets.json
+++ b/assets.json
@@ -88,5 +88,11 @@
         "platform": "linux-musl-x64",
         "version": "<AGENT_VERSION>",
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz"
+    },
+    {
+        "name": "vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz",
+        "platform": "linux-musl-arm64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz"
     }
 ]

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -11,6 +11,7 @@
 | Linux ARM      | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux ARM64    | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux musl x64 | [vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux musl ARM64 | [vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 
 After Download:
 
@@ -65,12 +66,21 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 
 ## Alpine x64
 
+***Note:*** Node 6 does not exist for Alpine.
+
 ``` bash
 ~/$ mkdir myagent && cd myagent
 ~/myagent$ tar xzf ~/Downloads/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz
 ```
 
+## Alpine ARM64
+
 ***Note:*** Node 6 does not exist for Alpine.
+
+``` bash
+~/$ mkdir myagent && cd myagent
+~/myagent$ tar xzf ~/Downloads/vsts-agent-linux-musl-ARM64-<AGENT_VERSION>.tar.gz
+```
 
 ## Alternate Agent Downloads
 

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -169,13 +169,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     var taskManager = HostContext.GetService<ITaskManager>();
                     await taskManager.DownloadAsync(context, message.Steps);
 
-                    if (!AgentKnobs.DisableNode6Tasks.GetValue(context).AsBoolean())
+                    if (!AgentKnobs.DisableNode6Tasks.GetValue(context).AsBoolean() && !PlatformUtil.RunningOnAlpine)
                     {
                         Trace.Info("Downloading Node 6 runner.");
                         var nodeUtil = new NodeJsUtil(HostContext);
                         await nodeUtil.DownloadNodeRunnerAsync(context, register.Token);
-                    } 
-          
+                    }
+
                     // Parse all Task conditions.
                     Trace.Info("Parsing all task's condition inputs.");
                     var expression = HostContext.GetService<IExpressionManager>();

--- a/src/Common.props
+++ b/src/Common.props
@@ -52,6 +52,9 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-musl-x64'">
     <OSArchitecture>X64</OSArchitecture>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-musl-arm64'">
+    <OSArchitecture>ARM64</OSArchitecture>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_LINUX' AND '$(PackageRuntime)' == 'linux-arm'">
     <OSArchitecture>ARM</OSArchitecture>
   </PropertyGroup>

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -44,9 +44,14 @@
         <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
-    <ServicingStep name="Add Linux musl x64 agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+    <ServicingStep name="Add x64 Linux musl agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="agent" platform="linux-musl-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add ARM64 Linux musl agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="agent" platform="linux-musl-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -18,6 +18,8 @@ if ($pwd -notlike '*tfsgheus20') {
 
     Add-DistributedTaskPackage -PackageType agent -Platform linux-musl-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz
 
+    Add-DistributedTaskPackage -PackageType agent -Platform linux-musl-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz
+
     Add-DistributedTaskPackage -PackageType agent -Platform osx-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz
 
     # alternate packages

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -201,6 +201,15 @@ else
         ARCH="darwin-arm64"
         acquireExternalTool "${NODE_URL}/v${NODE16_VERSION}/node-v${NODE16_VERSION}-${ARCH}.tar.gz" node16 fix_nested_dir
         acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/node-v${NODE20_VERSION}-${ARCH}.tar.gz" node20_1 fix_nested_dir
+    elif [[ "$PACKAGERUNTIME" == "linux-musl-arm64" ]]; then
+        ARCH="linux-arm64-musl"
+
+        if [[ "$INCLUDE_NODE10" == "true" ]]; then
+            acquireExternalTool "${CONTAINER_URL}/nodejs/${ARCH}/node-v${NODE10_VERSION}-${ARCH}.tar.gz" node10/bin fix_nested_dir
+        fi
+
+        acquireExternalTool "${CONTAINER_URL}/nodejs/${ARCH}/node-v${NODE16_VERSION}-${ARCH}.tar.gz" node16/bin fix_nested_dir
+        acquireExternalTool "${CONTAINER_URL}/nodejs/${ARCH}/node-v${NODE20_VERSION}-${ARCH}.tar.gz" node20_1/bin fix_nested_dir
     else
         case $PACKAGERUNTIME in
             "linux-musl-x64") ARCH="linux-x64-musl";;

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 "linux-arm",
                 "linux-arm64",
                 "linux-musl-x64",
+                "linux-musl-arm64",
                 "osx-x64",
                 "osx-arm64"
             };

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -75,6 +75,9 @@ function detect_platform_and_runtime_id ()
 
         if [ -e /etc/alpine-release ]; then
             DETECTED_RUNTIME_ID='linux-musl-x64'
+            if [ $(uname -m) == 'aarch64' ]; then
+                DETECTED_RUNTIME_ID='linux-musl-arm64'
+            fi
         fi
     elif [[ "$CURRENT_PLATFORM" == 'darwin' ]]; then
         DETECTED_RUNTIME_ID='osx-x64'
@@ -298,7 +301,7 @@ else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
 fi
 
-_VALID_RIDS='linux-x64:linux-arm:linux-arm64:linux-musl-x64:osx-x64:osx-arm64:win-x64:win-x86'
+_VALID_RIDS='linux-x64:linux-arm:linux-arm64:linux-musl-x64:linux-musl-arm64:osx-x64:osx-arm64:win-x64:win-x86'
 if [[ ":$_VALID_RIDS:" != *:$RUNTIME_ID:* ]]; then
     failed "must specify a valid target runtime ID (one of: $_VALID_RIDS)"
 fi


### PR DESCRIPTION
***Description:*** Starting to support the agent for Alpine ARM64.

* `RuntimeIdentifier` for Alpine ARM64 is set to `linux-musl-arm64`.

* URL to download node for Alpine ARM64 is set to
`https://vstsagenttools.blob.core.windows.net/tools/nodejs/linux-arm64-musl/node-v<X.X.X>-linux-arm64-musl.tar.gz`

* Building the agent for Alpine ARM64 is added to the agent CI.

* Checked that applied changes work as expected (tested end-to-end).