### PR TITLE
Remove ADO PAT for PRs

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -275,7 +275,7 @@ extends:
             displayName: macOS (x64)
             pool:
               name: Azure Pipelines
-              image: macOS-11
+              image: macOS-12
               os: macOS
             os: osx
             arch: x64

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -313,6 +313,8 @@ extends:
               artifactName: hash
               downloadPath: $(Build.SourcesDirectory)/_hashes
 
+          - template: /.azure-pipelines/get-pat.yml@self
+
           - bash: |
               set -x
               cd release
@@ -323,7 +325,7 @@ extends:
             displayName: Create PRs in AzureDevOps and ConfigChange
             env:
               USERNAME: $(User)
-              PAT: $(AdoPAT)
+              PAT: $(ACCESS_TOKEN)
               USEREMAIL: $(Email)
 
       - stage: S_Notifications


### PR DESCRIPTION
***Description:*** We need to remove ADO PAT from the pipeline of the agent release and use managed identity access token instead. Also, we have to use macOS-12 instead of macOS-11 due to [macOS-11 deprecation](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=28723903&view=logs&j=a7533b8e-2c22-5589-2003-d02b2580e365).

Tested that applied changes work as expected, here are test results —

* [Related pipeline run of the agent release](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=28723925&view=logs&j=8e497cd2-0b8c-5af9-6ec7-0b8908a3af69&t=5e4ec01d-21a9-5613-cf19-3cdde27bfd65)

* [ADO PR created during test run](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps/pullrequest/791793)

* [ADO.CC PR created during test run](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps.ConfigChange/pullrequest/791794)