### PR TITLE
Mask ACR token on Windows when System.Debug is true

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -721,7 +721,7 @@ namespace Agent.Sdk.Knob
             nameof(UseDockerStdinPasswordOnWindows),
             "If true, use --password-stdin for docker login on Windows.",
             new RuntimeKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
-            new EnvironmentKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
+            new PipelineFeatureSource("UseDockerStdinPasswordOnWindows"),
             new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -716,5 +716,14 @@ namespace Agent.Sdk.Knob
             "Checks if the PSModulePath environment variable contains locations specific to PowerShell Core.",
             new EnvironmentKnobSource("AZP_AGENT_CHECK_PSMODULES_LOCATIONS"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob UseDockerStdinPasswordOnWindows = new Knob(
+            nameof(CheckPsModulesLocations),
+            "If true, use --password-stdin for docker login on Windows.",
+            new EnvironmentKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
+            new RuntimeKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
+            new EnvironmentKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
+            new PipelineFeatureSource("UseDockerStdinPasswordOnWindows"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -718,12 +718,10 @@ namespace Agent.Sdk.Knob
             new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob UseDockerStdinPasswordOnWindows = new Knob(
-            nameof(CheckPsModulesLocations),
+            nameof(UseDockerStdinPasswordOnWindows),
             "If true, use --password-stdin for docker login on Windows.",
-            new EnvironmentKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
             new RuntimeKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
             new EnvironmentKnobSource("AZP_AGENT_USE_DOCKER_STDIN_PASSWORD_WINDOWS"),
-            new PipelineFeatureSource("UseDockerStdinPasswordOnWindows"),
             new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -100,7 +100,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             ArgUtil.NotNull(username, nameof(username));
             ArgUtil.NotNull(password, nameof(password));
 
-            var action = new Func<Task<int>>(async () => PlatformUtil.RunningOnWindows
+            var useDockerStdinPasswordOnWindows = AgentKnobs.UseDockerStdinPasswordOnWindows.GetValue(context).AsBoolean();
+
+            var action = new Func<Task<int>>(async () => PlatformUtil.RunningOnWindows && !useDockerStdinPasswordOnWindows
                 // Wait for 17.07 to switch using stdin for docker registry password.
                 ? await ExecuteDockerCommandAsync(context, "login", $"--username \"{username}\" --password \"{password.Replace("\"", "\\\"")}\" {server}", new List<string>() { password }, context.CancellationToken)
                 : await ExecuteDockerCommandAsync(context, "login", $"--username \"{username}\" --password-stdin {server}", new List<string>() { password }, context.CancellationToken)

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -296,6 +296,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             {
                 throw new NotSupportedException("Could not acquire ACR token from given AAD token. Please check that the necessary access is provided and try again.");
             }
+
+            // Mark retrieved password as secret
+            HostContext.SecretMasker.AddValue(AcrPassword);
+
             return AcrPassword;
         }
 


### PR DESCRIPTION
**Description**:
-- Added refresh token to secret masker
-- Added Knob to use --password-stdin on windows

**Related WI**: [AB#2174985](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2174985)

**Testing**: 

Tested with ACR token on test tenant. Refresh-token masked if we use --password argument:
![image](https://github.com/microsoft/azure-pipelines-agent/assets/106314398/a6850f6a-644d-488a-a52d-a8846475e4a3)
And passed via stdin if the knob is enabled
![image](https://github.com/microsoft/azure-pipelines-agent/assets/106314398/b1ee287b-a668-4b7a-9729-a839e211dbd1)
