### PR TITLE
Fix path for Get-ChildItem

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -258,7 +258,8 @@ extends:
                 
                 Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent" | ForEach-Object {
                   $target=$_
-                  Get-ChildItem -LiteralPath "$(System.ArtifactsDirectory)/agent/$target" -Include "*.zip","*.tar.gz" | ForEach-Object {
+                  $FullPath = $target.FullName
+                  Get-ChildItem -LiteralPath "$FullPath" -Include "*.zip","*.tar.gz" | ForEach-Object {
                     $executable = $_
                     Write-Host "Uploading $executable to BlobStorage vstsagentpackage/$container/$versionDir"
                     Set-AzStorageBlobContent -Context $storageContext -Container $container -File "$(System.ArtifactsDirectory)/agent/$target/$executable" -Blob "$versionDir/$executable" -Force
@@ -275,6 +276,7 @@ extends:
             displayName: Delete Azure Blob container with test agent version
             condition: and(succeeded(), eq(variables.IsTestRun, 'True'))
             inputs:
+              pwsh: true
               azurePowerShellVersion: 'LatestVersion'
               azureSubscription: 'azure-pipelines-agent-vstsagentpackage-oauth'
               scriptType: 'InlineScript'


### PR DESCRIPTION
**Description**:
After the migration to PowershellCore Get-ChildItem returns full path instead of the file name. 
Pass to the next Get-ChildItem FullPath instead of the concatenated path