### PR TITLE
Rename FF `CheckIfTaskNodeRunnerIsDeprecated`

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -661,11 +661,11 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("AZP_AGENT_CHECK_FOR_TASK_DEPRECATION"),
             new BuiltInDefaultKnobSource("false"));
 
-        public static readonly Knob CheckIfTaskNodeRunnerIsDeprecated = new Knob(
-            nameof(CheckIfTaskNodeRunnerIsDeprecated),
+        public static readonly Knob CheckIfTaskNodeRunnerIsDeprecated246 = new Knob(
+            nameof(CheckIfTaskNodeRunnerIsDeprecated246),
             "If true, the agent will check in the 'Initialize job' step each task used in the job if this task has node handlers, and all of them are deprecated.",
-            new RuntimeKnobSource("AZP_AGENT_CHECK_IF_TASK_NODE_RUNNER_IS_DEPRECATED"),
-            new PipelineFeatureSource("CheckIfTaskNodeRunnerIsDeprecated"),
+            new RuntimeKnobSource("AZP_AGENT_CHECK_IF_TASK_NODE_RUNNER_IS_DEPRECATED_246"),
+            new PipelineFeatureSource("CheckIfTaskNodeRunnerIsDeprecated246"),
             new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob UseNode20ToStartContainer = new Knob(

--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     CheckForTaskDeprecation(executionContext, task);
                 }
 
-                if (AgentKnobs.CheckIfTaskNodeRunnerIsDeprecated.GetValue(executionContext).AsBoolean())
+                if (AgentKnobs.CheckIfTaskNodeRunnerIsDeprecated246.GetValue(executionContext).AsBoolean())
                 {
                     if (!exceptionList.Contains(task.Id))
                     {


### PR DESCRIPTION
***Description:*** we have to rename the `CheckIfTaskNodeRunnerIsDeprecated` feature flag to avoid enabling it on agent versions below `3.244.1`. Postfix with the current sprint number was added.