### PR TITLE
Calculate the CPU usage statistics based on previous CPU usage values

### DIFF
--- a/src/Agent.Worker/ResourceMetricsManager.cs
+++ b/src/Agent.Worker/ResourceMetricsManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         #region MonitorProperties
         private IExecutionContext _context;
 
-        private const int METRICS_UPDATE_INTERVAL = 1000;
+        private const int METRICS_UPDATE_INTERVAL = 5000;
         private const int ACTIVE_MODE_INTERVAL = 5000;
         private const int WARNING_MESSAGE_INTERVAL = 5000;
         private const int AVAILABLE_DISK_SPACE_PERCENTAGE_THRESHOLD = 5;


### PR DESCRIPTION
**Description**: Since **/proc/stat** contains the statistics about the system since it was last restarted, we need to calculate the current values based on the previous ones.