### PR TITLE
Remove PAT from the agent CI

### DIFF
--- a/.azure-pipelines/get-pat.yml
+++ b/.azure-pipelines/get-pat.yml
@@ -1,0 +1,11 @@
+steps:
+- task: AzureCLI@2
+  inputs:
+    azureSubscription: ARM - WIF - manual
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      az account set --subscription $(SUBSCRIPTION_ID)
+      $accessToken = az account get-access-token --resource $(RESOURCE_ID) --query accessToken --output tsv
+      echo "##vso[task.setvariable variable=ACCESS_TOKEN;issecret=true]$accessToken"
+  displayName: Get Access Token

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -111,6 +111,7 @@ extends:
             nugetMultiFeedWarnLevel: none
           timeoutInMinutes: 300
           steps:
+          - template: /.azure-pipelines/get-pat.yml@self
           - bash: |
               cd ./.azure-pipelines/scripts/
               npm install axios minimist
@@ -123,7 +124,7 @@ extends:
               node ./run-and-verify.js \
                   --projectUrl "$(CANARY_PROJECT_URL)" \
                   --pipelineId "$(CANARY_PIPELINE_ID)" \
-                  --token "$(CANARY_PAT)" \
+                  --token "$(ACCESS_TOKEN)" \
                   --templateParameters "{ \"branch\": \"${branch}\" }"
             displayName: Test Proxy Agent
 


### PR DESCRIPTION
***Description:*** we need to get a new access token on each pipeline run via WIF instead of using canary PAT in the agent CI pipeline and in the agent release pipeline.