### PR TITLE
Use useradd on Alpine when user ID is large

### DIFF
--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -27,6 +27,7 @@
   "AgentWithSameNameAlreadyExistInPool": "Pool {0} already contains an agent with name {1}.",
   "AllowContainerUserRunDocker": "Allow user '{0}' run any docker command without SUDO.",
   "AlreadyConfiguredError": "Cannot configure the agent because it is already configured. To reconfigure the agent, run 'config.cmd remove' or './config.sh remove' first.",
+  "ApkAddShadowFailed": "The user ID is outside the range of the 'adduser' command. The alternative command 'useradd' cannot be used because the 'shadow' package is not preinstalled and the attempt to install this package failed. Check network availability or use a docker image with the 'shadow' package preinstalled.",
   "ArgumentNeeded": "'{0}' has to be specified.",
   "ArtifactCustomPropertiesNotJson": "Artifact custom properties is not valid JSON: '{0}'",
   "ArtifactCustomPropertyInvalid": "Artifact custom properties must be prefixed with 'user-'. Invalid property: '{0}'",


### PR DESCRIPTION
***Description:*** The `adduser` command can be used in Alpine by default without installing any additional packages. Therefore, this command has a higher priority. However, it does not work if the user ID is greater than `256000`. In this case, we should install the additional `shadow` package and use the `useradd` command instead.

The `shadow` package will be used in the following cases:
* if this package is preinstalled in the container;
* if user ID is outside the range of the `adduser` command.

[Related issue](https://github.com/microsoft/azure-pipelines-agent/issues/4519)