### PR TITLE
Added Oracle Linux 7+ to supported os

### DIFF
--- a/src/Agent.Listener/net6.json
+++ b/src/Agent.Listener/net6.json
@@ -72,6 +72,14 @@
     ]
   },
   {
+    "id": "ol",
+    "versions": [
+      {
+        "name": "7+"
+      }
+    ]
+  },  
+  {
     "id": "sles",
     "versions": [
       {


### PR DESCRIPTION
#4941: Added Oracle Linux 7+ to supported os for net6