### PR TITLE
Fallback from Node 20 to Node 16 on container startup

### DIFF
--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -83,6 +83,7 @@ namespace Agent.Sdk
         public string ContainerName { get; set; }
         public string ContainerCommand { get; set; }
         public string CustomNodePath { get; set; }
+        public string ResultNodePath { get; set; }
         public Guid ContainerRegistryEndpoint { get; private set; }
         public string ContainerCreateOptions { get; set; }
         public bool SkipContainerImagePull { get; private set; }

--- a/src/Agent.Sdk/ExecutionTargetInfo.cs
+++ b/src/Agent.Sdk/ExecutionTargetInfo.cs
@@ -8,6 +8,7 @@ namespace Agent.Sdk
     {
         PlatformUtil.OS ExecutionOS { get; }
         string CustomNodePath { get; set; }
+        string ResultNodePath { get; set; }
 
         string TranslateContainerPathForImageOS(PlatformUtil.OS runningOs, string path);
         string TranslateToContainerPath(string path);
@@ -18,6 +19,7 @@ namespace Agent.Sdk
     {
         public PlatformUtil.OS ExecutionOS => PlatformUtil.HostOS;
         public string CustomNodePath { get; set; }
+        public string ResultNodePath { get; set; }
 
         public string TranslateToContainerPath(string path)
         {

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         Task<string> DockerCreate(IExecutionContext context, ContainerInfo container);
         Task<int> DockerStart(IExecutionContext context, string containerId);
         Task<int> DockerLogs(IExecutionContext context, string containerId);
+        Task<List<string>> GetDockerLogs(IExecutionContext context, string containerId);
         Task<List<string>> DockerPS(IExecutionContext context, string options);
         Task<int> DockerRemove(IExecutionContext context, string containerId);
         Task<int> DockerNetworkCreate(IExecutionContext context, string network);
@@ -227,6 +228,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             ArgUtil.NotNull(containerId, nameof(containerId));
 
             return await ExecuteDockerCommandAsync(context, "logs", $"--details {containerId}", context.CancellationToken);
+        }
+
+        public async Task<List<string>> GetDockerLogs(IExecutionContext context, string containerId)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+            ArgUtil.NotNull(containerId, nameof(containerId));
+
+            return await ExecuteDockerCommandAsync(context, "logs", $"--details {containerId}");
         }
 
         public async Task<List<string>> DockerPS(IExecutionContext context, string options)

--- a/src/Agent.Worker/Handlers/StepHost.cs
+++ b/src/Agent.Worker/Handlers/StepHost.cs
@@ -182,16 +182,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             HostContext.GetTrace(nameof(ContainerStepHost)).Info($"Copying containerHandlerInvoker.js to {tempDir}");
             File.Copy(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Bin), "containerHandlerInvoker.js.template"), targetEntryScript, true);
 
-            string node;
-            if (!string.IsNullOrEmpty(Container.CustomNodePath))
-            {
-                node = Container.CustomNodePath;
-            }
-            else
-            {
-                node = Container.TranslateToContainerPath(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "node", "bin", $"node{IOUtil.ExeExtension}"));
-            }
-
             string entryScript = Container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, Container.TranslateToContainerPath(targetEntryScript));
 
             string userArgs = "";
@@ -209,7 +199,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 }
             }
 
-            string containerExecutionArgs = $"exec -i {userArgs} {workingDirectoryParam} {Container.ContainerId} {node} {entryScript}";
+            string containerExecutionArgs = $"exec -i {userArgs} {workingDirectoryParam} {Container.ContainerId} {Container.ResultNodePath} {entryScript}";
 
             using (var processInvoker = HostContext.CreateService<IProcessInvoker>())
             {

--- a/src/Misc/layoutbin/containerHandlerInvoker.js.template
+++ b/src/Misc/layoutbin/containerHandlerInvoker.js.template
@@ -1,62 +1,53 @@
 const { spawn } = require('child_process');
-var stdinString = "";
-process.stdin.on('data', function (chunk) {
-    stdinString += chunk;
-});
 
-process.stdin.on('end', function () {
-    var stdinData = JSON.parse(stdinString);
-    var handler = stdinData.handler;
-    var handlerArg = stdinData.args;
-    var handlerWorkDir = stdinData.workDir;
-    var prependPath = stdinData.prependPath;
+const debug = log => console.log(`##vso[task.debug]${log}`);
 
-    console.log("##vso[task.debug]Handler: " + handler);
-    console.log("##vso[task.debug]HandlerArg: " + handlerArg);
-    console.log("##vso[task.debug]HandlerWorkDir: " + handlerWorkDir);
-    Object.keys(stdinData.environment).forEach(function (key) {
-        console.log("##vso[task.debug]Set env: " + key + "=" + stdinData.environment[key].toString().replace(/\r/g, '%0D').replace(/\n/g, '%0A'));
-        process.env[key] = stdinData.environment[key];
-    });
+let stdinString = '';
+process.stdin.on('data', chunk => stdinString += chunk);
 
-    var currentPath = process.env['PATH'];
-    var options = {
+process.stdin.on('end', () => {
+    const { handler, args: handlerArg, workDir: handlerWorkDir, prependPath, environment } = JSON.parse(stdinString);
+
+    debug(`Handler: ${handler}`);
+    debug(`HandlerArg: ${handlerArg}`);
+    debug(`HandlerWorkDir: ${handlerWorkDir}`);
+
+    for (const key in environment) {
+        const value = environment[key].toString().replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+        debug(`Set env: ${key}=${value}`);
+        process.env[key] = environment[key];
+    }
+
+    const options = {
         stdio: 'inherit',
         cwd: handlerWorkDir
     };
-    if (process.platform == 'win32') {
+
+    const isWindows = process.platform == 'win32';
+
+    if (isWindows) {
         options.argv0 = `"${handler}"`;
         options.windowsVerbatimArguments = true;
-
-        if (prependPath && prependPath.length > 0) {
-            if (currentPath && currentPath.length > 0) {
-                process.env['PATH'] = prependPath + ';' + currentPath;
-            }
-            else {
-                process.env['PATH'] = prependPath;
-            }
-        }
-    }
-    else {
-        if (prependPath && prependPath.length > 0) {
-            if (currentPath && currentPath.length > 0) {
-                process.env['PATH'] = prependPath + ':' + currentPath;
-            }
-            else {
-                process.env['PATH'] = prependPath;
-            }
-        }
     }
 
     if (prependPath && prependPath.length > 0) {
-        console.log("##vso[task.debug]Prepend Path: " + process.env['PATH']);
+        const currentPath = process.env['PATH'];
+        process.env['PATH'] = prependPath;
+
+        if (currentPath && currentPath.length > 0) {
+            process.env['PATH'] += `${isWindows ? ';' : ':'}${currentPath}`;
+        }
+
+        debug(`Prepend Path: ${process.env['PATH']}`);
     }
 
     process.env['TF_BUILD'] = 'True';
-    console.log("##vso[task.debug]Handler Setup Complete");
-    var launch = spawn(handler, [handlerArg], options);
-    launch.on('exit', function (code) {
-        console.log("##vso[task.debug]Handler exit code: " + code);
+    debug(`Handler Setup Complete`);
+    const launch = spawn(handler, [handlerArg], options);
+
+    launch.on('exit', code => {
+        debug(`Handler exit code: ${code}`);
+
         if (code != 0) {
             process.exit(code);
         }


### PR DESCRIPTION
***Description:*** an improvement for [the previous PR](https://github.com/microsoft/azure-pipelines-agent/pull/4929). Fallback from Node 20 to Node 16 is added in the current PR.

Updated Docker command —

* On Windows —

```sh
docker create --name <name> --label <label> --network <network>
-v "<agent>\_work":"C:\__w"
-v "<agent>\_work\_tasks":"C:\__w\_tasks"
-v "<agent>\_work\_tool":"C:\__t"
-v "<agent>\externals":"C:\__a\externals"
mcr.microsoft.com/windows/servercore:ltsc2022
cmd.exe /c call

    ### UseNode20ToStartContainer is OFF (by default)
"C:\__a\externals\node\bin\node.exe" -e "setInterval(function(){}, 24 * 60 * 60 * 1000);"

    ### UseNode20ToStartContainer is ON
"C:\__a\externals\node20_1\bin\node.exe" --version
&& echo "container-startup-using-node-20"
&& "C:\__a\externals\node20_1\bin\node.exe" -e "setInterval(function(){}, 24 * 60 * 60 * 1000);"
|| "C:\__a\externals\node16\bin\node.exe" --version
&& echo "container-startup-using-node-16"
&& "C:\__a\externals\node16\bin\node.exe" -e "setInterval(function(){}, 24 * 60 * 60 * 1000);"
|| echo "container-startup-failed"
```

* On Linux —

```sh
/usr/bin/docker create --name <name> --label <label> --network <network>
-v "/var/run/docker.sock":"/var/run/docker.sock"
-v "<agent>/_work/1":"/__w/1"
-v "<agent>/_work/_temp":"/__w/_temp"
-v "<agent>/_work/_tasks":"/__w/_tasks"
-v "<agent>/_work/_tool":"/__t"
-v "<agent>/externals":"/__a/externals":ro
-v "<agent>/_work/.taskkey":"/__w/.taskkey"
ubuntu:latest
bash -c "

    ### UseNode20ToStartContainer is OFF (by default)
'/__a/externals/node/bin/node' -e 'setInterval(function(){}, 24 * 60 * 60 * 1000);'

    ### UseNode20ToStartContainer is ON
'/__a/externals/node20_1/bin/node' --version
&& echo 'container-startup-using-node-20'
&& '/__a/externals/node20_1/bin/node' -e 'setInterval(function(){}, 24 * 60 * 60 * 1000);'
|| '/__a/externals/node16/bin/node' --version
&& echo 'container-startup-using-node-16'
&& '/__a/externals/node16/bin/node' -e 'setInterval(function(){}, 24 * 60 * 60 * 1000);'
|| echo 'container-startup-failed'
"
```