### PR TITLE
Add AlmaLinux to the list of supported OS for .NET 8

### DIFF
--- a/src/Agent.Listener/net8.json
+++ b/src/Agent.Listener/net8.json
@@ -67,6 +67,14 @@
     ]
   },
   {
+    "id": "almalinux",
+    "versions": [
+      {
+        "name": "8+"
+      }
+    ]
+  },
+  {
     "id": "rhel",
     "versions": [
       {


### PR DESCRIPTION
In this PR I added AlmaLinux to the list of supported OS for .NET 8 (net8.json).

GH Issue: https://github.com/microsoft/azure-pipelines-agent/issues/4959
Related WI: [AB#2210883](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2210883)