### PR TITLE
Use caller node installation (containerHandler)

### DIFF
--- a/src/Misc/layoutbin/containerHandlerInvoker.js.template
+++ b/src/Misc/layoutbin/containerHandlerInvoker.js.template
@@ -7,7 +7,7 @@ process.stdin.on('data', function (chunk) {
 process.stdin.on('end', function () {
     var stdinData = JSON.parse(stdinString);
     var handler = stdinData.handler;
-    var handlerArg = stdinData.args;
+    var handler = process.execPath; //stdinData.handler;
     var handlerWorkDir = stdinData.workDir;
     var prependPath = stdinData.prependPath;
 


### PR DESCRIPTION
Hi,

I always experience issues when I run dockerized jobs in my Azure DevOps pipeline. The issue being that the docker image does not find the node installation path that the containerHandlerInvoker.js expects. I have, however, found a way to solve my issues. 

```
var handler = process.execPath; //stdinData.handler;
```

Instead of using the handler from the stdin, we use the handler directly from the caller node. As such, my docker containers do not need to have the exact node version installed at the given path.

Now, I can easily apply this if I run a local agent. However, for the default agents, it's more involved to get in the way. 

This is why I propose a PR. If you see another fix, or if I'm wrong, I'd be glad to hear why 👍🏼 

I feel like the steps should be able to run if `process.execPath` resolves to a correct node path, even if `stdinData.handler` does not.

Cheers


