### PR TITLE
Support sparse checkout

### DIFF
--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -320,6 +320,48 @@ namespace Agent.Plugins.Repository
             return fetchExitCode;
         }
 
+        // git sparse-checkout init
+        public async Task<int> GitSparseCheckoutSet(AgentTaskPluginExecutionContext context, string repositoryPath, string directories, string patterns, CancellationToken cancellationToken)
+        {
+            context.Debug($"Sparse checkout init");
+
+            bool useConeMode = !string.IsNullOrWhiteSpace(directories);
+            string options = useConeMode ? "--cone" : "--no-cone";
+
+            context.PublishTelemetry(area: "AzurePipelinesAgent", feature: "GitSparseCheckout", properties: new Dictionary<string, string>
+            {
+                { "Mode", useConeMode ? "cone" : "non-cone" },
+                { "Patterns", useConeMode ? directories : patterns }
+            });
+
+            int exitCode_sparseCheckoutInit = await ExecuteGitCommandAsync(context, repositoryPath, "sparse-checkout init", options, cancellationToken);
+
+            if (exitCode_sparseCheckoutInit != 0)
+            {
+                return exitCode_sparseCheckoutInit;
+            }
+            else
+            {
+                return await ExecuteGitCommandAsync(context, repositoryPath, "sparse-checkout set", useConeMode ? directories : patterns, cancellationToken);
+            }
+        }
+
+        // git sparse-checkout set
+        public async Task<int> GitSparseCheckoutSet(AgentTaskPluginExecutionContext context, string repositoryPath, string patterns, CancellationToken cancellationToken)
+        {
+            context.Debug($"Sparse checkout set");
+
+            return await ExecuteGitCommandAsync(context, repositoryPath, "sparse-checkout set", patterns, cancellationToken);
+        }
+
+        // git sparse-checkout disable
+        public async Task<int> GitSparseCheckoutDisable(AgentTaskPluginExecutionContext context, string repositoryPath, CancellationToken cancellationToken)
+        {
+            context.Debug($"Sparse checkout disable");
+
+            return await ExecuteGitCommandAsync(context, repositoryPath, "sparse-checkout disable", string.Empty, cancellationToken);
+        }
+
         // git checkout -f --progress <commitId/branch>
         public async Task<int> GitCheckout(AgentTaskPluginExecutionContext context, string repositoryPath, string committishOrBranchSpec, string additionalCommandLine, CancellationToken cancellationToken)
         {

--- a/src/Agent.Plugins/GitCliManager.cs
+++ b/src/Agent.Plugins/GitCliManager.cs
@@ -320,10 +320,10 @@ namespace Agent.Plugins.Repository
             return fetchExitCode;
         }
 
-        // git sparse-checkout init
-        public async Task<int> GitSparseCheckoutSet(AgentTaskPluginExecutionContext context, string repositoryPath, string directories, string patterns, CancellationToken cancellationToken)
+        // git sparse-checkout
+        public async Task<int> GitSparseCheckout(AgentTaskPluginExecutionContext context, string repositoryPath, string directories, string patterns, CancellationToken cancellationToken)
         {
-            context.Debug($"Sparse checkout init");
+            context.Debug($"Sparse checkout");
 
             bool useConeMode = !string.IsNullOrWhiteSpace(directories);
             string options = useConeMode ? "--cone" : "--no-cone";
@@ -344,14 +344,6 @@ namespace Agent.Plugins.Repository
             {
                 return await ExecuteGitCommandAsync(context, repositoryPath, "sparse-checkout set", useConeMode ? directories : patterns, cancellationToken);
             }
-        }
-
-        // git sparse-checkout set
-        public async Task<int> GitSparseCheckoutSet(AgentTaskPluginExecutionContext context, string repositoryPath, string patterns, CancellationToken cancellationToken)
-        {
-            context.Debug($"Sparse checkout set");
-
-            return await ExecuteGitCommandAsync(context, repositoryPath, "sparse-checkout set", patterns, cancellationToken);
         }
 
         // git sparse-checkout disable

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -342,6 +342,10 @@ namespace Agent.Plugins.Repository
 
             string fetchFilter = executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.FetchFilter);
 
+            string sparseCheckoutDirectories = executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.SparseCheckoutDirectories);
+            string sparseCheckoutPatterns = executionContext.GetInput(Pipelines.PipelineConstants.CheckoutTaskInputs.SparseCheckoutPatterns);
+            bool enableSparseCheckout = !string.IsNullOrWhiteSpace(sparseCheckoutDirectories) || !string.IsNullOrWhiteSpace(sparseCheckoutPatterns);
+
             executionContext.Debug($"repository url={repositoryUrl}");
             executionContext.Debug($"targetPath={targetPath}");
             executionContext.Debug($"sourceBranch={sourceBranch}");
@@ -355,6 +359,7 @@ namespace Agent.Plugins.Repository
             executionContext.Debug($"fetchTags={fetchTags}");
             executionContext.Debug($"gitLfsSupport={gitLfsSupport}");
             executionContext.Debug($"acceptUntrustedCerts={acceptUntrustedCerts}");
+            executionContext.Debug($"sparseCheckout={enableSparseCheckout}");
 
             bool schannelSslBackend = StringUtil.ConvertToBoolean(executionContext.Variables.GetValueOrDefault("agent.gituseschannel")?.Value);
             executionContext.Debug($"schannelSslBackend={schannelSslBackend}");
@@ -966,6 +971,30 @@ namespace Agent.Plugins.Repository
                     int exitCode_lfsLogs = await gitCommandManager.GitLFSLogs(executionContext, targetPath);
                     executionContext.Output($"Git lfs fetch failed with exit code: {exitCode_lfsFetch}. Git lfs logs returned with exit code: {exitCode_lfsLogs}.");
                     executionContext.Output($"Checkout will continue.  \"git checkout\" will fetch lfs files, however this could cause poor performance on old versions of git.");
+                }
+            }
+
+            if (AgentKnobs.UseSparseCheckoutInCheckoutTask.GetValue(executionContext).AsBoolean())
+            {
+                if (enableSparseCheckout)
+                {
+                    // Set up sparse checkout
+                    int exitCode_sparseCheckout = await gitCommandManager.GitSparseCheckoutSet(executionContext, targetPath, sparseCheckoutDirectories, sparseCheckoutPatterns, cancellationToken);
+
+                    if (exitCode_sparseCheckout != 0)
+                    {
+                        executionContext.Warning($"git sparse-checkout failed with exit code: {exitCode_sparseCheckout}");
+                    }
+                }
+                else
+                {
+                    // Disable sparse checkout in case it was enabled in a previous checkout
+                    int exitCode_sparseCheckoutDisable = await gitCommandManager.GitSparseCheckoutDisable(executionContext, targetPath, cancellationToken);
+
+                    if (exitCode_sparseCheckoutDisable != 0)
+                    {
+                        executionContext.Warning($"git sparse-checkout disable failed with exit code: {exitCode_sparseCheckoutDisable}");
+                    }
                 }
             }
 

--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -979,11 +979,11 @@ namespace Agent.Plugins.Repository
                 if (enableSparseCheckout)
                 {
                     // Set up sparse checkout
-                    int exitCode_sparseCheckout = await gitCommandManager.GitSparseCheckoutSet(executionContext, targetPath, sparseCheckoutDirectories, sparseCheckoutPatterns, cancellationToken);
+                    int exitCode_sparseCheckout = await gitCommandManager.GitSparseCheckout(executionContext, targetPath, sparseCheckoutDirectories, sparseCheckoutPatterns, cancellationToken);
 
                     if (exitCode_sparseCheckout != 0)
                     {
-                        executionContext.Warning($"git sparse-checkout failed with exit code: {exitCode_sparseCheckout}");
+                        throw new InvalidOperationException($"Git sparse checkout failed with exit code: {exitCode_sparseCheckout}");
                     }
                 }
                 else
@@ -993,7 +993,7 @@ namespace Agent.Plugins.Repository
 
                     if (exitCode_sparseCheckoutDisable != 0)
                     {
-                        executionContext.Warning($"git sparse-checkout disable failed with exit code: {exitCode_sparseCheckoutDisable}");
+                        throw new InvalidOperationException($"Git sparse checkout disable failed with exit code: {exitCode_sparseCheckoutDisable}");
                     }
                 }
             }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -773,5 +773,11 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_INSTALL_LEGACY_TF_EXE"),
             new PipelineFeatureSource("InstallLegacyTfExe"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob UseSparseCheckoutInCheckoutTask = new Knob(
+            nameof(UseSparseCheckoutInCheckoutTask),
+            "If true, agent will use sparse checkout in checkout task.",
+            new RuntimeKnobSource("AGENT_USE_SPARSE_CHECKOUT_IN_CHECKOUT_TASK"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Common.props
+++ b/src/Common.props
@@ -11,7 +11,7 @@
     <OSPlatform>OS_UNKNOWN</OSPlatform>
     <OSArchitecture>ARCH_UNKNOWN</OSArchitecture>
     <DebugConstant></DebugConstant>
-    <VssApiVersion>0.5.246-private</VssApiVersion>
+    <VssApiVersion>0.5.247-private</VssApiVersion>
     <CodeAnalysis>$(CodeAnalysis)</CodeAnalysis>
     <InvariantGlobalization>false</InvariantGlobalization>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>


### PR DESCRIPTION
Support for new YAML checkout task properties `sparseCheckoutDirectories` and `sparseCheckoutPatterns` to trigger a `git sparse-checkout`

If agent knob `AGENT_USE_SPARSE_CHECKOUT_IN_CHECKOUT_TASK` is not set, then agent will not initialize `sparse-checkout` regardless of whether the properties have values or not.

If agent knob `AGENT_USE_SPARSE_CHECKOUT_IN_CHECKOUT_TASK` is set to `true` and one of the properties are set, then agent will initialize the `sparse-checkout` process. `sparseCheckoutDirectories` will trigger cone mode where the checkout process will use directory-matching while `sparseCheckoutPatterns` will trigger non-cone mode and allow for more complicated pattern-matching. Agent will initialize cone mode and directory matching if both properties are set.

If agent knob `AGENT_USE_SPARSE_CHECKOUT_IN_CHECKOUT_TASK` is set to `true` and both properties are empty, then agent will disable the `sparse-checkout` process. 

Issues while running the command will also fail the checkout task so that users can investigate the error.

YAML example for cone mode:
```
- checkout: repo
  sparseCheckoutDirectories: src
```

YAML example for non-code mode:
```
- checkout: repo
  sparseCheckoutPatterns: /* !img
```