### PR TITLE
Add libicu74 to `installdependencies.sh` to account for Ubuntu 24

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -98,8 +98,8 @@ then
                 exit 1
             fi
 
-            # libicu versions: libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-            apt install -y libicu70 || apt install -y libicu67 || apt install  -y libicu66 || apt install -y libicu63 || apt install -y libicu60  || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
+            # libicu versions: libicu74 -> libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+            apt install -y libicu74 || apt install -y libicu70 || apt install -y libicu67 || apt install  -y libicu66 || apt install -y libicu63 || apt install -y libicu60  || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -132,8 +132,8 @@ then
                     exit 1
                 fi
 
-                # libicu versions: libicu->70 libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-                apt-get install -y libicu70 || apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
+                # libicu versions: libicu74 -> libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+                apt-get install -y libicu74 || apt-get install -y libicu70 || apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
**WI**
[AB#2209881](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2209881)

**Description**

Ubuntu 24.04 uses `libicu74` as mentioned in this issue:  https://github.com/microsoft/azure-pipelines-agent/issues/4960
I updated the `installdependencies` script to attempt to install `libicu74` first and fall back to previous versions.

Tested on Ubuntu-2204 and 24-04

