### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10944: Build ID 28877864

### DIFF
--- a/src/Misc/layoutbin/de-DE/strings.json
+++ b/src/Misc/layoutbin/de-DE/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "Verbindung mit dem Server wird hergestellt ...",
   "ConnectSectionHeader": "Verbinden",
   "ConnectToServer": "Verbindung zum Server wird hergestellt.",
-  "ContainerJobRequireSystemDefaultWorkDir": "\"System.DefaultWorkingDirectory\" ist für die Ausführung eines Containerauftrags erforderlich.",
   "ContainerWindowsVersionRequirement": "Das Containerfeature erfordert Windows Server 1803 oder höher. Weitere Informationen finden Sie in der Dokumentation (https://go.microsoft.com/fwlink/?linkid=875268).",
   "CopyFileComplete": "Artefakte wurden erfolgreich in {0} veröffentlicht.",
   "CopyFileToDestination": "Datei \"{0}\" in \"{1}\" kopieren",

--- a/src/Misc/layoutbin/es-ES/strings.json
+++ b/src/Misc/layoutbin/es-ES/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "Conectando con el servidor...",
   "ConnectSectionHeader": "Conectar",
   "ConnectToServer": "Conectando al servidor.",
-  "ContainerJobRequireSystemDefaultWorkDir": "Se requiere System.DefaultWorkingDirectory para ejecutar un trabajo de contenedor.",
   "ContainerWindowsVersionRequirement": "La característica de contenedor requiere Windows Server 1803 o posterior. Consulte la documentación (https://go.microsoft.com/fwlink/?linkid=875268).",
   "CopyFileComplete": "Los artefactos se publicaron correctamente en {0}",
   "CopyFileToDestination": "Copiar archivo '{0}' en '{1}'",

--- a/src/Misc/layoutbin/fr-FR/strings.json
+++ b/src/Misc/layoutbin/fr-FR/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "Connexion au serveur...",
   "ConnectSectionHeader": "Connexion",
   "ConnectToServer": "Connexion au serveur.",
-  "ContainerJobRequireSystemDefaultWorkDir": "System.DefaultWorkingDirectory est nécessaire pour l'exécution d'un travail de conteneur.",
   "ContainerWindowsVersionRequirement": "La fonctionnalité de conteneur nécessite Windows Server 1803 ou version ultérieure. Veuillez consulter la documentation de référence (https://go.microsoft.com/fwlink/?linkid=875268)",
   "CopyFileComplete": "Artefacts publiés sur {0}",
   "CopyFileToDestination": "Copier le fichier « {0} » dans « {1} »",

--- a/src/Misc/layoutbin/it-IT/strings.json
+++ b/src/Misc/layoutbin/it-IT/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "Connessione al server...",
   "ConnectSectionHeader": "Connetti",
   "ConnectToServer": "Connessione al server.",
-  "ContainerJobRequireSystemDefaultWorkDir": "Per l'esecuzione di un processo contenitore è richiesto System.DefaultWorkingDirectory.",
   "ContainerWindowsVersionRequirement": "La funzionalità del contenitore richiede Windows Server 1803 o versione successiva. Vedere la documentazione (https://go.microsoft.com/fwlink/?linkid=875268)",
   "CopyFileComplete": "Gli artefatti sono stati pubblicati correttamente in {0}",
   "CopyFileToDestination": "Copia file '{0}' in '{1}'",

--- a/src/Misc/layoutbin/ja-JP/strings.json
+++ b/src/Misc/layoutbin/ja-JP/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "サーバーに接続しています...",
   "ConnectSectionHeader": "接続",
   "ConnectToServer": "サーバーに接続しています...",
-  "ContainerJobRequireSystemDefaultWorkDir": "コンテナー ジョブを実行するには、System.DefaultWorkingDirectory が必要です。",
   "ContainerWindowsVersionRequirement": "コンテナーの機能には、Windows Server 1803 以降が必要です。ドキュメント (https://go.microsoft.com/fwlink/?linkid=875268) を参照してください",
   "CopyFileComplete": "成果物が {0} に正常に公開されました",
   "CopyFileToDestination": "ファイル '{0}' を '{1}' にコピーします",

--- a/src/Misc/layoutbin/ko-KR/strings.json
+++ b/src/Misc/layoutbin/ko-KR/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "서버에 연결하는 중...",
   "ConnectSectionHeader": "연결",
   "ConnectToServer": "서버에 연결 중입니다.",
-  "ContainerJobRequireSystemDefaultWorkDir": "컨테이너 작업을 실행하려면 System.DefaultWorkingDirectory가 필요합니다.",
   "ContainerWindowsVersionRequirement": "컨테이너 기능에는 Windows Server 1803 이상이 필요합니다. 설명서(https://go.microsoft.com/fwlink/?linkid=875268)를 참조하세요.",
   "CopyFileComplete": "아티팩트를 {0}에 게시함",
   "CopyFileToDestination": "'{0}' 파일을 '{1}'에 복사",

--- a/src/Misc/layoutbin/ru-RU/strings.json
+++ b/src/Misc/layoutbin/ru-RU/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "Соединение с сервером ...",
   "ConnectSectionHeader": "Подключить",
   "ConnectToServer": "Подключение к серверу.",
-  "ContainerJobRequireSystemDefaultWorkDir": "Для запуска задания контейнера требуется System.DefaultWorkingDirectory.",
   "ContainerWindowsVersionRequirement": "Для использования контейнеров требуется Windows Server 1803 или более поздней версии. Обратитесь к документации (https://go.microsoft.com/fwlink/?linkid=875268).",
   "CopyFileComplete": "Артефакты успешно опубликованы в {0}",
   "CopyFileToDestination": "Копирование файла {0} в {1}",

--- a/src/Misc/layoutbin/zh-CN/strings.json
+++ b/src/Misc/layoutbin/zh-CN/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "正在连接服务器...",
   "ConnectSectionHeader": "连接",
   "ConnectToServer": "正在连接到服务器。",
-  "ContainerJobRequireSystemDefaultWorkDir": "需要 System.DefaultWorkingDirectory 才能运行容器作业。",
   "ContainerWindowsVersionRequirement": "容器功能需要 Windows Server 1803 或更高版本。请参考文档(https://go.microsoft.com/fwlink/?linkid=875268)",
   "CopyFileComplete": "已成功将项目发布到 {0}",
   "CopyFileToDestination": "将文件 \"{0}\" 复制到 \"{1}\"",

--- a/src/Misc/layoutbin/zh-TW/strings.json
+++ b/src/Misc/layoutbin/zh-TW/strings.json
@@ -239,7 +239,6 @@
   "ConnectingToServer": "正在連線到伺服器 ...",
   "ConnectSectionHeader": "連線",
   "ConnectToServer": "正在連線至伺服器。",
-  "ContainerJobRequireSystemDefaultWorkDir": "執行容器作業時需要 System.DefaultWorkingDirectory。",
   "ContainerWindowsVersionRequirement": "容器功能需要 Windows Server 1803 或更高版本。請參閱文件 (https://go.microsoft.com/fwlink/?linkid=875268)",
   "CopyFileComplete": "已成功將成品發佈至 {0}",
   "CopyFileToDestination": "將檔案 '{0}' 複製到 '{1}'",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.