### PR TITLE
Disable codeql for agent

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -64,14 +64,6 @@ parameters:
   - agent
   - pipelines-agent
 
-- name: disableSdl
-  type: boolean
-  default: false
-
-- name: justificationForDisablingSdl
-  type: string
-  default: ''
-
 jobs:
 
 - job: ${{ parameters.jobName }}
@@ -82,13 +74,6 @@ jobs:
   ${{ if ne(parameters.container, '') }}:
     container: ${{ parameters.container }}
 
-  ${{ if eq(parameters.disableSdl, true) }}:
-    parameters:
-      sdl:
-        codeql:
-          compiled:
-            enabled: false
-            justificationForDisabling: ${{ parameters.justificationForDisablingSdl}}
   variables:
     PACKAGE_TYPE: ${{ parameters.packageType }}
     ${{ if eq(parameters.os, 'win') }}:

--- a/.azure-pipelines/build-jobs.yml
+++ b/.azure-pipelines/build-jobs.yml
@@ -59,10 +59,6 @@ parameters:
   type: boolean
   default: false
 
-- name: disableSdl
-  type: boolean
-  default: false
-
 jobs:
 - template: /.azure-pipelines/build-job.yml@self
   parameters:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -74,6 +74,10 @@ extends:
     featureFlags:
       autoBaseline: false
     sdl:
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: "CodeQL conflicting with signing on osx (see ICM 520690622)"
       # do not fail on CG
       componentgovernance:
         failOnAlert: false

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -275,7 +275,6 @@ extends:
       - ${{ if parameters.macOS_x64 }}:
         - template: /.azure-pipelines/build-jobs.yml@self
           parameters:
-            disableSdl: true
             jobName: build_osx
             displayName: macOS (x64)
             pool:
@@ -295,7 +294,6 @@ extends:
       - ${{ if parameters.macOS_arm64 }}:
         - template: /.azure-pipelines/build-jobs.yml@self
           parameters:
-            disableSdl: true
             jobName: build_osx_arm64
             displayName: macOS (ARM64)
             pool:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -60,6 +60,12 @@ parameters:
 - name: macOS_arm64
   type: boolean
   default: true
+
+variables:
+  - name: ONEES_ENFORCED_CODEQL_ENABLED # Disable CodeQL
+    value: false
+
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -74,11 +80,6 @@ extends:
     featureFlags:
       autoBaseline: false
     sdl:
-      enableAllTools: true
-      codeql:
-        compiled:
-          enabled: false
-          justificationForDisabling: "CodeQL conflicting with signing on osx (see ICM 520690622)"
       # do not fail on CG
       componentgovernance:
         failOnAlert: false

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -74,6 +74,7 @@ extends:
     featureFlags:
       autoBaseline: false
     sdl:
+      enableAllTools: true
       codeql:
         compiled:
           enabled: false

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -61,11 +61,6 @@ parameters:
   type: boolean
   default: true
 
-variables:
-  - name: ONEES_ENFORCED_CODEQL_ENABLED # Disable CodeQL
-    value: false
-
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -43,6 +43,13 @@ parameters:
   displayName: macOS (ARM64)
   default: true
 
+# Skip CG
+variables:
+  - name: OneES_JobScannedCount
+    value: 1
+  - name: ONEES_ENFORCED_CODEQL_ENABLED # Disable CodeQL
+    value: false
+
 pr:
   branches:
     include:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -46,6 +46,8 @@ parameters:
 variables:
   - name: OneES_JobScannedCount
     value: 1
+  - name: ONEES_ENFORCED_CODEQL_ENABLED # Disable CodeQL
+    value: false
 
 extends:
   template: /.azure-pipelines/pipeline.yml@self


### PR DESCRIPTION
Add ONEES_ENFORCED_CODEQL_ENABLED variable to temporary disable CodeQL for release and CI pipelines 