### PR TITLE
Fix agent hangs if agent fails to get FF state

### DIFF
--- a/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
+++ b/src/Agent.Listener/Configuration/FeatureFlagProvider.cs
@@ -61,19 +61,9 @@ namespace Agent.Listener.Configuration
             {
                 return await client.GetFeatureFlagByNameAsync(featureFlagName, checkFeatureExists: false, ctk);
             }
-            catch (VssServiceException e)
+            catch (Exception e)
             {
                 Trace.Warning("Unable to retrieve feature flag status: " + e.ToString());
-                return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
-            }
-            catch (VssUnauthorizedException e)
-            {
-                Trace.Warning("Unable to retrieve feature flag with following exception: " + e.ToString());
-                return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
-            }
-            catch (TimeoutException e)
-            {
-                Trace.Warning("Unable to retrieve feature flag status due to timeout error: " + e.ToString());
                 return new FeatureFlag(featureFlagName, "", "", "Off", "Off");
             }
         }


### PR DESCRIPTION
Recently we had an incident when the agent got the HttpRequestException during **GetFeatureFlag** request and just stuck until timeout reached (see related WI).

I decided to replace specific exception handlers with the common handler because the agent can hang and it's critical.

Related WI: [AB#2227901](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2227901)
