### PR TITLE
Remove `AZP_AGENT_MOUNT_WORKSPACE` knob

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -652,13 +652,6 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AZP_AGENT_CHECK_IF_TASK_NODE_RUNNER_IS_DEPRECATED"),
             new BuiltInDefaultKnobSource("false"));
 
-        public static readonly Knob MountWorkspace = new Knob(
-            nameof(MountWorkspace),
-            "If true, the agent will mount the Pipeline.Workspace directory instead of the Working directory for steps which target a Docker container.",
-            new RuntimeKnobSource("AZP_AGENT_MOUNT_WORKSPACE"),
-            new EnvironmentKnobSource("AZP_AGENT_MOUNT_WORKSPACE"),
-            new BuiltInDefaultKnobSource("false"));
-
         public static readonly Knob EnableNewSecretMasker = new Knob(
             nameof(EnableNewSecretMasker),
             "If true, the agent will use new SecretMasker with additional filters & performance enhancements",

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -483,34 +483,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
             if (container.ImageOS != PlatformUtil.OS.Windows)
             {
-                if (AgentKnobs.MountWorkspace.GetValue(executionContext).AsBoolean())
-                {
-                    string workspace = executionContext.Variables.Get(Constants.Variables.Pipeline.Workspace);
-                    workspace = container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, container.TranslateToContainerPath(workspace));
-                    string mountWorkspace = container.TranslateToHostPath(workspace);
-                    executionContext.Debug($"Workspace {workspace}");
-                    executionContext.Debug($"Mount Workspace {mountWorkspace}");
-                    container.MountVolumes.Add(new MountVolume(mountWorkspace, workspace, readOnly: container.isReadOnlyVolume(Constants.DefaultContainerMounts.Work)));
-                }
-                else
-                {
-                    string defaultWorkingDirectory = executionContext.Variables.Get(Constants.Variables.System.DefaultWorkingDirectory);
-                    defaultWorkingDirectory = container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, container.TranslateToContainerPath(defaultWorkingDirectory));
-                    if (string.IsNullOrEmpty(defaultWorkingDirectory))
-                    {
-                        throw new NotSupportedException(StringUtil.Loc("ContainerJobRequireSystemDefaultWorkDir"));
-                    }
-
-                    string workingDirectory = IOUtil.GetDirectoryName(defaultWorkingDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), container.ImageOS);
-                    string mountWorkingDirectory = container.TranslateToHostPath(workingDirectory);
-                    executionContext.Debug($"Default Working Directory {defaultWorkingDirectory}");
-                    executionContext.Debug($"Working Directory {workingDirectory}");
-                    executionContext.Debug($"Mount Working Directory {mountWorkingDirectory}");
-                    if (!string.IsNullOrEmpty(workingDirectory))
-                    {
-                        container.MountVolumes.Add(new MountVolume(mountWorkingDirectory, workingDirectory, readOnly: container.isReadOnlyVolume(Constants.DefaultContainerMounts.Work)));
-                    }
-                }
+                string workspace = executionContext.Variables.Get(Constants.Variables.Pipeline.Workspace);
+                workspace = container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, container.TranslateToContainerPath(workspace));
+                string mountWorkspace = container.TranslateToHostPath(workspace);
+                executionContext.Debug($"Workspace {workspace}");
+                executionContext.Debug($"Mount Workspace {mountWorkspace}");
+                container.MountVolumes.Add(new MountVolume(mountWorkspace, workspace, readOnly: container.isReadOnlyVolume(Constants.DefaultContainerMounts.Work)));
 
                 container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));
                 container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Tasks), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Tasks)),

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -486,8 +486,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 string workspace = executionContext.Variables.Get(Constants.Variables.Pipeline.Workspace);
                 workspace = container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, container.TranslateToContainerPath(workspace));
                 string mountWorkspace = container.TranslateToHostPath(workspace);
-                executionContext.Debug($"Workspace {workspace}");
-                executionContext.Debug($"Mount Workspace {mountWorkspace}");
+                executionContext.Debug($"Workspace: {workspace}");
+                executionContext.Debug($"Mount Workspace: {mountWorkspace}");
                 container.MountVolumes.Add(new MountVolume(mountWorkspace, workspace, readOnly: container.isReadOnlyVolume(Constants.DefaultContainerMounts.Work)));
 
                 container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Temp), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Temp))));

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "Connecting to server ...",
   "ConnectSectionHeader": "Connect",
   "ConnectToServer": "Connecting to the server.",
-  "ContainerJobRequireSystemDefaultWorkDir": "System.DefaultWorkingDirectory is required for running a container job.",
   "ContainerWindowsVersionRequirement": "Container feature requires Windows Server 1803 or higher. Please reference documentation (https://go.microsoft.com/fwlink/?linkid=875268)",
   "CopyFileComplete": "Successfully published artifacts to {0}",
   "CopyFileToDestination": "Copy file '{0}' to '{1}'",


### PR DESCRIPTION
***Description:*** The `DistributedTask.Agent.MountWorkspace` feature flag was enabled for all ADO users on February 29, 2024.
So now it is the default agent behavior, and the FF can be removed.

[ADO WI](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2116403)