### PR TITLE
Fix Node runner deprecation check

### DIFF
--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -377,10 +377,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             string[] approvedNodeRunners = { "Node16", "Node20_1" }; // Node runners which are not considered as deprecated
 
             JObject taskJson = GetTaskJson(task);
-            var taskRunners = (JObject)taskJson["execution"] ??
-                (JObject)taskJson["prejobexecution"] ??
-                (JObject)taskJson["postjobexecution"] ??
-                new JObject();
+            var taskRunners = (JObject)taskJson["execution"] ?? (JObject)taskJson["prejobexecution"] ?? (JObject)taskJson["postjobexecution"];
+
+            if (taskRunners == null)
+            {
+                return;
+            }
 
             foreach (string runner in approvedNodeRunners)
             {

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -377,7 +377,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             string[] approvedNodeRunners = { "Node16", "Node20_1" }; // Node runners which are not considered as deprecated
 
             JObject taskJson = GetTaskJson(task);
-            var taskRunners = (JObject)taskJson["execution"];
+            var taskRunners = (JObject)taskJson["execution"] ??
+                (JObject)taskJson["prejobexecution"] ??
+                (JObject)taskJson["postjobexecution"] ??
+                new JObject();
 
             foreach (string runner in approvedNodeRunners)
             {


### PR DESCRIPTION
In this PR I fixed the bug when an exception raises during task downloading process if the task doesn't have the main execution step (only pre- or post-execution ones)

For example, it happened with the DownloadSecureFile task - https://github.com/microsoft/azure-pipelines-agent/issues/4962

Related WI: AB#2210002
Testing: Manual