### PR TITLE
Added reauth command to refresh existing agent credentials

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -128,6 +128,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                     }
                 }
 
+                if (command.IsReAuthCommand())
+                {
+                    try
+                    {
+                        await configManager.ReAuthAsync(command);
+                        return Constants.Agent.ReturnCode.Success;
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.Error(ex);
+                        _term.WriteError(ex.Message);
+                        return Constants.Agent.ReturnCode.TerminatedError;
+                    }
+                }
+
                 _inConfigStage = false;
 
                 // warmup agent process (JIT/CLR)

--- a/src/Agent.Listener/CommandLine/ReAuthAgent.cs
+++ b/src/Agent.Listener/CommandLine/ReAuthAgent.cs
@@ -1,0 +1,10 @@
+﻿using CommandLine;
+using Microsoft.VisualStudio.Services.Agent;
+
+namespace Agent.Listener.CommandLine
+{
+    [Verb(Constants.Agent.CommandLine.Commands.ReAuth)]
+    public class ReAuthAgent : ConfigureOrRemoveBase
+    {
+    }
+}

--- a/src/Agent.Listener/CommandSettings.cs
+++ b/src/Agent.Listener/CommandSettings.cs
@@ -30,6 +30,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             typeof(RunAgent),
             typeof(RemoveAgent),
             typeof(WarmupAgent),
+            typeof(ReAuthAgent),
         };
 
         private string[] verbCommands = new string[]
@@ -38,6 +39,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             Constants.Agent.CommandLine.Commands.Remove,
             Constants.Agent.CommandLine.Commands.Run,
             Constants.Agent.CommandLine.Commands.Warmup,
+            Constants.Agent.CommandLine.Commands.ReAuth,
         };
 
 
@@ -46,6 +48,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         private RemoveAgent Remove { get; set; }
         private RunAgent Run { get; set; }
         private WarmupAgent Warmup { get; set; }
+        private ReAuthAgent ReAuth { get; set; }
 
         public IEnumerable<Error> ParseErrors { get; set; }
 
@@ -84,6 +87,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                 context.SecretMasker.AddValue(Remove.TenantId, WellKnownSecretAliases.RemoveTenantId);
                 context.SecretMasker.AddValue(Remove.ClientId, WellKnownSecretAliases.RemoveClientId);
                 context.SecretMasker.AddValue(Remove.ClientSecret, WellKnownSecretAliases.RemoveClientSecret);
+            }
+
+            if (ReAuth != null)
+            {
+                context.SecretMasker.AddValue(ReAuth.Token, WellKnownSecretAliases.RemoveToken);
             }
 
             PrintArguments();
@@ -609,7 +617,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             if ((Configure?.Version == true) ||
                 (Remove?.Version == true) ||
                 (Run?.Version == true) ||
-                (Warmup?.Version == true))
+                (Warmup?.Version == true) ||
+                (ReAuth?.Version == true))
             {
                 return true;
             }
@@ -622,7 +631,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             if ((Configure?.Help == true) ||
                 (Remove?.Help == true) ||
                 (Run?.Help == true) ||
-                (Warmup?.Help == true))
+                (Warmup?.Help == true) ||
+                (ReAuth?.Help == true))
             {
                 return true;
             }
@@ -669,6 +679,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
             return false;
         }
+
+        public bool IsReAuthCommand() => ReAuth != null;
 
 
         //
@@ -839,6 +851,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
                         {
                             Warmup = x;
                         })
+                    .WithParsed<ReAuthAgent>(
+                        x =>
+                        {
+                            ReAuth = x;
+                        })
                     .WithNotParsed(
                         errors =>
                         {
@@ -857,6 +874,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             if (Remove != null)
             {
                 _trace.Info(string.Concat(nameof(Remove), " ", ObjectAsJson(Remove)));
+            }
+
+            if (ReAuth != null)
+            {
+                _trace.Info(string.Concat(nameof(ReAuth), " ", ObjectAsJson(ReAuth)));
             }
 
             if (Warmup != null)
@@ -887,6 +909,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             if (Remove != null)
             {
                 return Remove as ConfigureOrRemoveBase;
+            }
+
+            if (ReAuth != null)
+            {
+                return ReAuth as ConfigureOrRemoveBase;
             }
 
             return null;

--- a/src/Agent.Listener/Program.cs
+++ b/src/Agent.Listener/Program.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
         // 1: Terminate failure
         // 2: Retriable failure
         // 3: Exit for self update
-        private async static Task<int> MainAsync(IHostContext context, string[] args)
+        private static async Task<int> MainAsync(IHostContext context, string[] args)
         {
             Tracing trace = context.GetTrace("AgentProcess");
             trace.Info($"Agent package {BuildConstants.AgentPackage.PackageName}.");

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -203,6 +203,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                     public const string Remove = "remove";
                     public const string Run = "run";
                     public const string Warmup = "warmup";
+                    public const string ReAuth = "reauth";
                 }
 
                 //if you are adding a new flag, please make sure you update the

--- a/src/Misc/layoutroot/reauth.cmd
+++ b/src/Misc/layoutroot/reauth.cmd
@@ -1,0 +1,31 @@
+@echo off
+
+rem ********************************************************************************
+rem Unblock specific files.
+rem ********************************************************************************
+setlocal
+if defined VERBOSE_ARG (
+  set VERBOSE_ARG='Continue'
+) else (
+  set VERBOSE_ARG='SilentlyContinue'
+)
+
+rem Unblock the following types of files:
+rem 1) The files in the root of the layout folder. E.g. .cmd files.
+rem
+rem 2) The PowerShell scripts delivered with the agent. E.g. capability scan scripts under "bin\"
+rem and legacy handler scripts under "externals\vstshost\".
+rem
+rem 3) The DLLs potentially loaded from a PowerShell script (e.g. DLLs in Agent.ServerOMDirectory).
+rem Otherwise, Add-Type may result in the following error:
+rem   Add-Type : Could not load file or assembly 'file:///[...].dll' or one of its dependencies.
+rem   Operation is not supported.
+rem Reproduced on Windows 8 in PowerShell 4. Changing the execution policy did not appear to make
+rem a difference. The error reproduced even with the execution policy set to Bypass. It may be a
+rem a policy setting.
+powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$VerbosePreference = %VERBOSE_ARG% ; Get-ChildItem -LiteralPath '%~dp0' | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null ; Get-ChildItem -Recurse -LiteralPath '%~dp0bin', '%~dp0externals' | Where-Object { $_ -match '\.(ps1|psd1|psm1)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null ; if (Test-Path -LiteralPath '%~dp0externals\vstsom' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\vstsom' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null } if (Test-Path -LiteralPath '%~dp0externals\vstshost' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\vstshost' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null } if (Test-Path -LiteralPath '%~dp0externals\tf' -PathType Container) { Get-ChildItem -LiteralPath '%~dp0externals\tf' | Where-Object { $_ -match '\.(dll|exe)$' } | ForEach-Object { Write-Verbose ('Unblock: {0}' -f $_.FullName) ; $_ } | Unblock-File | Out-Null }"
+
+rem ********************************************************************************
+rem Reauthenticate the agent.
+rem ********************************************************************************
+"%~dp0bin\Agent.Listener.exe" reauth %*

--- a/src/Misc/layoutroot/reauth.sh
+++ b/src/Misc/layoutroot/reauth.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+user_id="$(id -u)"
+
+# we want to snapshot the environment of the config user
+if [ $user_id -eq 0 -a -z "$AGENT_ALLOW_RUNASROOT" ]; then
+    echo "Must not run with sudo"
+    exit 1
+fi
+
+# Check dotnet core 6.0 dependencies for Linux
+if [[ "$(uname)" == "Linux" ]]; then
+    if [ -e /etc/redhat-release ]; then
+        redhatRelease=$(grep -oE "[0-9]+" /etc/redhat-release | awk "NR==1")
+        if [[ "${redhatRelease}" -lt 7 ]]; then
+            echo "RHEL supported for version 7 and higher."
+            exit 1
+        fi
+    fi
+
+    command -v ldd > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Can not find 'ldd'. Please install 'ldd' and try again."
+        exit 1
+    fi
+
+    ldd ./bin/libcoreclr.so | grep -E "not found|No such"
+    if [ $? -eq 0 ]; then
+        echo "Dependencies is missing for .NET Core 6.0"
+        echo "Execute ./bin/installdependencies.sh to install any missing dependencies."
+        exit 1
+    fi
+
+    ldd ./bin/libSystem.Security.Cryptography.Native.OpenSsl.so | grep -E "not found|No such"
+    if [ $? -eq 0 ]; then
+        echo "Dependencies missing for .NET 6.0"
+        echo "Execute ./bin/installdependencies.sh to install any missing dependencies."
+        exit 1
+    fi
+
+    ldd ./bin/libSystem.IO.Compression.Native.so | grep -E "not found|No such"
+    if [ $? -eq 0 ]; then
+        echo "Dependencies missing for .NET 6.0"
+        echo "Execute ./bin/installdependencies.sh to install any missing dependencies."
+        exit 1
+    fi
+
+    if [ -e /etc/alpine-release ]; then
+        if [ -z "$(apk info 2>&1 | grep icu-libs)" ]; then
+            echo "icu-libs are missing"
+            echo "Execute ./bin/installdependencies.sh to install any missing dependencies."
+            exit 1
+        fi
+    else
+        LDCONFIG="ldconfig"
+        if ! [ -x "$(command -v $LDCONFIG)" ]; then
+            LDCONFIG="/sbin/ldconfig"
+
+            if ! [ -x "$LDCONFIG" ]; then
+                echo "Can not find 'ldconfig' in PATH and '/sbin/ldconfig' doesn't exists either. Please install 'ldconfig' and try again."
+                exit 1
+            fi
+        fi
+
+        libpath="${LD_LIBRARY_PATH:-}"
+        $LDCONFIG -NXv "${libpath//:/}" 2>&1 | grep libicu >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "libicu's dependencies missing for .NET 6"
+            echo "Execute ./bin/installdependencies.sh to install any missing dependencies."
+            exit 1
+        fi
+    fi
+fi
+
+# Change directory to the script root directory
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+cd $DIR
+
+source ./env.sh
+
+shopt -s nocasematch
+if [[ "$1" == "remove" ]]; then
+    ./bin/Agent.Listener "$@"
+else
+    ./bin/Agent.Listener reauth "$@"
+fi

--- a/src/Test/L0/Listener/CommandSettingsL0.cs
+++ b/src/Test/L0/Listener/CommandSettingsL0.cs
@@ -1,17 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Listener;
 using Microsoft.VisualStudio.Services.Agent.Listener.Configuration;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Moq;
 using System;
-using System.Collections.Generic;
-using System.Reflection;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
-using Agent.Sdk;
-using System.Linq;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests
 {
@@ -225,6 +223,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
 
                 // Act.
                 bool actual = command.IsWarmupCommand();
+
+                // Assert.
+                Assert.True(actual);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", nameof(CommandSettings))]
+        public void GetsCommandReAuth()
+        {
+            using (TestHostContext hc = CreateTestContext())
+            {
+                // Arrange.
+                var command = new CommandSettings(hc, args: new string[] { "reauth" });
+
+                // Act.
+                bool actual = command.IsReAuthCommand();
 
                 // Assert.
                 Assert.True(actual);


### PR DESCRIPTION
Added reauth command to refresh existing agent settings with new credentials.
Usage: reauth.cmd or reauth.sh - similar to other CLI commands there. Instead of using 2 commands - 'config remove' and 'config' - to achieve the same result.
Main usecases:
1) After DevFabric redeployment if you have previously working agent configuration and local org has the same URL. Then running reauth cmd wll allow you to just update agent configuration with new PAT preserving the rest of configuration, registering build agent based on previously existing agent configuration.
2) If you need to update agent credential. Existing agent configuration will be updated with new credentials