### PR TITLE
Added tag for not masked message

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -696,7 +696,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         // the rule is command messages - which should be crafted using strongly typed wrapper methods.
         public long Write(string tag, string inputMessage, bool canMaskSecrets = true)
         {
-            string message = canMaskSecrets ? HostContext.SecretMasker.MaskSecrets($"{tag}{inputMessage}") : inputMessage;
+            string message = $"{tag}{inputMessage}";
+            if (canMaskSecrets)
+            {
+                message = HostContext.SecretMasker.MaskSecrets(message);
+            }
 
             long totalLines;
             lock (_loggerLock)


### PR DESCRIPTION
When `canMaskSecrets=true`, `Write` method ignored a message tag which is not by design.