### PR TITLE
Including support for Rocky Linux

### DIFF
--- a/src/Agent.Listener/net8.json
+++ b/src/Agent.Listener/net8.json
@@ -67,6 +67,14 @@
     ]
   },
   {
+    "id": "rocky",
+    "versions": [
+      {
+        "name": "8+"
+      }
+    ]
+  },
+  {
     "id": "sles",
     "versions": [
       {


### PR DESCRIPTION
Since RHEL 8+ is supported, Rocky 8+ can and should be included as well.