### PR TITLE
Fix intellisense: Replaced custom target framework prop to built-in with predefined value

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>$(NetTargetFramework)</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RuntimeFrameworkVersion>$(RuntimeVersion)</RuntimeFrameworkVersion>
     <RuntimeIdentifier Condition="'$(BuildingInsideVisualStudio)' != 'true'">$(PackageRuntime)</RuntimeIdentifier>
     <SelfContained>true</SelfContained>

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -124,12 +124,12 @@ function make_build (){
 
     if  [[ "$ADO_ENABLE_LOGISSUE" == "true" ]]; then
 
-        dotnet msbuild -t:"${TARGET}" -p:PackageRuntime="${RUNTIME_ID}" -p:PackageType="${PACKAGE_TYPE}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:CodeAnalysis="true" -p:NetTargetFramework="${TARGET_FRAMEWORK}" -p:RuntimeVersion="${DOTNETRUNTIME_VERSION}" \
+        dotnet msbuild -t:"${TARGET}" -p:PackageRuntime="${RUNTIME_ID}" -p:PackageType="${PACKAGE_TYPE}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:CodeAnalysis="true" -p:TargetFramework="${TARGET_FRAMEWORK}" -p:RuntimeVersion="${DOTNETRUNTIME_VERSION}" \
          | sed -e "/\: warning /s/^/${DOTNET_WARNING_PREFIX} /;" \
          | sed -e "/\: error /s/^/${DOTNET_ERROR_PREFIX} /;" \
          || failed build
     else
-        dotnet msbuild -t:"${TARGET}" -p:PackageRuntime="${RUNTIME_ID}" -p:PackageType="${PACKAGE_TYPE}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:CodeAnalysis="true" -p:NetTargetFramework="${TARGET_FRAMEWORK}" -p:RuntimeVersion="${DOTNETRUNTIME_VERSION}" \
+        dotnet msbuild -t:"${TARGET}" -p:PackageRuntime="${RUNTIME_ID}" -p:PackageType="${PACKAGE_TYPE}" -p:BUILDCONFIG="${BUILD_CONFIG}" -p:AgentVersion="${AGENT_VERSION}" -p:LayoutRoot="${LAYOUT_DIR}" -p:CodeAnalysis="true" -p:TargetFramework="${TARGET_FRAMEWORK}" -p:RuntimeVersion="${DOTNETRUNTIME_VERSION}" \
          || failed build
     fi
 


### PR DESCRIPTION
Currently intellisense features are unavailable as target framework is not specified directly.
This PR specifies targetFrameworks proerty which returns intellisense for vscode and visual studio.
