### PR TITLE
Update `TF.exe` and binding redirects for `vstshost`

### DIFF
--- a/src/Agent.Plugins/TFCliManager.cs
+++ b/src/Agent.Plugins/TFCliManager.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Xml;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.VisualStudio.Services.Agent.Util;
+using Agent.Sdk.Knob;
 
 namespace Agent.Plugins.Repository
 {
@@ -37,11 +38,15 @@ namespace Agent.Plugins.Repository
 
         public static readonly int RetriesOnFailure = 3;
 
-        public string FilePath => Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf", "tf.exe");
+        private string TfPath => AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean()
+            ? Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf-legacy")
+            : Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf");
 
-        private string AppConfigFile => Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf", "tf.exe.config");
+        public string FilePath => Path.Combine(TfPath, "tf.exe");
 
-        private string AppConfigRestoreFile => Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf", "tf.exe.config.restore");
+        private string AppConfigFile => Path.Combine(TfPath, "tf.exe.config");
+
+        private string AppConfigRestoreFile => Path.Combine(TfPath, "tf.exe.config.restore");
 
         // TODO: Remove AddAsync after last-saved-checkin-metadata problem is fixed properly.
         public async Task AddAsync(string localPath)

--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -101,7 +101,8 @@ namespace Agent.Plugins.Repository
             if (PlatformUtil.RunningOnWindows)
             {
                 // Set TFVC_BUILDAGENT_POLICYPATH
-                string policyDllPath = Path.Combine(executionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf", "Microsoft.TeamFoundation.VersionControl.Controls.dll");
+                string tfDirectoryName = AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean() ? "tf-legacy" : "tf";
+                string policyDllPath = Path.Combine(executionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", tfDirectoryName, "Microsoft.TeamFoundation.VersionControl.Controls.dll");
                 ArgUtil.File(policyDllPath, nameof(policyDllPath));
                 const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";
                 executionContext.Output(StringUtil.Loc("SetEnvVar", policyPathEnvKey));

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -758,5 +758,12 @@ namespace Agent.Sdk.Knob
             "Use PowerShell script wrapper to handle PowerShell ConstrainedLanguage mode.",
             new PipelineFeatureSource("UsePSScriptWrapper"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob InstallLegacyTfExe = new Knob(
+            nameof(InstallLegacyTfExe),
+            "If true, agent will install the previous version of TF.exe in the tf-legacy and vstsom-legacy directories",
+            new RuntimeKnobSource("AGENT_INSTALL_LEGACY_TF_EXE"),
+            new EnvironmentKnobSource("AGENT_INSTALL_LEGACY_TF_EXE"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -761,9 +761,10 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob InstallLegacyTfExe = new Knob(
             nameof(InstallLegacyTfExe),
-            "If true, agent will install the previous version of TF.exe in the tf-legacy and vstsom-legacy directories",
+            "If true, the agent will install the legacy versions of TF, vstsom and vstshost",
             new RuntimeKnobSource("AGENT_INSTALL_LEGACY_TF_EXE"),
             new EnvironmentKnobSource("AGENT_INSTALL_LEGACY_TF_EXE"),
+            new PipelineFeatureSource("InstallLegacyTfExe"),
             new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Worker/Build/TFCommandManager.cs
+++ b/src/Agent.Worker/Build/TFCommandManager.cs
@@ -11,6 +11,7 @@ using System.Xml.Serialization;
 using System.Text;
 using System.Xml;
 using System.Security.Cryptography.X509Certificates;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
@@ -34,11 +35,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         protected override string Switch => "/";
 
-        public override string FilePath => Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Tf), "tf.exe");
+        private string TfPath => AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean()
+            ? HostContext.GetDirectory(WellKnownDirectory.TfLegacy)
+            : HostContext.GetDirectory(WellKnownDirectory.Tf);
 
-        private string AppConfigFile => Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Tf), "tf.exe.config");
+        public override string FilePath => Path.Combine(TfPath, "tf.exe");
 
-        private string AppConfigRestoreFile => Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Tf), "tf.exe.config.restore");
+        private string AppConfigFile => Path.Combine(TfPath, "tf.exe.config");
+
+        private string AppConfigRestoreFile => Path.Combine(TfPath, "tf.exe.config.restore");
 
         // TODO: Remove AddAsync after last-saved-checkin-metadata problem is fixed properly.
         public async Task AddAsync(string localPath)

--- a/src/Agent.Worker/Build/TfsVCSourceProvider.cs
+++ b/src/Agent.Worker/Build/TfsVCSourceProvider.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
@@ -88,7 +89,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             if (PlatformUtil.RunningOnWindows)
             {
                 // Set TFVC_BUILDAGENT_POLICYPATH
-                string policyDllPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.ServerOM), "Microsoft.TeamFoundation.VersionControl.Controls.dll");
+                string vstsomPath = AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean()
+                    ? HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy)
+                    : HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+
+                string policyDllPath = Path.Combine(vstsomPath, "Microsoft.TeamFoundation.VersionControl.Controls.dll");
                 ArgUtil.File(policyDllPath, nameof(policyDllPath));
                 const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";
                 executionContext.Output(StringUtil.Loc("SetEnvVar", policyPathEnvKey));

--- a/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
+++ b/src/Agent.Worker/Handlers/LegacyPowerShellHandler.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.Services.WebApi;
 using System.Xml;
 using Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 {
@@ -205,8 +206,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
             // Copy the OM binaries into the legacy host folder.
             ExecutionContext.Output(StringUtil.Loc("PrepareTaskExecutionHandler"));
+
+            string sourceDirectory = AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean()
+                ? HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy)
+                : HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+
             IOUtil.CopyDirectory(
-                source: HostContext.GetDirectory(WellKnownDirectory.ServerOM),
+                source: sourceDirectory,
                 target: HostContext.GetDirectory(WellKnownDirectory.LegacyPSHost),
                 cancellationToken: ExecutionContext.CancellationToken);
             Trace.Info("Finished copying files.");

--- a/src/Agent.Worker/JobExtension.cs
+++ b/src/Agent.Worker/JobExtension.cs
@@ -269,6 +269,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         }
                     }
 
+                    if (AgentKnobs.InstallLegacyTfExe.GetValue(jobContext).AsBoolean())
+                    {
+                        await TfManager.DownloadLegacyTfToolsAsync(context);
+                    }
+
                     // build up 3 lists of steps, pre-job, job, post-job
                     Stack<IStep> postJobStepsBuilder = new Stack<IStep>();
                     Dictionary<Guid, Variables> taskVariablesMapping = new Dictionary<Guid, Variables>();

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -177,7 +177,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 jobContext.SetVariable(Constants.Variables.Agent.RootDirectory, HostContext.GetDirectory(WellKnownDirectory.Work), isFilePath: true);
                 if (PlatformUtil.RunningOnWindows)
                 {
-                    jobContext.SetVariable(Constants.Variables.Agent.ServerOMDirectory, HostContext.GetDirectory(WellKnownDirectory.ServerOM), isFilePath: true);
+                    string serverOMDirectoryVariable = AgentKnobs.InstallLegacyTfExe.GetValue(jobContext).AsBoolean()
+                        ? HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy)
+                        : HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+
+                    jobContext.SetVariable(Constants.Variables.Agent.ServerOMDirectory, serverOMDirectoryVariable, isFilePath: true);
                 }
                 if (!PlatformUtil.RunningOnWindows)
                 {

--- a/src/Agent.Worker/Release/ReleaseJobExtension.cs
+++ b/src/Agent.Worker/Release/ReleaseJobExtension.cs
@@ -229,6 +229,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Release
                 await teeUtil.DownloadTeeIfAbsent();
             }
 
+            if (AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean())
+            {
+                await TfManager.DownloadLegacyTfToolsAsync(executionContext);
+            }
+
             try
             {
                 foreach (AgentArtifactDefinition agentArtifactDefinition in agentArtifactDefinitions)

--- a/src/Agent.Worker/TfManager.cs
+++ b/src/Agent.Worker/TfManager.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.VisualStudio.Services.Agent.Util;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker
+{
+    public interface IRetryOptions
+    {
+        int CurrentCount { get; set; }
+        int Limit { get; init; }
+    }
+
+    public record RetryOptions : IRetryOptions
+    {
+        public int CurrentCount { get; set; }
+        public int Limit { get; init; }
+    }
+
+    public static class TfManager
+    {
+        public static async Task DownloadLegacyTfToolsAsync(IExecutionContext executionContext)
+        {
+            ArgUtil.NotNull(executionContext, nameof(executionContext));
+            string externalsPath = Path.Combine(executionContext.GetVariableValueOrDefault("Agent.HomeDirectory"), Constants.Path.ExternalsDirectory);
+            ArgUtil.NotNull(externalsPath, nameof(externalsPath));
+
+            string tfLegacyExternalsPath = Path.Combine(externalsPath, "tf-legacy");
+            var retryOptions = new RetryOptions() { CurrentCount = 0, Limit = 3 };
+
+            if (!Directory.Exists(tfLegacyExternalsPath))
+            {
+                const string tfDownloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/vstsom/m153_47c0856d/vstsom.zip";
+                string tempTfDirectory = Path.Combine(externalsPath, "tf_download_temp");
+
+                await DownloadAsync(executionContext, tfDownloadUrl, tempTfDirectory, tfLegacyExternalsPath, retryOptions);
+            }
+            else
+            {
+                executionContext.Debug($"tf-legacy download already exists at {tfLegacyExternalsPath}.");
+            }
+
+            string vstsomLegacyExternalsPath = Path.Combine(externalsPath, "vstsom-legacy");
+
+            if (!Directory.Exists(vstsomLegacyExternalsPath))
+            {
+                const string vstsomDownloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/vstsom/m122_887c6659/vstsom.zip";
+                string tempVstsomDirectory = Path.Combine(externalsPath, "vstsom_download_temp");
+
+                await DownloadAsync(executionContext, vstsomDownloadUrl, tempVstsomDirectory, vstsomLegacyExternalsPath, retryOptions);
+            }
+            else
+            {
+                executionContext.Debug($"vstsom-legacy download already exists at {vstsomLegacyExternalsPath}.");
+            }
+        }
+
+        public static async Task DownloadAsync(IExecutionContext executionContext, string blobUrl, string tempDirectory, string extractPath, IRetryOptions retryOptions)
+        {
+            Directory.CreateDirectory(tempDirectory);
+            string downloadPath = Path.ChangeExtension(Path.Combine(tempDirectory, "download"), ".completed");
+            string toolName = new DirectoryInfo(extractPath).Name;
+
+            const int timeout = 180;
+            const int defaultFileStreamBufferSize = 4096;
+            const int retryDelay = 10000;
+
+            try
+            {
+                using CancellationTokenSource downloadCts = new(TimeSpan.FromSeconds(timeout));
+                using CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(downloadCts.Token, executionContext.CancellationToken);
+                CancellationToken cancellationToken = linkedTokenSource.Token;
+
+                using HttpClient httpClient = new();
+                using Stream stream = await httpClient.GetStreamAsync(blobUrl, cancellationToken);
+                using FileStream fs = new(downloadPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: defaultFileStreamBufferSize, useAsync: true);
+
+                while (retryOptions.CurrentCount < retryOptions.Limit)
+                {
+                    try
+                    {
+                        executionContext.Debug($"Retry options: {retryOptions.ToString()}.");
+                        await stream.CopyToAsync(fs, cancellationToken);
+                        executionContext.Debug($"Finished downloading {toolName}.");
+                        await fs.FlushAsync(cancellationToken);
+                        fs.Close();
+                        break;
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        executionContext.Debug($"{toolName} download has been cancelled.");
+                        throw;
+                    }
+                    catch (Exception)
+                    {
+                        retryOptions.CurrentCount++;
+
+                        if (retryOptions.CurrentCount == retryOptions.Limit)
+                        {
+                            IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
+                            executionContext.Error($"Retry limit for {toolName} download has been exceeded.");
+                            return;
+                        }
+
+                        executionContext.Debug($"Failed to download {toolName}");
+                        executionContext.Debug($"Retry {toolName} download in 10 seconds.");
+                        await Task.Delay(retryDelay, cancellationToken);
+                    }
+                }
+
+                executionContext.Debug($"Extracting {toolName}...");
+                ZipFile.ExtractToDirectory(downloadPath, extractPath);
+                File.WriteAllText(downloadPath, DateTime.UtcNow.ToString());
+                executionContext.Debug($"{toolName} has been extracted and cleaned up");
+            }
+            catch (Exception ex)
+            {
+                executionContext.Error(ex);
+            }
+            finally
+            {
+                IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
+                executionContext.Debug($"{toolName} download directory has been cleaned up.");
+            }
+        }
+    }
+}

--- a/src/Agent.Worker/TfManager.cs
+++ b/src/Agent.Worker/TfManager.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Agent.Worker;
 using System;
 using System.IO;
 using System.IO.Compression;
@@ -55,6 +56,20 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             else
             {
                 executionContext.Debug($"vstsom-legacy download already exists at {vstsomLegacyExternalsPath}.");
+            }
+
+            string vstsHostLegacyExternalsPath = Path.Combine(externalsPath, "vstshost-legacy");
+
+            if (!Directory.Exists(vstsHostLegacyExternalsPath))
+            {
+                const string vstsHostDownloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/vstshost/m122_887c6659/vstshost.zip";
+                string tempVstsHostDirectory = Path.Combine(externalsPath, "vstshost_download_temp");
+
+                await DownloadAsync(executionContext, vstsHostDownloadUrl, tempVstsHostDirectory, vstsHostLegacyExternalsPath, retryOptions);
+            }
+            else
+            {
+                executionContext.Debug($"vstshost-legacy download already exists at {vstsHostLegacyExternalsPath}.");
             }
         }
 

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -22,6 +22,8 @@ namespace Microsoft.VisualStudio.Services.Agent
         Tools,
         Update,
         Work,
+        TfLegacy,
+        ServerOMLegacy
     }
 
     public enum WellKnownConfigFile
@@ -313,9 +315,11 @@ namespace Microsoft.VisualStudio.Services.Agent
             public static readonly string ExternalsDirectory = "externals";
             public static readonly string LegacyPSHostDirectory = "vstshost";
             public static readonly string ServerOMDirectory = "vstsom";
+            public static readonly string ServerOMLegacyDirectory = "vstsom-legacy";
             public static readonly string TempDirectory = "_temp";
             public static readonly string TeeDirectory = "tee";
             public static readonly string TfDirectory = "tf";
+            public static readonly string TfLegacyDirectory = "tf-legacy";
             public static readonly string ToolDirectory = "_tool";
             public static readonly string TaskJsonFile = "task.json";
             public static readonly string TasksDirectory = "_tasks";

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -23,7 +23,8 @@ namespace Microsoft.VisualStudio.Services.Agent
         Update,
         Work,
         TfLegacy,
-        ServerOMLegacy
+        ServerOMLegacy,
+        LegacyPSHostLegacy
     }
 
     public enum WellKnownConfigFile
@@ -314,6 +315,7 @@ namespace Microsoft.VisualStudio.Services.Agent
             public static readonly string DiagDirectory = "_diag";
             public static readonly string ExternalsDirectory = "externals";
             public static readonly string LegacyPSHostDirectory = "vstshost";
+            public static readonly string LegacyPSHostLegacyDirectory = "vstshost-legacy";
             public static readonly string ServerOMDirectory = "vstsom";
             public static readonly string ServerOMLegacyDirectory = "vstsom-legacy";
             public static readonly string TempDirectory = "_temp";

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -206,10 +206,22 @@ namespace Microsoft.VisualStudio.Services.Agent
                         Constants.Path.ServerOMDirectory);
                     break;
 
+                case WellKnownDirectory.ServerOMLegacy:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.ServerOMLegacyDirectory);
+                    break;
+
                 case WellKnownDirectory.Tf:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Externals),
                         Constants.Path.TfDirectory);
+                    break;
+
+                case WellKnownDirectory.TfLegacy:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.TfLegacyDirectory);
                     break;
 
                 case WellKnownDirectory.Tee:

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -196,6 +196,12 @@ namespace Microsoft.VisualStudio.Services.Agent
                         Constants.Path.LegacyPSHostDirectory);
                     break;
 
+                case WellKnownDirectory.LegacyPSHostLegacy:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.LegacyPSHostLegacyDirectory);
+                    break;
+
                 case WellKnownDirectory.Root:
                     path = new DirectoryInfo(GetDirectory(WellKnownDirectory.Bin)).Parent.FullName;
                     break;

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -164,14 +164,14 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
 
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy
         acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659/vstshost.zip" vstshost
-        acquireExternalTool "$CONTAINER_URL/vstsom/m122_887c6659/vstsom.zip" vstsom
+        acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git
     acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/x${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
     acquireExternalTool "$CONTAINER_URL/pdbstr/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore
-    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d/vstsom.zip" tf
+    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -163,7 +163,7 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
         BIT="64"
 
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy
-        acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect/vstshost.zip" vstshost
+        acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost
         acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom
     fi
 

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -163,7 +163,7 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
         BIT="64"
 
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy
-        acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659/vstshost.zip" vstshost
+        acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect/vstshost.zip" vstshost
         acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom
     fi
 

--- a/src/Test/L0/ServiceInterfacesL0.cs
+++ b/src/Test/L0/ServiceInterfacesL0.cs
@@ -99,7 +99,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 typeof(IResultReader),
                 typeof(INUnitResultsXmlReader),
                 typeof(IWorkerCommand),
-                typeof(ITaskRestrictionsChecker)
+                typeof(ITaskRestrictionsChecker),
+                typeof(IRetryOptions)
             };
             Validate(
                 assembly: typeof(IStepsRunner).GetTypeInfo().Assembly,

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -211,10 +211,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                         Constants.Path.ServerOMDirectory);
                     break;
 
+                case WellKnownDirectory.ServerOMLegacy:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.ServerOMLegacyDirectory);
+                    break;
+
                 case WellKnownDirectory.Tf:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Externals),
                         Constants.Path.TfDirectory);
+                    break;
+
+                case WellKnownDirectory.TfLegacy:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.TfLegacyDirectory);
                     break;
 
                 case WellKnownDirectory.Tee:

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -201,6 +201,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                         Constants.Path.LegacyPSHostDirectory);
                     break;
 
+                case WellKnownDirectory.LegacyPSHostLegacy:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.LegacyPSHostLegacyDirectory);
+                    break;
+
                 case WellKnownDirectory.Root:
                     path = new DirectoryInfo(GetDirectory(WellKnownDirectory.Bin)).Parent.FullName;
                     break;

--- a/src/Test/L0/Worker/TfManagerL0.cs
+++ b/src/Test/L0/Worker/TfManagerL0.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Agent.Worker;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
+{
+    public sealed class TfManagerL0
+    {
+        private const string VstsomLegacy = "vstsom-legacy";
+        private const string TfLegacy = "tf-legacy";
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task DownloadTfLegacyToolsAsync()
+        {
+            // Arrange
+            using var tokenSource = new CancellationTokenSource();
+            using var hostContext = new TestHostContext(this);
+            var executionContext = new Mock<IExecutionContext>();
+
+            executionContext.Setup(x => x.CancellationToken).Returns(tokenSource.Token);
+            executionContext.Setup(x => x.GetVariableValueOrDefault(It.Is<string>(s => s == "Agent.HomeDirectory")))
+                .Returns(hostContext.GetDirectory(WellKnownDirectory.Root));
+
+            string externalsPath = hostContext.GetDirectory(WellKnownDirectory.Externals);
+            string tfPath = Path.Combine(externalsPath, TfLegacy);
+            string vstsomPath = Path.Combine(externalsPath, VstsomLegacy);
+
+            // Act
+            await TfManager.DownloadLegacyTfToolsAsync(executionContext.Object);
+
+            // Assert
+            Assert.True(Directory.Exists(tfPath));
+            Assert.True(File.Exists(Path.Combine(tfPath, "TF.exe")));
+            Assert.False(Directory.Exists(Path.Combine(externalsPath, "tf_download_temp")));
+
+            Assert.True(Directory.Exists(vstsomPath));
+            Assert.True(File.Exists(Path.Combine(vstsomPath, "TF.exe")));
+            Assert.False(Directory.Exists(Path.Combine(externalsPath, "vstsom_download_temp")));
+
+            // Cleanup
+            IOUtil.DeleteDirectory(tfPath, CancellationToken.None);
+            IOUtil.DeleteDirectory(vstsomPath, CancellationToken.None);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task DownloadAsync_Retries()
+        {
+            // Arrange
+            using var tokenSource = new CancellationTokenSource();
+            using var hostContext = new TestHostContext(this);
+            var executionContext = new Mock<IExecutionContext>();
+
+            executionContext.Setup(x => x.CancellationToken).Returns(tokenSource.Token);
+            executionContext.Setup(x => x.GetVariableValueOrDefault(It.Is<string>(s => s == "Agent.HomeDirectory")))
+                .Returns(hostContext.GetDirectory(WellKnownDirectory.Root));
+
+            var retryOptions = new Mock<IRetryOptions>();
+            retryOptions.SetupProperty(opt => opt.CurrentCount);
+            retryOptions.Setup(opt => opt.ToString()).Throws<Exception>();
+            retryOptions.Setup(opt => opt.Limit).Returns(3);
+
+            const string downloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/vstsom/m122_887c6659/vstsom.zip";
+            string tempDirectory = Path.Combine(hostContext.GetDirectory(WellKnownDirectory.Externals), "temp-test");
+            string extractDirectory = Path.Combine(hostContext.GetDirectory(WellKnownDirectory.Externals), "test");
+
+            // Act
+            await TfManager.DownloadAsync(executionContext.Object, downloadUrl, tempDirectory, extractDirectory, retryOptions.Object);
+
+            // Assert
+            Assert.False(Directory.Exists(tempDirectory));
+            Assert.False(Directory.Exists(extractDirectory));
+            retryOptions.VerifySet(opt => opt.CurrentCount = It.IsAny<int>(), Times.Exactly(3));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task DownloadAsync_Cancellation()
+        {
+            // Arrange
+            using var tokenSource = new CancellationTokenSource();
+            using var hostContext = new TestHostContext(this);
+            var executionContext = new Mock<IExecutionContext>();
+
+            executionContext.Setup(x => x.CancellationToken).Returns(tokenSource.Token);
+            executionContext.Setup(x => x.GetVariableValueOrDefault(It.Is<string>(s => s == "Agent.HomeDirectory")))
+                .Returns(hostContext.GetDirectory(WellKnownDirectory.Root));
+
+            var retryOptions = new Mock<IRetryOptions>();
+            retryOptions.SetupProperty(opt => opt.CurrentCount);
+            retryOptions.Setup(opt => opt.ToString()).Callback(() => tokenSource.Cancel());
+            retryOptions.Setup(opt => opt.Limit).Returns(3);
+
+            const string downloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/vstsom/m122_887c6659/vstsom.zip";
+            string tempDirectory = Path.Combine(hostContext.GetDirectory(WellKnownDirectory.Externals), "temp-test");
+            string extractDirectory = Path.Combine(hostContext.GetDirectory(WellKnownDirectory.Externals), "test");
+
+            // Act
+            await TfManager.DownloadAsync(executionContext.Object, downloadUrl, tempDirectory, extractDirectory, retryOptions.Object);
+
+            // Assert
+            Assert.False(Directory.Exists(tempDirectory));
+            Assert.False(Directory.Exists(extractDirectory));
+            retryOptions.VerifySet(opt => opt.CurrentCount = It.IsAny<int>(), Times.Never());
+        }
+    }
+}

--- a/src/Test/L0/Worker/TfManagerL0.cs
+++ b/src/Test/L0/Worker/TfManagerL0.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
     {
         private const string VstsomLegacy = "vstsom-legacy";
         private const string TfLegacy = "tf-legacy";
+        private const string VstsHostLegacy = "vstshost-legacy";
 
         [Fact]
         [Trait("Level", "L0")]
@@ -34,6 +35,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             string externalsPath = hostContext.GetDirectory(WellKnownDirectory.Externals);
             string tfPath = Path.Combine(externalsPath, TfLegacy);
             string vstsomPath = Path.Combine(externalsPath, VstsomLegacy);
+            string vstsHostPath = Path.Combine(externalsPath, VstsHostLegacy);
 
             // Act
             await TfManager.DownloadLegacyTfToolsAsync(executionContext.Object);
@@ -47,9 +49,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             Assert.True(File.Exists(Path.Combine(vstsomPath, "TF.exe")));
             Assert.False(Directory.Exists(Path.Combine(externalsPath, "vstsom_download_temp")));
 
+            Assert.True(Directory.Exists(vstsHostPath));
+            Assert.True(File.Exists(Path.Combine(vstsHostPath, "LegacyVSTSPowerShellHost.exe")));
+            Assert.False(Directory.Exists(Path.Combine(externalsPath, "vstshost_download_temp")));
+
             // Cleanup
             IOUtil.DeleteDirectory(tfPath, CancellationToken.None);
             IOUtil.DeleteDirectory(vstsomPath, CancellationToken.None);
+            IOUtil.DeleteDirectory(vstsHostPath, CancellationToken.None);
         }
 
         [Fact]


### PR DESCRIPTION
**WI**
[AB#2138625](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2138625)

**Description**
Re-introduce this PR: https://github.com/microsoft/azure-pipelines-agent/pull/4955 with the fix of `LegacyVSTSPowerShellHost`'s binding redirects for `Newtonsoft.Json`. It should fix the incompatibility between `tf` and `vstsom` and `vstshost` binaries.

Tested with VsTest@0 task which runs on the legacy Powershell handler (with `AGENT_INSTALL_LEGACY_TF_EXE` knob both enabled and disabled)