### PR TITLE
Add workfolder validation for nix systems

### DIFF
--- a/src/Agent.Listener/CommandSettings.cs
+++ b/src/Agent.Listener/CommandSettings.cs
@@ -452,7 +452,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 validator: Validators.NonEmptyValidator);
         }
 
-        public string GetWork()
+        public string GetWorkNonValidated()
         {
             return GetArgOrPrompt(
                 argValue: Configure?.Work,
@@ -460,6 +460,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 description: StringUtil.Loc("WorkFolderDescription"),
                 defaultValue: Constants.Path.WorkDirectory,
                 validator: Validators.NonEmptyValidator);
+        }
+
+        public string GetWork()
+        {
+            return GetArgOrPrompt(
+                argValue: Configure?.Work,
+                name: Constants.Agent.CommandLine.Args.Work,
+                description: StringUtil.Loc("WorkFolderDescription"),
+                defaultValue: Constants.Path.WorkDirectory,
+                validator: Validators.WorkFolderPathValidator);
         }
 
         public string GetMonitorSocketAddress()

--- a/src/Agent.Listener/CommandSettings.cs
+++ b/src/Agent.Listener/CommandSettings.cs
@@ -452,24 +452,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 validator: Validators.NonEmptyValidator);
         }
 
-        public string GetWorkNonValidated()
+        public string GetWork(bool validateWorkFolderPath = false)
         {
-            return GetArgOrPrompt(
-                argValue: Configure?.Work,
-                name: Constants.Agent.CommandLine.Args.Work,
-                description: StringUtil.Loc("WorkFolderDescription"),
-                defaultValue: Constants.Path.WorkDirectory,
-                validator: Validators.NonEmptyValidator);
-        }
+            var validator = Validators.NonEmptyValidator;
+            if (validateWorkFolderPath)
+            {
+                validator = Validators.WorkFolderPathValidator;
+            }
 
-        public string GetWork()
-        {
             return GetArgOrPrompt(
                 argValue: Configure?.Work,
                 name: Constants.Agent.CommandLine.Args.Work,
                 description: StringUtil.Loc("WorkFolderDescription"),
                 defaultValue: Constants.Path.WorkDirectory,
-                validator: Validators.WorkFolderPathValidator);
+                validator: validator);
         }
 
         public string GetMonitorSocketAddress()

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -388,7 +388,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             }
 
             // We will Combine() what's stored with root.  Defaults to string a relative path
-            agentSettings.WorkFolder = command.GetWork();
+            if (PlatformUtil.RunningOnWindows)
+            {
+                agentSettings.WorkFolder = command.GetWorkNonValidated();
+            }
+            else
+            {
+                agentSettings.WorkFolder = command.GetWork();
+            }
 
             // notificationPipeName for Hosted agent provisioner.
             agentSettings.NotificationPipeName = command.GetNotificationPipeName();

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -22,6 +22,7 @@ using System.Security.AccessControl;
 using System.Security.Principal;
 using Newtonsoft.Json;
 using Microsoft.VisualStudio.Services.Agent.Listener.Telemetry;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
 {
@@ -390,7 +391,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
             // Check if the workFolder path contains spaces on linux and macos
             bool validateWorkFolderPath = false;
 
-            if (!PlatformUtil.RunningOnWindows)
+            if (!AgentKnobs.AgentSkipWorkFolderValidation.GetValue(HostContext).AsBoolean() && !PlatformUtil.RunningOnWindows)
             {
                 validateWorkFolderPath = true;
             }

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -387,15 +387,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 throw;
             }
 
+            // Check if the workFolder path contains spaces or file extensions on linux and macos
+            bool validateWorkFolderPath = false;
+
+            if (!PlatformUtil.RunningOnWindows)
+            {
+                validateWorkFolderPath = true;
+            }
+
             // We will Combine() what's stored with root.  Defaults to string a relative path
-            if (PlatformUtil.RunningOnWindows)
-            {
-                agentSettings.WorkFolder = command.GetWorkNonValidated();
-            }
-            else
-            {
-                agentSettings.WorkFolder = command.GetWork();
-            }
+            agentSettings.WorkFolder = command.GetWork(validateWorkFolderPath);
 
             // notificationPipeName for Hosted agent provisioner.
             agentSettings.NotificationPipeName = command.GetNotificationPipeName();

--- a/src/Agent.Listener/Configuration/ConfigurationManager.cs
+++ b/src/Agent.Listener/Configuration/ConfigurationManager.cs
@@ -387,7 +387,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 throw;
             }
 
-            // Check if the workFolder path contains spaces or file extensions on linux and macos
+            // Check if the workFolder path contains spaces on linux and macos
             bool validateWorkFolderPath = false;
 
             if (!PlatformUtil.RunningOnWindows)

--- a/src/Agent.Listener/Configuration/Validators.cs
+++ b/src/Agent.Listener/Configuration/Validators.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                 return false;
             }
 
-            if (value.Contains(' ') || value.Contains(".sh"))
+            if (value.Contains(' '))
             {
                 Console.WriteLine(StringUtil.Loc("InvalidWorkFolderPath"));
                 return false;

--- a/src/Agent.Listener/Configuration/Validators.cs
+++ b/src/Agent.Listener/Configuration/Validators.cs
@@ -68,6 +68,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener.Configuration
                    string.Equals(value, StringUtil.Loc("N"), StringComparison.CurrentCultureIgnoreCase);
         }
 
+        public static bool WorkFolderPathValidator(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            if (value.Contains(' ') || value.Contains(".sh"))
+            {
+                Console.WriteLine(StringUtil.Loc("InvalidWorkFolderPath"));
+                return false;
+            }
+
+            return true;
+        }
+
         public static bool NonEmptyValidator(string value)
         {
             return !string.IsNullOrEmpty(value);

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -413,6 +413,12 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("ENABLE_FCS_ITEM_PATH_FIX"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob AgentSkipWorkFolderValidation = new Knob(
+            nameof(AgentSkipWorkFolderValidation),
+            "If true, skip the workfolder path validation on nix systems during the agent configuration.",
+            new EnvironmentKnobSource("AZP_SKIP_WORKFOLDER_VALIDATION"),
+            new BuiltInDefaultKnobSource("false"));
+
         // Set DISABLE_JAVA_CAPABILITY_HIGHER_THAN_9 variable with any value
         // to disable recognition of Java higher than 9
         public static readonly Knob DisableRecognitionOfJDKHigherThen9 = new Knob(

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -384,7 +384,7 @@
   "InvalidSIDForUser": "Invalid Security Identifier for the user {0}\\{1} while configuring/unconfiguring AutoLogon. Refer logs for more details.",
   "InvalidValueInXml": "Unable to retrieve value for '{0}' from the summary file '{1}'. Verify the summary file is well-formed and try again.",
   "InvalidWindowsCredential": "Invalid windows credentials entered. Try again or ctrl-c to quit",
-  "InvalidWorkFolderPath": "Invalid work folder path, please avoid using spaces or file extensions in the path.",
+  "InvalidWorkFolderPath": "Invalid work folder path, please avoid using spaces in the path.",
   "JenkinsBuildDoesNotExistsForCommits": "Cannot find build index for jenkins builds {0} and {1}. Found indexes are {2} and {3}. Probably the build does not exist",
   "JenkinsCommitsInvalidEndJobId": "EndJobId {0} associated with the jenkins artifact {1} is invalid. Commits will not be downloaded.",
   "JenkinsDownloadingChangeFromCurrentBuild": "Cannot find endJobId, will be fetching the current build's changeset",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -384,6 +384,7 @@
   "InvalidSIDForUser": "Invalid Security Identifier for the user {0}\\{1} while configuring/unconfiguring AutoLogon. Refer logs for more details.",
   "InvalidValueInXml": "Unable to retrieve value for '{0}' from the summary file '{1}'. Verify the summary file is well-formed and try again.",
   "InvalidWindowsCredential": "Invalid windows credentials entered. Try again or ctrl-c to quit",
+  "InvalidWorkFolderPath": "Invalid work folder path, please avoid using spaces or file extensions in the path.",
   "JenkinsBuildDoesNotExistsForCommits": "Cannot find build index for jenkins builds {0} and {1}. Found indexes are {2} and {3}. Probably the build does not exist",
   "JenkinsCommitsInvalidEndJobId": "EndJobId {0} associated with the jenkins artifact {1} is invalid. Commits will not be downloaded.",
   "JenkinsDownloadingChangeFromCurrentBuild": "Cannot find endJobId, will be fetching the current build's changeset",

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -790,7 +790,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     .Returns("some work");
 
                 // Act.
-                string actual = command.GetWork();
+                string actual = command.GetWorkNonValidated();
 
                 // Assert.
                 Assert.Equal("some work", actual);

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -790,7 +790,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                     .Returns("some work");
 
                 // Act.
-                string actual = command.GetWorkNonValidated();
+                string actual = command.GetWork();
 
                 // Assert.
                 Assert.Equal("some work", actual);


### PR DESCRIPTION
This PR adds `workFolder` directory path validation during the agent configuration for Linux and MacOS systems to avoid incorrect paths or typos that may lead to various failures.

**WI:** https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2165472

**Example**
In case if `workFolder` was set to `svc.sh start`/`some folder`
```
workingDirectory=***/azure-pipelines-agent/_layout/osx-arm64/svc.sh start/1/s
```
Some commands executed in Bash task will incorrectly parse the agent folders.
```
cp -r $AGENT_TEMPDIRECTORY/ $AGENT_WORKFOLDER/* 
```
```
cp: target 'start/*' is not a directory
```

**Testing:**
Validated on Ubuntu 22.04 / MacOS 14.0

**How it was tested:**
```
Testing agent connection.
Enter work folder (press enter for _work) > svc.sh start
Invalid work folder path, please avoid using spaces or file extensions in the path.
Enter a valid value for work folder.
Enter work folder (press enter for _work) > some folder
Invalid work folder path, please avoid using spaces or file extensions in the path.
Enter a valid value for work folder.
Enter work folder (press enter for _work) >
***: Settings Saved.
```