### PR TITLE
Allow publish execution handler telemetry for non in-the-box tasks

### DIFF
--- a/src/Agent.Worker/TaskRunner.cs
+++ b/src/Agent.Worker/TaskRunner.cs
@@ -636,11 +636,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         private void PublishTelemetry(Definition taskDefinition, HandlerData handlerData)
         {
-            if (!IsTelemetryPublishRequired())
-            {
-                return;
-            }
-
             ArgUtil.NotNull(Task, nameof(Task));
             ArgUtil.NotNull(Task.Reference, nameof(Task.Reference));
             ArgUtil.NotNull(taskDefinition.Data, nameof(taskDefinition.Data));

--- a/src/Test/L0/NodeHandlerL0.cs
+++ b/src/Test/L0/NodeHandlerL0.cs
@@ -30,6 +30,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Trait("Category", "Common")]
         public void UseNodeForNodeHandlerEnvVarNotSet()
         {
+            ResetNodeKnobs();
+
             var agentUseNode10 = Environment.GetEnvironmentVariable("AGENT_USE_NODE10");
             Environment.SetEnvironmentVariable("AGENT_USE_NODE10", null);
             using (TestHostContext thc = CreateTestHostContext())
@@ -67,6 +69,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Trait("Category", "Common")]
         public void UseNewNodeForNewNodeHandler(string nodeVersion)
         {
+            ResetNodeKnobs();
+
             using (TestHostContext thc = CreateTestHostContext())
             {
                 thc.SetSingleton(new WorkerCommandManager() as IWorkerCommandManager);
@@ -161,6 +165,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Trait("Category", "Common")]
         public void UseNewNodeForNewNodeHandlerHostContextVarUnset()
         {
+            ResetNodeKnobs();
+
             using (TestHostContext thc = CreateTestHostContext())
             {
                 thc.SetSingleton(new WorkerCommandManager() as IWorkerCommandManager);
@@ -458,6 +464,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 .Returns(Array.Empty<string>);
 
             return nodeHandlerHelper;
+        }
+
+        private void ResetNodeKnobs()
+        {
+            Environment.SetEnvironmentVariable("AGENT_USE_NODE10", null);
+            Environment.SetEnvironmentVariable("AGENT_USE_NODE20_1", null);
+            Environment.SetEnvironmentVariable("AGENT_USE_NODE20_IN_UNSUPPORTED_SYSTEM", null);
         }
     }
 }

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -200,6 +200,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             // Use different working directories for each test
             var config = GetMockedService<FakeConfigurationStore>(); // TODO: Need to update this. can hack it for now.
             config.WorkingDirectoryName = testName;
+            
+            // Reset node knobs in case if tests cruns in the pipeline or machine set node envs
+            ResetNodeKnobs();
         }
 
         public string GetWorkingDirectory([CallerMemberName] string testName = "")
@@ -345,6 +348,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        private void ResetNodeKnobs()
+        {
+            Environment.SetEnvironmentVariable("AGENT_USE_NODE10", null);
+            Environment.SetEnvironmentVariable("AGENT_USE_NODE20_1", null);
+            Environment.SetEnvironmentVariable("AGENT_USE_NODE20_IN_UNSUPPORTED_SYSTEM", null);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Description:
Removed check for in-the-box tasks when we publish handlers' telemetry. 
Fix flaky tests when node knobs set on target machine or in the pipeline

Related WI: 2139555