### PR TITLE
Added ContainerStructureTestParser

### DIFF
--- a/src/Microsoft.VisualStudio.Services.Agent/ExtensionManager.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/ExtensionManager.cs
@@ -116,6 +116,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                     Add<T>(extensions, "Microsoft.VisualStudio.Services.Agent.Worker.TestResults.CTestParser, Agent.Worker");
                     Add<T>(extensions, "Microsoft.VisualStudio.Services.Agent.Worker.TestResults.TrxParser, Agent.Worker");
                     Add<T>(extensions, "Microsoft.VisualStudio.Services.Agent.Worker.TestResults.XUnitParser, Agent.Worker");
+                    Add<T>(extensions, "Microsoft.VisualStudio.Services.Agent.Worker.TestResults.ContainerStructureTestParser, Agent.Worker");
                     break;
                 // Worker code coverage summary reader extensions.
                 case "Microsoft.VisualStudio.Services.Agent.Worker.CodeCoverage.ICodeCoverageSummaryReader":


### PR DESCRIPTION
Fixed a Warning in the ContainerStructureTest@0 task that the parser does not exist.
---
##[warning]Failed to publish test run data: System.ArgumentException: Unknown test runner
   at Microsoft.VisualStudio.Services.Agent.Worker.TestResults.TestDataPublisher.ParseTestResultsFile(TestRunContext runContext, List`1 testResultFiles) in /mnt/vss/_work/1/s/src/Agent.Worker/TestResults/TestDataPublisher.cs:line 230
   at Microsoft.VisualStudio.Services.Agent.Worker.TestResults.TestDataPublisher.PublishAsync(TestRunContext runContext, List`1 testResultFiles, PublishOptions publishOptions, CancellationToken cancellationToken) in /mnt/vss/_work/1/s/src/Agent.Worker/TestResults/TestDataPublisher.cs:line 70
##[debug]Processed: ##vso[results.publish type=ContainerStructure;mergeResults=false;runTitle=Container Structure Test;resultFiles=/home/azureuser/myagent/_work/_temp/cc4f0010-4b24-11ef-987b-e33922ec9c40.json;testRunSystem=VSTS-PTR;publishRunAttachments=true;]