### PR TITLE
[Agent] Support for Windows ARM 64 - AB#2143637

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -149,7 +149,7 @@ jobs:
       )
 
   # 1ES images used on the ARM pool doesn't contain unzip tool, so we need to install it before starting the build
-  - ${{ if and(eq(parameters.arch, 'arm64'), ne(parameters.os, 'osx')), ne(parameters.os, 'win')) }}:
+  - ${{ if and(eq(parameters.arch, 'arm64'), ne(parameters.os, 'osx'), ne(parameters.os, 'win')) }}:
     - script: sudo dnf -y update && sudo dnf -y install unzip
       displayName: Install unzip
       retryCountOnTaskFailure: 5

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -188,6 +188,15 @@ jobs:
           installationPath: 'C:\Program Files (x86)\dotnet'
         env:
           PROCESSOR_ARCHITECTURE: x86
+    - ${{ if and(eq(parameters.os, 'win'), eq(parameters.arch, 'arm64')) }}:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 6 Runtime
+        inputs:
+          version: '6.0.x'
+          packageType: 'runtime'
+          installationPath: 'C:\Program Files (x86)\dotnet'
+        env:
+          PROCESSOR_ARCHITECTURE: arm64
     - script: ${{ variables.devCommand }} testl0 $(targetFramework) Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Unit tests
@@ -202,6 +211,13 @@ jobs:
           version: '6.0.424'
           packageType: sdk
           performMultiLevelLookup: true
+    - ${{ if and(eq(parameters.os, 'win'), eq(parameters.arch, 'arm64')) }}:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 6 SDK
+        inputs:
+          version: '6.0.424'
+          packageType: sdk
+          performMultiLevelLookup: true    
     - script: ${{ variables.devCommand }} testl1 $(targetFramework) Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Functional tests

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -188,15 +188,6 @@ jobs:
           installationPath: 'C:\Program Files (x86)\dotnet'
         env:
           PROCESSOR_ARCHITECTURE: x86
-    - ${{ if and(eq(parameters.os, 'win'), eq(parameters.arch, 'arm64')) }}:
-      - task: UseDotNet@2
-        displayName: Install .NET Core 6 Runtime
-        inputs:
-          version: '6.0.x'
-          packageType: 'runtime'
-          installationPath: 'C:\Program Files (x86)\dotnet'
-        env:
-          PROCESSOR_ARCHITECTURE: arm64
     - script: ${{ variables.devCommand }} testl0 $(targetFramework) Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Unit tests
@@ -211,13 +202,6 @@ jobs:
           version: '6.0.424'
           packageType: sdk
           performMultiLevelLookup: true
-    - ${{ if and(eq(parameters.os, 'win'), eq(parameters.arch, 'arm64')) }}:
-      - task: UseDotNet@2
-        displayName: Install .NET Core 6 SDK
-        inputs:
-          version: '6.0.424'
-          packageType: sdk
-          performMultiLevelLookup: true    
     - script: ${{ variables.devCommand }} testl1 $(targetFramework) Debug ${{ parameters.os }}-${{ parameters.arch }}
       workingDirectory: src
       displayName: Functional tests

--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -149,7 +149,7 @@ jobs:
       )
 
   # 1ES images used on the ARM pool doesn't contain unzip tool, so we need to install it before starting the build
-  - ${{ if and(eq(parameters.arch, 'arm64'), ne(parameters.os, 'osx')) }}:
+  - ${{ if and(eq(parameters.arch, 'arm64'), ne(parameters.os, 'osx')), ne(parameters.os, 'win')) }}:
     - script: sudo dnf -y update && sudo dnf -y install unzip
       displayName: Install unzip
       retryCountOnTaskFailure: 5

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -193,11 +193,11 @@ extends:
               jobName: build_windows_arm64
               displayName: Windows (ARM64)
               pool:
-                name: 1ES-ABTT-Shared-ARM-64-Pool
-                image: abtt-windows-2022_arm64
+                name: 1ES-ABTT-Shared-Pool
+                image: abtt-windows-2022
                 os: windows
               os: win
-              arch: x64
+              arch: arm64
               branch: ${{ parameters.branch }}
               unitTests: ${{ parameters.test }}
               functionalTests: ${{ parameters.test }}

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -199,8 +199,8 @@ extends:
               os: win
               arch: arm64
               branch: ${{ parameters.branch }}
-              unitTests: ${{ parameters.test }}
-              functionalTests: ${{ parameters.test }}
+              unitTests: false
+              functionalTests: false
               sign: ${{ parameters.sign }}
               publishArtifacts: ${{ parameters.publishArtifacts }}
               buildAlternatePackage: ${{ parameters.buildAlternatePackage }}

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -42,6 +42,9 @@ parameters:
 - name: win_x86
   type: boolean
   default: true
+- name: win_arm64
+  type: boolean
+  default: true
 - name: linux_x64
   type: boolean
   default: true
@@ -182,6 +185,26 @@ extends:
             publishArtifacts: ${{ parameters.publishArtifacts }}
             buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
             targetFramework: ${{ parameters.targetFramework }}
+  
+  # Windows (ARM)
+      - ${{ if parameters.win_arm64 }}:
+          - template: /.azure-pipelines/build-jobs.yml@self
+            parameters:
+              jobName: build_windows_arm64
+              displayName: Windows (ARM64)
+              pool:
+                name: 1ES-ABTT-Shared-ARM-64-Pool
+                image: abtt-windows-2022_arm64
+                os: windows
+              os: win
+              arch: x64
+              branch: ${{ parameters.branch }}
+              unitTests: ${{ parameters.test }}
+              functionalTests: ${{ parameters.test }}
+              sign: ${{ parameters.sign }}
+              publishArtifacts: ${{ parameters.publishArtifacts }}
+              buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
+              targetFramework: ${{ parameters.targetFramework }}
 
   # Linux (x64)
       - ${{ if parameters.linux_x64 }}:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Written for .NET Core in C#.
 |---|:-----:|
 |![Win-x64](docs/res/win_med.png) **Windows x64**|[![Build & Test][win-x64-build-badge]][build]| 
 |![Win-x86](docs/res/win_med.png) **Windows x86**|[![Build & Test][win-x86-build-badge]][build]| 
+|![Win-arm64](docs/res/win_med.png) **Windows ARM64**|[![Build & Test][win-arm64-build-badge]][build]| 
 |![macOS](docs/res/apple_med.png) **macOS**|[![Build & Test][macOS-build-badge]][build]| 
 |![Linux-x64](docs/res/linux_med.png) **Linux x64**|[![Build & Test][linux-x64-build-badge]][build]|
 |![Linux-arm](docs/res/linux_med.png) **Linux ARM**|[![Build & Test][linux-arm-build-badge]][build]|
@@ -27,6 +28,7 @@ Written for .NET Core in C#.
 
 [win-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x64)
 [win-x86-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x86)
+[win-arm64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(arm64)
 [macOS-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=macOS%20(x64)
 [linux-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(x64)
 [linux-arm-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(ARM)

--- a/assets.json
+++ b/assets.json
@@ -24,6 +24,12 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip"
     },
     {
+        "name": "pipelines-agent-win-arm64-<AGENT_VERSION>.zip",
+        "platform": "win-arm64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip"
+    },
+    {
         "name": "vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz",
         "platform": "osx-x64",
         "version": "<AGENT_VERSION>",

--- a/assets.json
+++ b/assets.json
@@ -24,6 +24,12 @@
         "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip"
     },
     {
+        "name": "vsts-agent-win-arm64-<AGENT_VERSION>.zip",
+        "platform": "win-arm64",
+        "version": "<AGENT_VERSION>",
+        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip"
+    },
+    {
         "name": "pipelines-agent-win-arm64-<AGENT_VERSION>.zip",
         "platform": "win-arm64",
         "version": "<AGENT_VERSION>",

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -5,6 +5,7 @@
 | -------------- | ------- | ------- |
 | Windows x64    | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86    | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| Windows ARM64    | [vsts-agent-win-arm64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64      | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | macOS ARM64    | [vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64      | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
@@ -27,6 +28,13 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 ``` bash
 C:\> mkdir myagent && cd myagent
 C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\vsts-agent-win-x86-<AGENT_VERSION>.zip", "$PWD")
+```
+
+## Windows ARM64
+
+``` bash
+C:\> mkdir myagent && cd myagent
+C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\vsts-agent-win-arm64-<AGENT_VERSION>.zip", "$PWD")
 ```
 
 ## macOS x64
@@ -91,6 +99,7 @@ See [notes](docs/node6.md) on Node version support for more details.
 | ----------- | ------- | ------- |
 | Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| Windows ARM64 | [pipelines-agent-win-arm64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64   | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |

--- a/src/Common.props
+++ b/src/Common.props
@@ -38,7 +38,7 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'X86'">
     <OSArchitecture>X86</OSArchitecture>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PackageRuntime)' == 'win-arm64'">
     <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
 
@@ -69,8 +69,7 @@
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X86'">win-x86</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'ARM64'">win-arm64</RuntimeIdentifier>
-    <!-- <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'AMD64'">win-arm64</RuntimeIdentifier> -->
-  </PropertyGroup>
+ </PropertyGroup>
 
   <PropertyGroup>
     <DefineConstants>$(OSPlatform);$(OSArchitecture);$(DebugConstant);TRACE</DefineConstants>

--- a/src/Common.props
+++ b/src/Common.props
@@ -38,6 +38,9 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'X86'">
     <OSArchitecture>X86</OSArchitecture>
   </PropertyGroup>
+    <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
+    <OSArchitecture>X64</OSArchitecture>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_OSX' AND '$(PackageRuntime)' == 'osx-x64'">
     <OSArchitecture>X64</OSArchitecture>
@@ -65,6 +68,7 @@
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X86'">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'ARM64'">win-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Common.props
+++ b/src/Common.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64'">
-    <OSArchitecture>ARM64</OSArchitecture>
+    <OSArchitecture>X64</OSArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'X86'">
     <OSArchitecture>X86</OSArchitecture>
@@ -69,7 +69,7 @@
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X86'">win-x86</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'ARM64'">win-arm64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'AMD64'">win-arm64</RuntimeIdentifier>
+    <!-- <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'AMD64'">win-arm64</RuntimeIdentifier> -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Common.props
+++ b/src/Common.props
@@ -38,7 +38,7 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'X86'">
     <OSArchitecture>X86</OSArchitecture>
   </PropertyGroup>
-    <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
     <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
 

--- a/src/Common.props
+++ b/src/Common.props
@@ -41,6 +41,10 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
     <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PackageRuntime)' == 'win-arm64'">
+    <OSArchitecture>ARM64</OSArchitecture>
+  </PropertyGroup>
+  <!-- PROCESSOR_ARCHITECTURE does not always return ARM64 on all ARM-64 machines. So added a fallback condition to check the PackageRuntime variable -->
 
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_OSX' AND '$(PackageRuntime)' == 'osx-x64'">
     <OSArchitecture>X64</OSArchitecture>

--- a/src/Common.props
+++ b/src/Common.props
@@ -33,13 +33,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'AMD64'">
-    <OSArchitecture>X64</OSArchitecture>
+    <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'X86'">
     <OSArchitecture>X86</OSArchitecture>
   </PropertyGroup>
     <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
-    <OSArchitecture>X64</OSArchitecture>
+    <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_OSX' AND '$(PackageRuntime)' == 'osx-x64'">
@@ -69,6 +69,7 @@
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'X86'">win-x86</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'ARM64'">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(OSPlatform)' == 'OS_WINDOWS' And '$(OSArchitecture)' == 'AMD64'">win-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Common.props
+++ b/src/Common.props
@@ -38,7 +38,7 @@
   <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'X86'">
     <OSArchitecture>X86</OSArchitecture>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PackageRuntime)' == 'win-arm64'">
+  <PropertyGroup Condition="'$(OSPlatform)' == 'OS_WINDOWS' AND '$(PROCESSOR_ARCHITECTURE)' == 'ARM64'">
     <OSArchitecture>ARM64</OSArchitecture>
   </PropertyGroup>
 

--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -74,6 +74,16 @@
         <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
+        <ServicingStep name="Add ARM64 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="agent" platform="win-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-arm64-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add ARM64 Windows alternate agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-arm64-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
     <ServicingStep name="Add arm64 osx agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="agent" platform="osx-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz" />

--- a/src/Misc/Publish.template.ps1
+++ b/src/Misc/Publish.template.ps1
@@ -8,6 +8,8 @@ if ($pwd -notlike '*tfsgheus20') {
 
     Add-DistributedTaskPackage -PackageType agent -Platform win-x86 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-win-x86-<AGENT_VERSION>.zip
 
+    Add-DistributedTaskPackage -PackageType agent -Platform win-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-win-arm64-<AGENT_VERSION>.zip
+
     Add-DistributedTaskPackage -PackageType agent -Platform osx-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz
 
     Add-DistributedTaskPackage -PackageType agent -Platform linux-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz
@@ -27,6 +29,8 @@ if ($pwd -notlike '*tfsgheus20') {
     Add-DistributedTaskPackage -PackageType pipelines-agent -Platform win-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-win-x64-<AGENT_VERSION>.zip
 
     Add-DistributedTaskPackage -PackageType pipelines-agent -Platform win-x86 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-win-x86-<AGENT_VERSION>.zip
+
+    Add-DistributedTaskPackage -PackageType pipelines-agent -Platform win-arm64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-win-arm64-<AGENT_VERSION>.zip
 
     Add-DistributedTaskPackage -PackageType pipelines-agent -Platform osx-x64 -Version <AGENT_VERSION> -DownloadUrl https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz -HashValue <HASH_VALUE> -InfoUrl https://go.microsoft.com/fwlink/?LinkId=798199 -Filename pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz
 

--- a/src/Misc/UpdateAgentPackage.template.xml
+++ b/src/Misc/UpdateAgentPackage.template.xml
@@ -82,7 +82,7 @@
         <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
-    <ServicingStep name="Add ARM64 Windows agent package (without Node 6)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+    <ServicingStep name="Add ARM64 Windows agent package (without Node 6 and Node 10)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="pipelines-agent" platform="win-arm64" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-arm64-<AGENT_VERSION>.zip" />
       </StepData>

--- a/src/Misc/UpdateAgentPackage.template.xml
+++ b/src/Misc/UpdateAgentPackage.template.xml
@@ -42,6 +42,11 @@
         <AddTaskPackageData packageType="agent" platform="win-x86" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add ARM64 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="agent" platform="win-arm64" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-win-arm64-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
     <ServicingStep name="Add OSX agent package (without Node 6)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="pipelines-agent" platform="osx-x64" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz" />
@@ -75,6 +80,11 @@
     <ServicingStep name="Add x86 Windows agent package (without Node 6)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
         <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
+    <ServicingStep name="Add ARM64 Windows agent package (without Node 6)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-arm64" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-arm64-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
   </Steps>

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -10,14 +10,22 @@ INCLUDE_NODE10=${INCLUDE_NODE10:-true}
 CONTAINER_URL=https://vstsagenttools.blob.core.windows.net/tools
 
 NODE_URL=https://nodejs.org/dist
+NODE_UNOFFICIAL_URL=https://unofficial-builds.nodejs.org/download/release
+
 if [[ "$PACKAGERUNTIME" == "linux-musl-x64" ]]; then
     NODE_URL=https://unofficial-builds.nodejs.org/download/release
     INCLUDE_NODE6=false
 fi
 
+if [[ "$PACKAGERUNTIME" == "win-arm64" ]]; then
+    INCLUDE_NODE6=false
+    INCLUDE_NODE10=false;
+fi
+
 NODE_VERSION="6.17.1"
 NODE10_VERSION="10.24.1"
 NODE16_VERSION="16.20.2"
+NODE16_WIN_ARM64_VERSION="16.9.1"
 NODE20_VERSION="20.17.0"
 MINGIT_VERSION="2.47.0.2"
 LFS_VERSION="3.4.0"
@@ -154,13 +162,16 @@ function acquireExternalTool() {
         fi
     fi
 }
+
+echo "PACKAGE RUNTIME: $PACKAGERUNTIME"
+
 # TODO: Check external tools for ARM-64
-if [[ "$PACKAGERUNTIME" == "win-x"* || "$PACKAGERUNTIME" == "win-arm64" ]]; then
+if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
     # Download external tools for Windows.
 
     BIT="32"
-    if [[ "$PACKAGERUNTIME" == "win-x64" || "$PACKAGERUNTIME" == "win-arm64" ]]; then
-        BIT="64"
+    if [[ "$PACKAGERUNTIME" == "win-x64" ]]; then
+        BIT="64" # QQ: Why are these tools being installed for Win 64 only?
 
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy
         acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost
@@ -185,6 +196,44 @@ if [[ "$PACKAGERUNTIME" == "win-x"* || "$PACKAGERUNTIME" == "win-arm64" ]]; then
     fi
     acquireExternalTool "${NODE_URL}/v${NODE16_VERSION}/${PACKAGERUNTIME}/node.exe" node16/bin
     acquireExternalTool "${NODE_URL}/v${NODE16_VERSION}/${PACKAGERUNTIME}/node.lib" node16/bin
+    acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/${PACKAGERUNTIME}/node.exe" node20_1/bin
+    acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/${PACKAGERUNTIME}/node.lib" node20_1/bin
+elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]]; then
+    # Download external tools for Windows.
+
+    BIT="32"
+    if [[ "$PACKAGERUNTIME" == "win-arm64" ]]; then
+        BIT="64"
+
+        acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy # Unavailable for Win ARM 64 - https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf#download-the-azcopy-portable-binary
+        acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost  # Custom package. Will the same work for Win ARM 64?
+        acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom  # Custom package. Will the same work for Win ARM 64?
+    fi
+
+    acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git # Unavailable for Win ARM 64 - https://github.com/git-for-windows/git/releases
+    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/x${BIT}/git-lfs.exe" "git/mingw${BIT}/bin" # AVAILABLE FOR WINDOWS ARM 64 - https://github.com/git-lfs/git-lfs/releases?utm_source=gitlfs_site&utm_medium=releases_link&utm_campaign=gitlfs
+    acquireExternalTool "$CONTAINER_URL/pdbstr/1/pdbstr.zip" pdbstr # Where was this exe sourced from? I see that it ships with Windows
+    acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore # Shipped with Debugging Tools for Windows (https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/) - https://learn.microsoft.com/en-us/windows/win32/debug/using-symstore
+    # Requires installation of Debugging Tools for Windows and taking the symstore from Debuggers\Arm64
+    # https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/debugging-arm64#getting-arm--debugging-tools-for-windows
+    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
+    acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
+    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
+
+    if [[ "$INCLUDE_NODE6" == "true" ]]; then
+        acquireExternalTool "${NODE_URL}/v${NODE_VERSION}/${PACKAGERUNTIME}/node.exe" node/bin # Not available for Windows ARM
+        acquireExternalTool "${NODE_URL}/v${NODE_VERSION}/${PACKAGERUNTIME}/node.lib" node/bin # Not available for Windows ARM
+    fi
+    if [[ "$INCLUDE_NODE10" == "true" ]]; then
+        acquireExternalTool "${NODE_URL}/v${NODE10_VERSION}/${PACKAGERUNTIME}/node.exe" node10/bin # Not available for Windows ARM
+        acquireExternalTool "${NODE_URL}/v${NODE10_VERSION}/${PACKAGERUNTIME}/node.lib" node10/bin # Not available for Windows ARM
+    fi
+
+    # Unofficial distribution of Node contains Node 16 for Windows ARM
+    acquireExternalTool "${NODE_UNOFFICIAL_URL}/v${NODE16_WIN_ARM64_VERSION}/${PACKAGERUNTIME}/node.exe" node16/bin
+    acquireExternalTool "${NODE_UNOFFICIAL_URL}/v${NODE16_WIN_ARM64_VERSION}/${PACKAGERUNTIME}/node.lib" node16/bin
+
+    # Official distribution of Node contains Node 20 for Windows ARM
     acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/${PACKAGERUNTIME}/node.exe" node20_1/bin
     acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/${PACKAGERUNTIME}/node.lib" node20_1/bin
 else

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -165,14 +165,12 @@ function acquireExternalTool() {
 
 echo "PACKAGE RUNTIME: $PACKAGERUNTIME"
 
-# TODO: Check external tools for ARM-64
 if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
     # Download external tools for Windows.
 
     BIT="32"
     if [[ "$PACKAGERUNTIME" == "win-x64" ]]; then
-        BIT="64" # QQ: Why are these tools being installed for Win 64 only?
-
+        BIT="64"
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy
         acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost
         acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -199,24 +199,22 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
     acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/${PACKAGERUNTIME}/node.exe" node20_1/bin
     acquireExternalTool "${NODE_URL}/v${NODE20_VERSION}/${PACKAGERUNTIME}/node.lib" node20_1/bin
 elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]]; then
-    # Download external tools for Windows.
+    # Download external tools for Windows ARM
 
     BIT="32"
     if [[ "$PACKAGERUNTIME" == "win-arm64" ]]; then
         BIT="64"
 
-        acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy # Unavailable for Win ARM 64 - https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf#download-the-azcopy-portable-binary
+        # acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy # Unavailable for Win ARM 64 - https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf#download-the-azcopy-portable-binary
         acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost  # Custom package. Will the same work for Win ARM 64?
         acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom  # Custom package. Will the same work for Win ARM 64?
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git # Unavailable for Win ARM 64 - https://github.com/git-for-windows/git/releases
-    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/x${BIT}/git-lfs.exe" "git/mingw${BIT}/bin" # AVAILABLE FOR WINDOWS ARM 64 - https://github.com/git-lfs/git-lfs/releases?utm_source=gitlfs_site&utm_medium=releases_link&utm_campaign=gitlfs
-    acquireExternalTool "$CONTAINER_URL/pdbstr/1/pdbstr.zip" pdbstr # Where was this exe sourced from? I see that it ships with Windows
-    acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore # Shipped with Debugging Tools for Windows (https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/) - https://learn.microsoft.com/en-us/windows/win32/debug/using-symstore
-    # Requires installation of Debugging Tools for Windows and taking the symstore from Debuggers\Arm64
-    # https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/debugging-arm64#getting-arm--debugging-tools-for-windows
-    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
+    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/win-arm{BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
+    acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm{BIT}/1/pdbstr.zip" pdbstr
+    acquireExternalTool "$CONTAINER_URL/symstore/win-arm{BIT}/1/symstore.zip" symstore
+    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf # Custom package. Will the same work for Win ARM 64? 
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -154,12 +154,12 @@ function acquireExternalTool() {
         fi
     fi
 }
-
-if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
+# TODO: Check external tools for ARM-64
+if [[ "$PACKAGERUNTIME" == "win-x"* || "$PACKAGERUNTIME" == "win-arm64" ]]; then
     # Download external tools for Windows.
 
     BIT="32"
-    if [[ "$PACKAGERUNTIME" == "win-x64" ]]; then
+    if [[ "$PACKAGERUNTIME" == "win-x64" || "$PACKAGERUNTIME" == "win-arm64" ]]; then
         BIT="64"
 
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -211,9 +211,9 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git # Unavailable for Win ARM 64 - https://github.com/git-for-windows/git/releases
-    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/win-arm{BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
-    acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm{BIT}/1/pdbstr.zip" pdbstr
-    acquireExternalTool "$CONTAINER_URL/symstore/win-arm{BIT}/1/symstore.zip" symstore
+    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/win-arm${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
+    acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm${BIT}/1/pdbstr.zip" pdbstr
+    acquireExternalTool "$CONTAINER_URL/symstore/win-arm${BIT}/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf # Custom package. Will the same work for Win ARM 64? 
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -209,7 +209,7 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git # Unavailable for Win ARM 64 - https://github.com/git-for-windows/git/releases
-    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/arm${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
+    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/win-arm${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
     acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm${BIT}/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/win-arm${BIT}/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf # Custom package. Will the same work for Win ARM 64? 

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -212,7 +212,7 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
     acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/win-arm${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
     acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm${BIT}/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/win-arm${BIT}/1/symstore.zip" symstore
-    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf # Custom package. Will the same work for Win ARM 64? 
+    acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
 

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -211,7 +211,7 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git # Unavailable for Win ARM 64 - https://github.com/git-for-windows/git/releases
-    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/win-arm${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
+    acquireExternalTool "$CONTAINER_URL/git-lfs/${LFS_VERSION}/arm${BIT}/git-lfs.exe" "git/mingw${BIT}/bin"
     acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm${BIT}/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/win-arm${BIT}/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf # Custom package. Will the same work for Win ARM 64? 

--- a/src/Test/L0/ConstantGenerationL0.cs
+++ b/src/Test/L0/ConstantGenerationL0.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             {
                 "win-x64",
                 "win-x86",
+                "win-arm64",
                 "linux-x64",
                 "linux-arm",
                 "linux-arm64",

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -121,8 +121,8 @@ function detect_platform_and_runtime_id() {
             DETECTED_RUNTIME_ID='win-x86'
         elif [[ "$PROCESSOR_ARCHITECTURE" == 'ARM64' ]]; then
             DETECTED_RUNTIME_ID='win-arm64'
-        elif [[ "$PROCESSOR_ARCHITECTURE" == 'AMD64' ]]; then
-            DETECTED_RUNTIME_ID='win-arm64'
+##        elif [[ "$PROCESSOR_ARCHITECTURE" == 'AMD64' ]]; then
+##            DETECTED_RUNTIME_ID='win-arm64'
         fi
     elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
         DETECTED_RUNTIME_ID="linux-x64"

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -375,7 +375,7 @@ else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
 fi
 
-_VALID_RIDS='linux-x64:linux-arm:linux-arm64:linux-musl-x64:linux-musl-arm64:osx-x64:osx-arm64:win-x64:win-x86'
+_VALID_RIDS='linux-x64:linux-arm:linux-arm64:linux-musl-x64:linux-musl-arm64:osx-x64:osx-arm64:win-x64:win-x86:win-arm64'
 if [[ ":$_VALID_RIDS:" != *:$RUNTIME_ID:* ]]; then
     failed "must specify a valid target runtime ID (one of: $_VALID_RIDS)"
 fi

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -120,6 +120,7 @@ function detect_platform_and_runtime_id() {
             DETECTED_RUNTIME_ID='win-x86'
         elif [[ "$PROCESSOR_ARCHITECTURE" == 'ARM64' ]]; then
             DETECTED_RUNTIME_ID='win-arm64'
+        if
     elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
         DETECTED_RUNTIME_ID="linux-x64"
         if command -v uname >/dev/null; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -120,7 +120,7 @@ function detect_platform_and_runtime_id() {
             DETECTED_RUNTIME_ID='win-x86'
         elif [[ "$PROCESSOR_ARCHITECTURE" == 'ARM64' ]]; then
             DETECTED_RUNTIME_ID='win-arm64'
-        if
+        fi
     elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
         DETECTED_RUNTIME_ID="linux-x64"
         if command -v uname >/dev/null; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -374,10 +374,8 @@ echo "Current runtime ID: $DETECTED_RUNTIME_ID"
 
 if [ "$DEV_RUNTIME_ID" ]; then
     RUNTIME_ID=$DEV_RUNTIME_ID
-    echo "Proceeding with DEV_RUNTIME_ID"
 else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
-    echo "Proceeding with detected DETECTED_RUNTIME_ID"
 fi
 
 _VALID_RIDS='linux-x64:linux-arm:linux-arm64:linux-musl-x64:linux-musl-arm64:osx-x64:osx-arm64:win-x64:win-x86:win-arm64'

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -118,7 +118,8 @@ function detect_platform_and_runtime_id() {
         DETECTED_RUNTIME_ID='win-x64'
         if [[ "$PROCESSOR_ARCHITECTURE" == 'x86' ]]; then
             DETECTED_RUNTIME_ID='win-x86'
-        fi
+        elif [[ "$PROCESSOR_ARCHITECTURE" == 'ARM64' ]]; then
+            DETECTED_RUNTIME_ID='win-arm64'
     elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
         DETECTED_RUNTIME_ID="linux-x64"
         if command -v uname >/dev/null; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -126,8 +126,6 @@ function detect_platform_and_runtime_id() {
             DETECTED_RUNTIME_ID='win-x86'
         elif [[ "$PROCESSOR_ARCHITECTURE" == 'ARM64' ]]; then
             DETECTED_RUNTIME_ID='win-arm64'
-##        elif [[ "$PROCESSOR_ARCHITECTURE" == 'AMD64' ]]; then
-##            DETECTED_RUNTIME_ID='win-arm64'
         fi
     elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then
         DETECTED_RUNTIME_ID="linux-x64"

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -113,12 +113,15 @@ function detect_platform_and_runtime_id() {
     if [[ ($(uname) == "Linux") || ($(uname) == "Darwin") ]]; then
         CURRENT_PLATFORM=$(uname | awk '{print tolower($0)}')
     fi
-    echo "ARCH ###: $PROCESSOR_ARCHITECTURE"
+    
+    echo "Detected Process Arch: $PROCESSOR_ARCHITECTURE"
     if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
         DETECTED_RUNTIME_ID='win-x64'
         if [[ "$PROCESSOR_ARCHITECTURE" == 'x86' ]]; then
             DETECTED_RUNTIME_ID='win-x86'
         elif [[ "$PROCESSOR_ARCHITECTURE" == 'ARM64' ]]; then
+            DETECTED_RUNTIME_ID='win-arm64'
+        elif [[ "$PROCESSOR_ARCHITECTURE" == 'AMD64' ]]; then
             DETECTED_RUNTIME_ID='win-arm64'
         fi
     elif [[ "$CURRENT_PLATFORM" == 'linux' ]]; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -113,7 +113,7 @@ function detect_platform_and_runtime_id() {
     if [[ ($(uname) == "Linux") || ($(uname) == "Darwin") ]]; then
         CURRENT_PLATFORM=$(uname | awk '{print tolower($0)}')
     fi
-
+    echo "ARCH ###: $PROCESSOR_ARCHITECTURE"
     if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
         DETECTED_RUNTIME_ID='win-x64'
         if [[ "$PROCESSOR_ARCHITECTURE" == 'x86' ]]; then

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -374,8 +374,10 @@ echo "Current runtime ID: $DETECTED_RUNTIME_ID"
 
 if [ "$DEV_RUNTIME_ID" ]; then
     RUNTIME_ID=$DEV_RUNTIME_ID
+    echo "Proceeding with DEV_RUNTIME_ID"
 else
     RUNTIME_ID=$DETECTED_RUNTIME_ID
+    echo "Proceeding with detected DETECTED_RUNTIME_ID"
 fi
 
 _VALID_RIDS='linux-x64:linux-arm:linux-arm64:linux-musl-x64:linux-musl-arm64:osx-x64:osx-arm64:win-x64:win-x86:win-arm64'

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -91,6 +91,11 @@ function restore_sdk_and_runtime() {
         dotnet_windows_dir=${dotnet_windows_dir:0:1}:${dotnet_windows_dir:1}
         local architecture
         architecture=$(echo "$RUNTIME_ID" | cut -d "-" -f2)
+        
+        # We compile on an x64 machine, even when targeting ARM64. Thereby we are installing the x64 version of .NET instead of the arm64 version.
+        if [[ "$architecture" == "arm64" ]]; then
+            architecture="x64"
+        fi
 
         printf "\nInstalling SDK...\n"
         powershell -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "& \"${DOTNET_INSTALL_SCRIPT_PATH}\" -Version ${DOTNET_SDK_VERSION} -InstallDir \"${dotnet_windows_dir}\" -Architecture ${architecture}  -NoPath; exit \$LastExitCode;" || checkRC "${DOTNET_INSTALL_SCRIPT_NAME} (SDK)"

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -110,7 +110,7 @@
     <Copy SourceFiles="@(LayoutBinFiles)"  DestinationFolder="$(LayoutRoot)/bin/%(RecursiveDir)"/>
 
     <ItemGroup>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.cmd" Condition="'$(PackageRuntime)' != 'win-x64' Or '$(PackageRuntime)' != 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.cmd" Condition="'$(PackageRuntime)' != 'win-x64' And '$(PackageRuntime)' != 'win-x86' And '$(PackageRuntime)' != 'win-arm64'"/>
         <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.sh" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'"/>
         <LayoutRootFilesToDelete Include="$(LayoutRoot)/license.html" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'"/>
         <LayoutRootFilesToDelete Include="$(LayoutRoot)/bin/AgentService.js" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'"/>

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -74,7 +74,7 @@
              SkipNonExistentProjects="false"
              StopOnFirstFailure="true"
              Properties="Configuration=$(BUILDCONFIG);PackageRuntime=$(PackageRuntime);Version=$(AgentVersion);RuntimeIdentifier=$(PackageRuntime);PublishDir=$(LayoutRoot)/bin;TreatWarningsAsErrors=$(TreatWarningsAsErrors)" />
-    <Exec Command="%22$(DesktopMSBuild)%22 Agent.Service/Windows/AgentService.csproj /p:Configuration=$(BUILDCONFIG) /p:OutputPath=%22$(LayoutRoot)/bin%22 /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors)" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86'" />
+    <Exec Command="%22$(DesktopMSBuild)%22 Agent.Service/Windows/AgentService.csproj /p:Configuration=$(BUILDCONFIG) /p:OutputPath=%22$(LayoutRoot)/bin%22 /p:TreatWarningsAsErrors=$(TreatWarningsAsErrors)" ConsoleToMSBuild="true" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'" />
   </Target>
 
   <Target Name="TestL0" DependsOnTargets="GenerateConstant">
@@ -110,10 +110,10 @@
     <Copy SourceFiles="@(LayoutBinFiles)"  DestinationFolder="$(LayoutRoot)/bin/%(RecursiveDir)"/>
 
     <ItemGroup>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.cmd" Condition="'$(PackageRuntime)' != 'win-x64' And '$(PackageRuntime)' != 'win-x86'"/>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.sh" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86'"/>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/license.html" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86'"/>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/bin/AgentService.js" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.cmd" Condition="'$(PackageRuntime)' != 'win-x64' Or '$(PackageRuntime)' != 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.sh" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/license.html" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/bin/AgentService.js" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
     </ItemGroup>
 
     <Delete Files="@(LayoutRootFilesToDelete)" />

--- a/src/dir.proj
+++ b/src/dir.proj
@@ -111,9 +111,9 @@
 
     <ItemGroup>
         <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.cmd" Condition="'$(PackageRuntime)' != 'win-x64' Or '$(PackageRuntime)' != 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.sh" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/license.html" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
-        <LayoutRootFilesToDelete Include="$(LayoutRoot)/bin/AgentService.js" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' != 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/*.sh" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/license.html" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'"/>
+        <LayoutRootFilesToDelete Include="$(LayoutRoot)/bin/AgentService.js" Condition="'$(PackageRuntime)' == 'win-x64' Or '$(PackageRuntime)' == 'win-x86' Or '$(PackageRuntime)' == 'win-arm64'"/>
     </ItemGroup>
 
     <Delete Files="@(LayoutRootFilesToDelete)" />


### PR DESCRIPTION
## Purpose of this Change

This PR enables support for build and run the Agent Service on Windows ARM64, expanding platform compatibility.

## Summary of Changes

1. Updated CI pipeline definitions to include Windows ARM64 builds.
2. Modified installation and servicing scripts to accommodate Windows ARM64.
3. Updated relevant documentation to reflect these changes.

## Testing

- Sanity Test: A Windows ARM64 VM was created, deployed with the build, and executed. The VM was connected as a self-hosted agent, and several test pipelines were run successfully.
- E2E Test: Since a Windows ARM64 agent is not yet available, we are currently building on an x64 machine targeting ARM64. The first signed build of Windows ARM64 agents will be deployed to Ring 0 for initial testing.

## Related PRs

1. [CIPlat.Externals - PR 814218: Externals for Agent Win ARM 64](https://dev.azure.com/mseng/AzureDevOps/_git/CIPlat.Externals/pullrequest/814218)
1. [CIPlat.Externals - PR 814434: Corrected path for git-lfs for Windows ARM 64](https://dev.azure.com/mseng/AzureDevOps/_git/CIPlat.Externals/pullrequest/814434)
1. [CIPlat.Externals - PR 815860: Externals for Win ARM 64 - C++ Redist](https://dev.azure.com/mseng/AzureDevOps/_git/CIPlat.Externals/pullrequest/815860)
