### PR TITLE
Bump Azure.Identity to 1.11.4 to fix CVE-2024-35255

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.230.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.230.0-preview" />

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.1" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />


### PR DESCRIPTION
In this PR I bumped Azure.Identity to 1.11.4 to fix [CVE-2024-35255](https://github.com/advisories/GHSA-m5vv-6r4h-3vj9)