### PR TITLE
Fix an issue with pipeline timeline update

### DIFF
--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -557,7 +557,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 }
                 catch (AggregateException ex)
                 {
-                    ExceptionsUtil.HandleAggregateException((AggregateException)ex, Trace.Error);
+                    ExceptionsUtil.HandleAggregateException(ex, Trace.Error);
+
+                    if (throwOnFailure)
+                    {
+                        throw;
+                    }
                 }
                 catch (Exception ex) when (!throwOnFailure)
                 {


### PR DESCRIPTION
In this PR I fixed a bug where any exception during a timeline update request would stop the timeline update process.

This bug was confusing for users because it caused no logs in the web console (it seemed like the process was frozen), but the job was eventually successful.

Related WI: [AB#2226231](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2226231)

Testing: manual