### PR TITLE
Use the latest version of `Azure.Core`

### DIFF
--- a/src/Agent.Listener/Agent.Listener.csproj
+++ b/src/Agent.Listener/Agent.Listener.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.42.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.230.0-preview" />

--- a/src/Agent.Worker/Agent.Worker.csproj
+++ b/src/Agent.Worker/Agent.Worker.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.42.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.1" />
     <PackageReference Include="vss-api-netcore" Version="$(VssApiVersion)" />

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.42.0" />
     <PackageReference Include="azuredevops-testresultparser" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.4.0" />


### PR DESCRIPTION
**WI**

AB#2200571

**Description**

Overrode the `Azure.Core` dependency with the latest package version to apply this fix: https://github.com/Azure/azure-sdk-for-net/issues/44817