### PR TITLE
Fix for release pipeline

### DIFF
--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -9,7 +9,7 @@ const INTEGRATION_DIR = path.join(__dirname, '..', '_layout', 'integrations');
 const GIT = 'git';
 
 const opt = require('node-getopt').create([
-    ['', 'dryrun', 'Dry run only, do not actually commit new release'],
+    ['', 'dryrun=ARG', 'Dry run only, do not actually commit new release'],
     ['h', 'help', 'Display this help'],
 ])
     .setHelp(
@@ -170,7 +170,10 @@ async function main() {
         util.verifyMinimumGitVersion();
         createIntegrationFiles(agentVersion);
 
-        const dryrun = (opt.options.dryrun.toString().toLowerCase() === "true");
+        let dryrun = false;
+        if (opt.options.dryrun) {
+            dryrun = opt.options.dryrun.toString().toLowerCase() === "true"
+        }
 
         console.log(`Dry run: ${dryrun}`);
 


### PR DESCRIPTION
Changed dryrun to long option with argument in terms of node-getopt: https://www.npmjs.com/package/node-getopt#features

This is needed to fix the bug where the dryrun option always evaluated to true