### PR TITLE
Handling disposed connection

### DIFF
--- a/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
@@ -49,6 +49,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
             _resultReader = GetTestResultReader(_testRunner, publishRunLevelAttachments);
             _testRunPublisher = HostContext.GetService<ITestRunPublisher>();
             _featureFlagService = HostContext.GetService<IFeatureFlagService>();
+            _featureFlagService.InitializeFeatureService(_executionContext, connection);
             _testRunPublisher.InitializePublisher(_executionContext, connection, projectName, _resultReader);
             _testResultsServer = HostContext.GetService<ITestResultsServer>();
             _testResultsServer.InitializeServer(connection, _executionContext);

--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -57,6 +57,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             _testResultsServer.InitializeServer(connection, _executionContext);
             var extensionManager = HostContext.GetService<IExtensionManager>();
             _featureFlagService = HostContext.GetService<IFeatureFlagService>();
+            _featureFlagService.InitializeFeatureService(_executionContext, connection);
             _parser = (extensionManager.GetExtensions<IParser>()).FirstOrDefault(x => _testRunner.Equals(x.Name, StringComparison.OrdinalIgnoreCase));
             _testRunPublisherHelper = new TestRunDataPublisherHelper(_executionContext, _testRunPublisher, null, _testResultsServer);
             Trace.Leaving();


### PR DESCRIPTION
We are trying to use a connection which is already disposed. This change was introduced in this PR : https://github.com/microsoft/azure-pipelines-agent/pull/4708

As a fix, we are initializing the service at the time of object creation and disposing of connection would be taken care by the using statement in the parent block. 

We have an active CRI which is dependent on this fix.

Before : 
![image](https://github.com/microsoft/azure-pipelines-agent/assets/110218555/819b6f7e-fa49-4769-ab29-fbc8c2c6269a)

After :
![image](https://github.com/microsoft/azure-pipelines-agent/assets/110218555/20e88a4f-6c75-43bd-a997-a366af70065a)
