### PR TITLE
Test branch cleanup for release pipeline

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -435,7 +435,7 @@ extends:
               cd release
               npm install
               ls
-              node createAdoPrs.js $(AgentVersion) --dryrun=$(IsTestRun)
+              node createAdoPrs.js $(AgentVersion) --dryrun="$(IsTestRun)"
             name: s_CreateAdoPrs
             displayName: Create PRs in AzureDevOps and ConfigChange
             env:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -362,6 +362,7 @@ extends:
         - Verify_release
         - Create_Release_Branch
         - Release
+        condition: always()
         jobs:
         - job: Delete_Release_Branch
           displayName: Delete Release Branch

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -359,6 +359,7 @@ extends:
       - stage: Cleanup_Release_Branch
         displayName: Cleanup Release Branch
         dependsOn:
+        - Verify_release
         - Create_Release_Branch
         - Release
         jobs:
@@ -369,6 +370,7 @@ extends:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
             ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
             AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
+          condition: eq(variables[IsTestRun, 'True')
 
           pool:
             name: 1ES-ABTT-Shared-Pool
@@ -390,7 +392,6 @@ extends:
                 git push --delete origin v$(AgentVersion)
               }
             displayName: Clean up test release branch
-            condition: eq(variables.IsTestRun, 'True')
 
       - stage: CreatePRs
         dependsOn:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -370,7 +370,7 @@ extends:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
             ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
             AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
-          condition: eq(variables[IsTestRun, 'True')
+          condition: eq(variables.IsTestRun, 'True')
 
           pool:
             name: 1ES-ABTT-Shared-Pool

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -389,7 +389,7 @@ extends:
               }
               
               if (git ls-remote --tags origin v$(AgentVersion)) { 
-                git push --delete origin v$(AgentVersion)
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push --delete origin v$(AgentVersion)
               }
             displayName: Clean up test release branch
 

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -356,6 +356,42 @@ extends:
             displayName: Delete test agent release from Github
             condition: and(succeeded(), eq(variables.IsTestRun, 'True'))
 
+      - stage: Cleanup_Release_Branch
+        displayName: Cleanup Release Branch
+        dependsOn:
+        - Create_Release_Branch
+        - Release
+        condition: eq(variables.IsTestRun, 'True')
+        jobs:
+        - job: Delete_Release_Branch
+          displayName: Delete Release Branch
+          variables:
+            IsTestRun: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ]
+            IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
+            ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
+            AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
+
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-ubuntu-2204
+            os: linux
+          steps:
+          - checkout: self
+
+          - powershell: |
+              git config --global user.email "azure-pipelines-bot@microsoft.com"
+              git config --global user.name "azure-pipelines-bot"
+              git status
+              
+              if (git ls-remote --heads origin $(ReleaseBranch)) { 
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
+              }
+              
+              if (git ls-remote --tags origin v$(AgentVersion)) { 
+                git push --delete origin v$(AgentVersion)
+              }
+            displayName: Clean up test release branch
+
       - stage: CreatePRs
         dependsOn:
         - Release
@@ -443,39 +479,3 @@ extends:
               ADO_PR_LINK: $(AdoPrLink)
               CC_PR_ID: $(CcPrId)
               CC_PR_LINK: $(CcPrLink)
-
-      - stage: Cleanup_Release_Branch
-        displayName: Cleanup Release Branch
-        dependsOn:
-        - Create_Release_Branch
-        - Release
-        condition: eq(variables.IsTestRun, 'True')
-        jobs:
-        - job: Delete_Release_Branch
-          displayName: Delete Release Branch
-          variables:
-            IsTestRun: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ]
-            IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
-            ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
-            AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
-
-          pool:
-            name: 1ES-ABTT-Shared-Pool
-            image: abtt-ubuntu-2204
-            os: linux
-          steps:
-          - checkout: self
-
-          - powershell: |
-              git config --global user.email "azure-pipelines-bot@microsoft.com"
-              git config --global user.name "azure-pipelines-bot"
-              git status
-              
-              if (git ls-remote --heads origin $(ReleaseBranch)) { 
-                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
-              }
-              
-              if (git ls-remote --tags origin v$(AgentVersion)) { 
-                git push --delete origin v$(AgentVersion)
-              }
-            displayName: Clean up test release branch

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -71,7 +71,7 @@ extends:
   parameters:
     branch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
     test: ${{ not(parameters.skipTests) }}
-    sign: false
+    sign: true
     publishArtifacts: true
     testProxyAgent: ${{ parameters.testProxyAgent }}
     stageDependencies:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -369,7 +369,7 @@ extends:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
             ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
             AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
-          condition: eq(variables.IsTestRun, 'True')
+          condition: eq($[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ], 'True')
 
           pool:
             name: 1ES-ABTT-Shared-Pool

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -384,13 +384,16 @@ extends:
               git config --global user.email "azure-pipelines-bot@microsoft.com"
               git config --global user.name "azure-pipelines-bot"
               git status
+
+              $testBranch = "releases/3.000.999"
+              $testTag = "v3.000.999"
               
-              if (git ls-remote --heads origin $(ReleaseBranch)) { 
-                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
+              if (git ls-remote --heads origin $testBranch) { 
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $testBranch)
               }
               
-              if (git ls-remote --tags origin v$(AgentVersion)) { 
-                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push --delete origin v$(AgentVersion)
+              if (git ls-remote --tags origin $testTag) { 
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push --delete origin $testTag)
               }
             displayName: Clean up test release branch
 

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -386,11 +386,11 @@ extends:
               $testTag = "v3.000.999"
               
               if (git ls-remote --heads origin $testBranch) { 
-                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $testBranch)
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $testBranch
               }
               
               if (git ls-remote --tags origin $testTag) { 
-                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push --delete origin $testTag)
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push --delete origin $testTag
               }
             displayName: Clean up test release branch
 

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -1,6 +1,18 @@
 # This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-
 trigger:
+  branches:
+    include:
+    - '*'
+  paths:
+    include:
+    - release
+    - .azure-pipelines
+    - .vsts.release.yml
+
+pr:
+  branches:
+    include:
+    - '*'
   paths:
     include:
     - release
@@ -344,16 +356,6 @@ extends:
             displayName: Delete test agent release from Github
             condition: and(succeeded(), eq(variables.IsTestRun, 'True'))
 
-          # Clean up test release branch
-          - powershell: |
-              git config --global user.email "azure-pipelines-bot@microsoft.com"
-              git config --global user.name "azure-pipelines-bot"
-              git status
-              git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
-              git push --delete origin v$(AgentVersion)
-            displayName: Clean up test release branch
-            condition: and(succeeded(), eq(variables.IsTestRun, 'True'))
-
       - stage: CreatePRs
         dependsOn:
         - Release
@@ -441,3 +443,33 @@ extends:
               ADO_PR_LINK: $(AdoPrLink)
               CC_PR_ID: $(CcPrId)
               CC_PR_LINK: $(CcPrLink)
+
+      - stage: Cleanup_Release_Branch
+        displayName: Cleanup Release Branch
+        dependsOn:
+        - Create_Release_Branch
+        - Release
+        jobs:
+        - job: Delete_Release_Branch
+          displayName: Delete Release Branch
+          variables:
+            IsTestRun: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ]
+            IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
+            ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
+            AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
+          condition: and(succeeded('Create_Release_Branch'), eq(variables.IsTestRun, 'True'))
+
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-ubuntu-2204
+            os: linux
+          steps:
+          - checkout: self
+
+          - powershell: |
+              git config --global user.email "azure-pipelines-bot@microsoft.com"
+              git config --global user.name "azure-pipelines-bot"
+              git status
+              git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
+              git push --delete origin v$(AgentVersion)
+            displayName: Clean up test release branch

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -449,7 +449,7 @@ extends:
         dependsOn:
         - Create_Release_Branch
         - Release
-        condition: and(succeeded('Create_Release_Branch'), eq(variables.IsTestRun, 'True'))
+        condition: eq(variables.IsTestRun, 'True')
         jobs:
         - job: Delete_Release_Branch
           displayName: Delete Release Branch
@@ -470,6 +470,12 @@ extends:
               git config --global user.email "azure-pipelines-bot@microsoft.com"
               git config --global user.name "azure-pipelines-bot"
               git status
-              git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
-              git push --delete origin v$(AgentVersion)
+              
+              if (git ls-remote --heads origin $(ReleaseBranch)) { 
+                git -c credential.helper='!f() { echo "username=pat"; echo "password=$(GithubToken)"; };f' push origin --delete $(ReleaseBranch)
+              }
+              
+              if (git ls-remote --tags origin v$(AgentVersion)) { 
+                git push --delete origin v$(AgentVersion)
+              }
             displayName: Clean up test release branch

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -449,6 +449,7 @@ extends:
         dependsOn:
         - Create_Release_Branch
         - Release
+        condition: and(succeeded('Create_Release_Branch'), eq(variables.IsTestRun, 'True'))
         jobs:
         - job: Delete_Release_Branch
           displayName: Delete Release Branch
@@ -457,7 +458,6 @@ extends:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
             ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
             AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
-          condition: and(succeeded('Create_Release_Branch'), eq(variables.IsTestRun, 'True'))
 
           pool:
             name: 1ES-ABTT-Shared-Pool

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -361,7 +361,6 @@ extends:
         dependsOn:
         - Create_Release_Branch
         - Release
-        condition: eq(variables.IsTestRun, 'True')
         jobs:
         - job: Delete_Release_Branch
           displayName: Delete Release Branch
@@ -370,6 +369,7 @@ extends:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
             ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
             AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
+          condition: eq(variables.IsTestRun, 'True')
 
           pool:
             name: 1ES-ABTT-Shared-Pool

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -368,9 +368,6 @@ extends:
           displayName: Delete Release Branch
           variables:
             IsTestRun: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ]
-            IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
-            ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
-            AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
           condition: eq(variables.IsTestRun, 'True')
 
           pool:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -71,7 +71,7 @@ extends:
   parameters:
     branch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
     test: ${{ not(parameters.skipTests) }}
-    sign: true
+    sign: false
     publishArtifacts: true
     testProxyAgent: ${{ parameters.testProxyAgent }}
     stageDependencies:

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -369,7 +369,6 @@ extends:
             IsRelease: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isRelease'] ]
             ReleaseBranch: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.releaseBranch'] ]
             AgentVersion: $[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.agentVersion'] ]
-          condition: eq($[ stageDependencies.Verify_release.Set_variables.outputs['SetReleaseVariables.isTestRun'] ], 'True')
 
           pool:
             name: 1ES-ABTT-Shared-Pool
@@ -391,6 +390,7 @@ extends:
                 git push --delete origin v$(AgentVersion)
               }
             displayName: Clean up test release branch
+            condition: eq(variables.IsTestRun, 'True')
 
       - stage: CreatePRs
         dependsOn:

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -170,7 +170,7 @@ async function main() {
         util.verifyMinimumGitVersion();
         createIntegrationFiles(agentVersion);
 
-        const dryrun = (opt.options.dryrun.toLowerCase() === "true");
+        const dryrun = (opt.options.dryrun.toString().toLowerCase() === "true");
 
         console.log(`Dry run: ${dryrun}`);
         console.log(`Type of dryrun variable: ${typeof dryrun}`);

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -173,13 +173,6 @@ async function main() {
         const dryrun = (opt.options.dryrun.toString().toLowerCase() === "true");
 
         console.log(`Dry run: ${dryrun}`);
-        console.log(`Type of dryrun variable: ${typeof dryrun}`);
-        if (dryrun) {
-            console.log("This is a dry run");
-        }
-        if (!dryrun) {
-            console.log("This is not a dry run");
-        }
 
         util.execInForeground(`${GIT} config --global user.email "${process.env.USEREMAIL}"`, null, dryrun);
         util.execInForeground(`${GIT} config --global user.name "${process.env.USERNAME}"`, null, dryrun);

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -78,14 +78,14 @@ function clearEmptyHashValueLine(filePath) {
  * @param {string} description pull reqest description
  * @param {string[]} targetsToCommit files to add in pull request
  */
-async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, title, description, targetsToCommit) {
+async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, title, description, targetsToCommit, dryrun = false) {
     console.log(`Creating PR from "${sourceBranch}" into "${targetBranch}" in the "${project}/${repo}" repo`);
 
     const repoPath = path.join(INTEGRATION_DIR, repo);
 
     if (!fs.existsSync(repoPath)) {
         const gitUrl = `https://${process.env.PAT}@${orgUrl}/${project}/_git/${repo}`;
-        util.execInForeground(`${GIT} clone --depth 1 ${gitUrl} ${repoPath}`, null, opt.options.dryrun);
+        util.execInForeground(`${GIT} clone --depth 1 ${gitUrl} ${repoPath}`, null, dryrun);
     }
 
     for (const targetToCommit of targetsToCommit) {
@@ -95,7 +95,7 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
         const sourceFile = path.join(INTEGRATION_DIR, fileName);
         const targetFile = path.join(fullPath, fileName);
 
-        if (opt.options.dryrun) {
+        if (dryrun) {
             console.log(`Fake copy file from ${sourceFile} to ${targetFile}`);
         } else {
             console.log(`Copy file from ${sourceFile} to ${targetFile}`);
@@ -105,12 +105,12 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
     }
 
     for (const targetToCommit of targetsToCommit) {
-        util.execInForeground(`${GIT} add ${targetToCommit}`, repoPath, opt.options.dryrun);
+        util.execInForeground(`${GIT} add ${targetToCommit}`, repoPath, dryrun);
     }
 
-    util.execInForeground(`${GIT} checkout -b ${sourceBranch}`, repoPath, opt.options.dryrun);
-    util.execInForeground(`${GIT} commit -m "${commitMessage}"`, repoPath, opt.options.dryrun);
-    util.execInForeground(`${GIT} push --force origin ${sourceBranch}`, repoPath, opt.options.dryrun);
+    util.execInForeground(`${GIT} checkout -b ${sourceBranch}`, repoPath, dryrun);
+    util.execInForeground(`${GIT} commit -m "${commitMessage}"`, repoPath, dryrun);
+    util.execInForeground(`${GIT} push --force origin ${sourceBranch}`, repoPath, dryrun);
 
     const prefix = 'refs/heads/';
 
@@ -129,7 +129,7 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
 
     if (PR) {
         console.log('PR already exists');
-    } else if (opt.options.dryrun) {
+    } else if (dryrun) {
         return [-1, 'test']; // return without creating PR for test runs
     } else {
         console.log('PR does not exist; creating PR');
@@ -169,8 +169,20 @@ async function main() {
         util.verifyMinimumNodeVersion();
         util.verifyMinimumGitVersion();
         createIntegrationFiles(agentVersion);
-        util.execInForeground(`${GIT} config --global user.email "${process.env.USEREMAIL}"`, null, opt.options.dryrun);
-        util.execInForeground(`${GIT} config --global user.name "${process.env.USERNAME}"`, null, opt.options.dryrun);
+
+        const dryrun = (opt.options.dryrun.toLowerCase() === "true");
+
+        console.log(`Dry run: ${dryrun}`);
+        console.log(`Type of dryrun variable: ${typeof dryrun}`);
+        if (dryrun) {
+            console.log("This is a dry run");
+        }
+        if (!dryrun) {
+            console.log("This is not a dry run");
+        }
+
+        util.execInForeground(`${GIT} config --global user.email "${process.env.USEREMAIL}"`, null, dryrun);
+        util.execInForeground(`${GIT} config --global user.name "${process.env.USERNAME}"`, null, dryrun);
 
         const sprint = await getCurrentSprint();
 
@@ -191,7 +203,8 @@ async function main() {
                 path.join(
                     'DistributedTask', 'Service', 'Servicing', 'Host', 'Deployment', 'Groups', 'UpdateAgentPackage.xml'
                 ),
-            ]
+            ],
+            dryrun
         );
 
         const [ccPrId, ccPrLink] = await openPR(
@@ -202,7 +215,8 @@ async function main() {
                 path.join(
                     'tfs', `m${sprint}`, 'PipelinesAgentRelease', agentVersion, 'Publish.ps1'
                 )
-            ]
+            ],
+            dryrun
         );
 
         console.log(`##vso[task.setvariable variable=AdoPrId;isOutput=true]${adoPrId}`);


### PR DESCRIPTION
- Extracted the branch cleanup to a stage so it is not skipped if an error occurs during build or release
- Currently the paths filter for trigger is not being respected, so I added a branch filter and pr keyword that may fix the issue (according to the examples in the [docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#paths))
