### PR TITLE
Rename AZP_USENEWNODEHANDLERTELEMETRY  knob

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -569,8 +569,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob UseNewNodeHandlerTelemetry = new Knob(
             nameof(UseNewNodeHandlerTelemetry),
             "Enables new approach to publish node handler information to the telemetry",
-            new RuntimeKnobSource("USENEWNODEHANDLERTELEMETRY"),
-            new EnvironmentKnobSource("USENEWNODEHANDLERTELEMETRY"),
+            new PipelineFeatureSource("USENEWNODEHANDLERTELEMETRY"),
             new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob ProcessHandlerEnableNewLogic = new Knob(

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -569,8 +569,8 @@ namespace Agent.Sdk.Knob
         public static readonly Knob UseNewNodeHandlerTelemetry = new Knob(
             nameof(UseNewNodeHandlerTelemetry),
             "Enables new approach to publish node handler information to the telemetry",
-            new RuntimeKnobSource("AZP_USENEWNODEHANDLERTELEMETRY"),
-            new EnvironmentKnobSource("AZP_USENEWNODEHANDLERTELEMETRY"),
+            new RuntimeKnobSource("USENEWNODEHANDLERTELEMETRY"),
+            new EnvironmentKnobSource("USENEWNODEHANDLERTELEMETRY"),
             new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob ProcessHandlerEnableNewLogic = new Knob(


### PR DESCRIPTION
**Description**:
rename `AZP_USENEWNODEHANDLERTELEMETRY` to `USENEWNODEHANDLERTELEMETRY` to use with dynamic featureflag injection

**Related WI**: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2139555