### PR TITLE
Perform Node 6-16 -> 20 runner upgrade experiment

### DIFF
--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -925,16 +925,18 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         // This overload is to handle specific types some other way.
         private void PublishTelemetry<T>(
             Dictionary<string, T> telemetryData,
-            string feature = "TaskHandler"
+            string feature = "TaskHandler",
+            bool IsAgentTelemetry = false
         )
         {
             // JsonConvert.SerializeObject always converts to base object.
-            PublishTelemetry((object)telemetryData, feature);
+            PublishTelemetry((object)telemetryData, feature, IsAgentTelemetry);
         }
 
         private void PublishTelemetry(
             object telemetryData,
-            string feature = "TaskHandler"
+            string feature = "TaskHandler",
+            bool IsAgentTelemetry = false
         )
         {
             var cmd = new Command("telemetry", "publish")
@@ -944,14 +946,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             cmd.Properties.Add("area", "PipelinesTasks");
             cmd.Properties.Add("feature", feature);
 
-            var publishTelemetryCmd = new TelemetryCommandExtension();
+            var publishTelemetryCmd = new TelemetryCommandExtension(IsAgentTelemetry);
             publishTelemetryCmd.Initialize(HostContext);
             publishTelemetryCmd.ProcessCommand(this, cmd);
         }
 
         public void PublishTaskRunnerTelemetry(Dictionary<string,string> taskRunnerData)
         {
-            PublishTelemetry(taskRunnerData);
+            PublishTelemetry(taskRunnerData, IsAgentTelemetry: true);
         }
 
         public void Dispose()

--- a/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs
+++ b/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs
@@ -21,6 +21,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Telemetry
             SupportedHostTypes = HostTypes.All;
             InstallWorkerCommand(new PublishTelemetryCommand());
         }
+        public TelemetryCommandExtension(bool IsAgentTelemetry = false)
+        {
+            CommandArea = "telemetry";
+            SupportedHostTypes = HostTypes.All;
+            InstallWorkerCommand(new PublishTelemetryCommand(IsAgentTelemetry: IsAgentTelemetry));
+        }
     }
 
     [CommandRestriction(AllowedInRestrictedMode = true)]
@@ -29,13 +35,25 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Telemetry
         public string Name => "publish";
         public List<string> Aliases => null;
 
+        public bool IsAgentTelemetry;
+
+        public PublishTelemetryCommand() 
+        {
+            IsAgentTelemetry = false;
+        }
+
+        public PublishTelemetryCommand(bool IsAgentTelemetry = false)
+        {
+            this.IsAgentTelemetry = IsAgentTelemetry;
+        }
+
         public void Execute(IExecutionContext context, Command command)
         {
             ArgUtil.NotNull(context, nameof(context));
             ArgUtil.NotNull(command, nameof(command));
 
             context.Variables.TryGetValue(Constants.Variables.Task.PublishTelemetry, out string publishTelemetryVar);
-            if (bool.TryParse(publishTelemetryVar, out bool publishTelemetry) && !publishTelemetry)
+            if (bool.TryParse(publishTelemetryVar, out bool publishTelemetry) && !publishTelemetry && !IsAgentTelemetry)
             {
                 return;
             }

--- a/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs
+++ b/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs
@@ -35,12 +35,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Telemetry
         public string Name => "publish";
         public List<string> Aliases => null;
 
-        public bool IsAgentTelemetry;
-
-        public PublishTelemetryCommand() 
-        {
-            IsAgentTelemetry = false;
-        }
+        public readonly bool IsAgentTelemetry = false;
 
         public PublishTelemetryCommand(bool IsAgentTelemetry = false)
         {


### PR DESCRIPTION
**Description**
For now, if the telemetry publishing through commandExtension in worker it won't be published without [specific variable](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Worker/Telemetry/TelemetryCommandExtension.cs#L38) which is needed to block telemetry from third party tasks([related PR](https://github.com/microsoft/azure-pipelines-agent/pull/4522)). The variable sets in [TaskRunner](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Worker/TaskRunner.cs#L102), so, for example, [node telemetry](https://github.com/microsoft/azure-pipelines-agent/blob/master/src/Agent.Worker/Handlers/NodeHandler.cs#L573) will be published only for in-the-box tasks, because the variable is false.
The PR allows to publish agent worker's telemetry through commandExtension API.

**Related WI**: [AB#2139555](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2139555)

**Testing**:
Tested locally, after the changes handler's telemetry started to publish