### PR TITLE
Change AddBuildTagAsync to send tags as Body parameter

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -135,6 +135,12 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AGENT_GIT_USE_SECURE_PARAMETER_PASSING"),
             new BuiltInDefaultKnobSource("true"));
 
+        public static readonly Knob UseBuildTagsBodyApi = new Knob(
+            nameof(UseBuildTagsBodyApi),
+            "If true (default), the agent sends build tags in the request body via BuildHttpClient.AddBuildTagsAsync, preserving reserved URL characters such as ';'. Set the agent-host environment variable AGENT_USE_BUILD_TAGS_BODY_API=false to fall back to the legacy single-tag AddBuildTagAsync (URL-path) overload — only needed for older on-prem Azure DevOps Server versions that do not accept the body-based endpoint.",
+            new EnvironmentKnobSource("AGENT_USE_BUILD_TAGS_BODY_API"),
+            new BuiltInDefaultKnobSource("true"));
+
         public static readonly Knob FixPossibleGitOutOfMemoryProblem = new Knob(
             nameof(FixPossibleGitOutOfMemoryProblem),
             "When true, set config git properties to fix possible out of memory problem",

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -137,9 +137,10 @@ namespace Agent.Sdk.Knob
 
         public static readonly Knob UseBuildTagsBodyApi = new Knob(
             nameof(UseBuildTagsBodyApi),
-            "If true (default), the agent sends build tags in the request body via BuildHttpClient.AddBuildTagsAsync, preserving reserved URL characters such as ';'. Set the agent-host environment variable AGENT_USE_BUILD_TAGS_BODY_API=false to fall back to the legacy single-tag AddBuildTagAsync (URL-path) overload — only needed for older on-prem Azure DevOps Server versions that do not accept the body-based endpoint.",
+            "If true, the agent posts build tags via the body-based BuildHttpClient.AddBuildTagsAsync overload, preserving reserved URL characters such as ';'. If false (default), uses the legacy URL-path AddBuildTagAsync overload.",
+            new RuntimeKnobSource("AGENT_USE_BUILD_TAGS_BODY_API"),
             new EnvironmentKnobSource("AGENT_USE_BUILD_TAGS_BODY_API"),
-            new BuiltInDefaultKnobSource("true"));
+            new BuiltInDefaultKnobSource("false"));
 
         public static readonly Knob FixPossibleGitOutOfMemoryProblem = new Knob(
             nameof(FixPossibleGitOutOfMemoryProblem),

--- a/src/Agent.Worker/Build/BuildCommandExtension.cs
+++ b/src/Agent.Worker/Build/BuildCommandExtension.cs
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
         {
             var buildServer = context.GetHostContext().GetService<IBuildServer>();
             await buildServer.ConnectAsync(connection);
-            var tags = await buildServer.AddBuildTag(buildId, projectId, buildTag, cancellationToken);
+            var tags = await buildServer.AddBuildTag(buildId, projectId, buildTag, context, cancellationToken);
 
             if (tags == null || !tags.Any(t => t.Equals(buildTag, StringComparison.OrdinalIgnoreCase)))
             {

--- a/src/Agent.Worker/Build/BuildServer.cs
+++ b/src/Agent.Worker/Build/BuildServer.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             string buildTag,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await _buildHttpClient.AddBuildTagAsync(projectId, buildId, buildTag, cancellationToken: cancellationToken);
+            return await _buildHttpClient.AddBuildTagsAsync(new[] { buildTag }, projectId, buildId, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Agent.Worker/Build/BuildServer.cs
+++ b/src/Agent.Worker/Build/BuildServer.cs
@@ -35,14 +35,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             int buildId,
             Guid projectId,
             string buildTag,
+            IKnobValueContext knobContext,
             CancellationToken cancellationToken = default(CancellationToken));
     }
 
     public class BuildServer : AgentService, IBuildServer
     {
         private VssConnection _connection;
-        // Exposed as internal (not private) so unit tests in the Test assembly can substitute a mocked
-        // BuildHttpClient via [assembly: InternalsVisibleTo("Test")] declared in AssemblyInfo.cs.
+        // Exposed as internal so unit tests in the Test assembly can inject a mocked
+        // BuildHttpClient via [assembly: InternalsVisibleTo("Test")].
         internal Build2.BuildHttpClient _buildHttpClient;
 
         public async Task ConnectAsync(VssConnection jobConnection)
@@ -118,27 +119,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             int buildId,
             Guid projectId,
             string buildTag,
+            IKnobValueContext knobContext,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Prefer the bulk AddBuildTagsAsync overload (body transport), which preserves reserved
-            // URL characters such as ';'. The legacy single-tag AddBuildTagAsync overload encodes
-            // the tag into the URL path and mangles such characters, causing the post-call
-            // verification in BuildAddBuildTagCommand to fail. See:
-            //   https://github.com/microsoft/azure-pipelines-task-lib/issues/1072
-            //
-            // The kill-switch knob UseBuildTagsBodyApi (set the agent-host environment variable
-            // AGENT_USE_BUILD_TAGS_BODY_API=false and restart the agent) lets operators fall back
-            // to the legacy URL-path API if the body-based endpoint is unsupported on their
-            // on-prem Azure DevOps Server version. Do not "simplify" this branch away.
+            ArgUtil.NotNull(knobContext, nameof(knobContext));
+
+            // Prefer the body-based AddBuildTagsAsync overload, which preserves reserved URL
+            // characters such as ';'. The legacy AddBuildTagAsync overload encodes the tag into
+            // the URL path and mangles such characters, causing the post-call verification in
+            // BuildAddBuildTagCommand to fail. See azure-pipelines-task-lib#1072.
+            // The UseBuildTagsBodyApi knob is a kill-switch for on-prem servers that don't
+            // support the body endpoint.
             bool useBodyApi = AgentKnobs.UseBuildTagsBodyApi
-                .GetValue(UtilKnobValueContext.Instance())
+                .GetValue(knobContext)
                 .AsBoolean();
 
             if (useBodyApi)
             {
+                Trace.Info("Adding build tag using body-based API.");
                 return await _buildHttpClient.AddBuildTagsAsync(new[] { buildTag }, projectId, buildId, cancellationToken: cancellationToken);
             }
 
+            Trace.Info("Adding build tag using legacy URL-path API.");
             return await _buildHttpClient.AddBuildTagAsync(projectId, buildId, buildTag, cancellationToken: cancellationToken);
         }
     }

--- a/src/Agent.Worker/Build/BuildServer.cs
+++ b/src/Agent.Worker/Build/BuildServer.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Build2 = Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
+using Agent.Sdk.Knob;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 {
@@ -119,13 +120,26 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             string buildTag,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Intentionally call the bulk AddBuildTagsAsync (sends tags in the request body) instead of
-            // the single-tag AddBuildTagAsync overload (which encodes the tag into the URL path).
-            // The URL-path variant mangles reserved characters such as ';' on the server side, which
-            // caused the post-call verification in BuildAddBuildTagCommand to fail. See:
+            // Prefer the bulk AddBuildTagsAsync overload (body transport), which preserves reserved
+            // URL characters such as ';'. The legacy single-tag AddBuildTagAsync overload encodes
+            // the tag into the URL path and mangles such characters, causing the post-call
+            // verification in BuildAddBuildTagCommand to fail. See:
             //   https://github.com/microsoft/azure-pipelines-task-lib/issues/1072
-            // Do not "simplify" this back to AddBuildTagAsync.
-            return await _buildHttpClient.AddBuildTagsAsync(new[] { buildTag }, projectId, buildId, cancellationToken: cancellationToken);
+            //
+            // The kill-switch knob UseBuildTagsBodyApi (set the agent-host environment variable
+            // AGENT_USE_BUILD_TAGS_BODY_API=false and restart the agent) lets operators fall back
+            // to the legacy URL-path API if the body-based endpoint is unsupported on their
+            // on-prem Azure DevOps Server version. Do not "simplify" this branch away.
+            bool useBodyApi = AgentKnobs.UseBuildTagsBodyApi
+                .GetValue(UtilKnobValueContext.Instance())
+                .AsBoolean();
+
+            if (useBodyApi)
+            {
+                return await _buildHttpClient.AddBuildTagsAsync(new[] { buildTag }, projectId, buildId, cancellationToken: cancellationToken);
+            }
+
+            return await _buildHttpClient.AddBuildTagAsync(projectId, buildId, buildTag, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Agent.Worker/Build/BuildServer.cs
+++ b/src/Agent.Worker/Build/BuildServer.cs
@@ -40,7 +40,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
     public class BuildServer : AgentService, IBuildServer
     {
         private VssConnection _connection;
-        private Build2.BuildHttpClient _buildHttpClient;
+        // Exposed as internal (not private) so unit tests in the Test assembly can substitute a mocked
+        // BuildHttpClient via [assembly: InternalsVisibleTo("Test")] declared in AssemblyInfo.cs.
+        internal Build2.BuildHttpClient _buildHttpClient;
 
         public async Task ConnectAsync(VssConnection jobConnection)
         {
@@ -117,6 +119,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             string buildTag,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            // Intentionally call the bulk AddBuildTagsAsync (sends tags in the request body) instead of
+            // the single-tag AddBuildTagAsync overload (which encodes the tag into the URL path).
+            // The URL-path variant mangles reserved characters such as ';' on the server side, which
+            // caused the post-call verification in BuildAddBuildTagCommand to fail. See:
+            //   https://github.com/microsoft/azure-pipelines-task-lib/issues/1072
+            // Do not "simplify" this back to AddBuildTagAsync.
             return await _buildHttpClient.AddBuildTagsAsync(new[] { buildTag }, projectId, buildId, cancellationToken: cancellationToken);
         }
     }

--- a/src/Test/L0/Worker/Build/BuildServerL0.cs
+++ b/src/Test/L0/Worker/Build/BuildServerL0.cs
@@ -6,7 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Agent.Sdk;
+using Agent.Sdk.Knob;
 using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.Agent.Tests;
 using Microsoft.VisualStudio.Services.Common;
 using Moq;
 using Xunit;
@@ -15,166 +18,201 @@ namespace Test.L0.Worker.Build
 {
     public sealed class BuildServerL0
     {
-        private const string UseBuildTagsBodyApiEnvVar = "AGENT_USE_BUILD_TAGS_BODY_API";
+        private const string _knobName = "AGENT_USE_BUILD_TAGS_BODY_API";
+
+        // Minimal IKnobValueContext stub that exposes a settable pipeline-variable map and a
+        // settable in-memory environment scope, so the knob's RuntimeKnobSource and
+        // EnvironmentKnobSource can be exercised without depending on the real agent host or
+        // ambient process environment.
+        private sealed class TestKnobContext : IKnobValueContext
+        {
+            private readonly IDictionary<string, string> _variables;
+            private readonly Dictionary<string, string> _envVars;
+
+            public TestKnobContext(
+                IDictionary<string, string> variables = null,
+                Dictionary<string, string> envVars = null)
+            {
+                _variables = variables ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _envVars = envVars ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            public string GetVariableValueOrDefault(string variableName)
+            {
+                _variables.TryGetValue(variableName, out var value);
+                return value;
+            }
+
+            public IScopedEnvironment GetScopedEnvironment() => new LocalEnvironment(_envVars);
+        }
 
         // Regression test for tags containing reserved URL characters such as ';' — see
         // https://github.com/microsoft/azure-pipelines-task-lib/issues/1072.
-        //
-        // BuildServer.AddBuildTag must call the bulk BuildHttpClient.AddBuildTagsAsync overload
-        // (which transports tags in the request body) instead of the legacy single-tag
-        // AddBuildTagAsync overload (which encodes the tag into the URL path and corrupts
-        // characters like ';').
+        // When the knob is enabled via a pipeline runtime variable, BuildServer.AddBuildTag must
+        // call the body-based AddBuildTagsAsync overload instead of the legacy AddBuildTagAsync.
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async Task AddBuildTag_UsesBodyApi_AndPreservesSemicolonInTag()
+        public async Task AddBuildTag_UsesBodyApi_AndPreservesSemicolonInTag_WhenKnobEnabledViaRuntimeVariable()
         {
-            string previous = Environment.GetEnvironmentVariable(UseBuildTagsBodyApiEnvVar);
-            try
-            {
-                // Force-clear the env var so the BuiltInDefault ("true") wins, regardless of
-                // anything the host machine may have set.
-                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, null);
+            const string tag = "foo;bar";
+            const int buildId = 42;
+            Guid projectId = Guid.NewGuid();
 
-                const string tag = "foo;bar";
-                const int buildId = 42;
-                Guid projectId = Guid.NewGuid();
-
-                var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
-
-                IEnumerable<string> capturedTags = null;
-                Guid capturedProject = Guid.Empty;
-                int capturedBuildId = 0;
-
-                mockClient
-                    .Setup(x => x.AddBuildTagsAsync(
-                        It.IsAny<IEnumerable<string>>(),
-                        It.IsAny<Guid>(),
-                        It.IsAny<int>(),
-                        It.IsAny<object>(),
-                        It.IsAny<CancellationToken>()))
-                    .Callback<IEnumerable<string>, Guid, int, object, CancellationToken>(
-                        (tags, project, id, _, __) =>
-                        {
-                            capturedTags = tags?.ToArray();
-                            capturedProject = project;
-                            capturedBuildId = id;
-                        })
-                    .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
-
-                var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
+            var knobContext = new TestKnobContext(
+                variables: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    _buildHttpClient = mockClient.Object
-                };
+                    { _knobName, "true" }
+                });
 
-                var result = await server.AddBuildTag(buildId, projectId, tag);
+            var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
 
-                Assert.NotNull(capturedTags);
-                Assert.Equal(new[] { tag }, capturedTags);
-                Assert.Equal(projectId, capturedProject);
-                Assert.Equal(buildId, capturedBuildId);
-                Assert.Contains(tag, result);
+            IEnumerable<string> capturedTags = null;
+            Guid capturedProject = Guid.Empty;
+            int capturedBuildId = 0;
 
-                mockClient.Verify(
-                    x => x.AddBuildTagsAsync(
-                        It.IsAny<IEnumerable<string>>(),
-                        It.IsAny<Guid>(),
-                        It.IsAny<int>(),
-                        It.IsAny<object>(),
-                        It.IsAny<CancellationToken>()),
-                    Times.Once);
+            mockClient
+                .Setup(x => x.AddBuildTagsAsync(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<string>, Guid, int, object, CancellationToken>(
+                    (tags, project, id, _, __) =>
+                    {
+                        capturedTags = tags?.ToArray();
+                        capturedProject = project;
+                        capturedBuildId = id;
+                    })
+                .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
 
-                // Guard against accidental revert to the URL-path single-tag overload.
-                mockClient.Verify(
-                    x => x.AddBuildTagAsync(
-                        It.IsAny<Guid>(),
-                        It.IsAny<int>(),
-                        It.IsAny<string>(),
-                        It.IsAny<object>(),
-                        It.IsAny<CancellationToken>()),
-                    Times.Never);
-            }
-            finally
+            var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
             {
-                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, previous);
-            }
+                _buildHttpClient = mockClient.Object
+            };
+            using var hc = new TestHostContext(this);
+            server.Initialize(hc);
+
+            var result = await server.AddBuildTag(buildId, projectId, tag, knobContext);
+
+            Assert.Equal(new[] { tag }, capturedTags);
+            Assert.Equal(projectId, capturedProject);
+            Assert.Equal(buildId, capturedBuildId);
+            Assert.Contains(tag, result);
+
+            mockClient.Verify(
+                x => x.AddBuildTagAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
-        // Kill-switch test: when AGENT_USE_BUILD_TAGS_BODY_API=false, BuildServer.AddBuildTag must
-        // fall back to the legacy single-tag URL-path overload (AddBuildTagAsync) — providing an
-        // operator-controlled rollback path for older on-prem Azure DevOps Server versions that do
-        // not accept the body-based endpoint.
+        // Default behavior (knob unset → BuiltInDefault "false") falls back to the legacy
+        // URL-path overload. Locks in the kill-switch default.
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public async Task AddBuildTag_FallsBackToLegacyApi_WhenKnobDisabled()
+        public async Task AddBuildTag_UsesLegacyApi_ByDefault()
         {
-            string previous = Environment.GetEnvironmentVariable(UseBuildTagsBodyApiEnvVar);
-            try
+            const string tag = "simple-tag";
+            const int buildId = 7;
+            Guid projectId = Guid.NewGuid();
+
+            var knobContext = new TestKnobContext();
+
+            var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
+
+            string capturedTag = null;
+
+            mockClient
+                .Setup(x => x.AddBuildTagAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<Guid, int, string, object, CancellationToken>(
+                    (_, __, t, ___, ____) => { capturedTag = t; })
+                .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
+
+            var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
             {
-                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, "false");
+                _buildHttpClient = mockClient.Object
+            };
+            using var hc = new TestHostContext(this);
+            server.Initialize(hc);
 
-                const string tag = "simple-tag";
-                const int buildId = 7;
-                Guid projectId = Guid.NewGuid();
+            var result = await server.AddBuildTag(buildId, projectId, tag, knobContext);
 
-                var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
+            Assert.Equal(tag, capturedTag);
+            Assert.Contains(tag, result);
 
-                string capturedTag = null;
-                Guid capturedProject = Guid.Empty;
-                int capturedBuildId = 0;
+            mockClient.Verify(
+                x => x.AddBuildTagsAsync(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
 
-                mockClient
-                    .Setup(x => x.AddBuildTagAsync(
-                        It.IsAny<Guid>(),
-                        It.IsAny<int>(),
-                        It.IsAny<string>(),
-                        It.IsAny<object>(),
-                        It.IsAny<CancellationToken>()))
-                    .Callback<Guid, int, string, object, CancellationToken>(
-                        (project, id, t, _, __) =>
-                        {
-                            capturedProject = project;
-                            capturedBuildId = id;
-                            capturedTag = t;
-                        })
-                    .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
+        // Verifies the EnvironmentKnobSource path: knob enabled via the agent-host env var (not
+        // a pipeline runtime variable). Same expected behavior as the runtime-variable test.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AddBuildTag_UsesBodyApi_WhenKnobEnabledViaEnvironmentVariable()
+        {
+            const string tag = "env-tag;with;semis";
+            const int buildId = 99;
+            Guid projectId = Guid.NewGuid();
 
-                var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
+            var knobContext = new TestKnobContext(
+                envVars: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    _buildHttpClient = mockClient.Object
-                };
+                    { _knobName, "true" }
+                });
 
-                var result = await server.AddBuildTag(buildId, projectId, tag);
+            var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
 
-                Assert.Equal(tag, capturedTag);
-                Assert.Equal(projectId, capturedProject);
-                Assert.Equal(buildId, capturedBuildId);
-                Assert.Contains(tag, result);
+            IEnumerable<string> capturedTags = null;
 
-                mockClient.Verify(
-                    x => x.AddBuildTagAsync(
-                        It.IsAny<Guid>(),
-                        It.IsAny<int>(),
-                        It.IsAny<string>(),
-                        It.IsAny<object>(),
-                        It.IsAny<CancellationToken>()),
-                    Times.Once);
+            mockClient
+                .Setup(x => x.AddBuildTagsAsync(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<string>, Guid, int, object, CancellationToken>(
+                    (tags, _, __, ___, ____) => { capturedTags = tags?.ToArray(); })
+                .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
 
-                mockClient.Verify(
-                    x => x.AddBuildTagsAsync(
-                        It.IsAny<IEnumerable<string>>(),
-                        It.IsAny<Guid>(),
-                        It.IsAny<int>(),
-                        It.IsAny<object>(),
-                        It.IsAny<CancellationToken>()),
-                    Times.Never);
-            }
-            finally
+            var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
             {
-                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, previous);
-            }
+                _buildHttpClient = mockClient.Object
+            };
+            using var hc = new TestHostContext(this);
+            server.Initialize(hc);
+
+            var result = await server.AddBuildTag(buildId, projectId, tag, knobContext);
+
+            Assert.Equal(new[] { tag }, capturedTags);
+            Assert.Contains(tag, result);
+
+            mockClient.Verify(
+                x => x.AddBuildTagAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
     }
 }
-

--- a/src/Test/L0/Worker/Build/BuildServerL0.cs
+++ b/src/Test/L0/Worker/Build/BuildServerL0.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Moq;
+using Xunit;
+
+namespace Test.L0.Worker.Build
+{
+    public sealed class BuildServerL0
+    {
+        // Regression test for tags containing reserved URL characters such as ';' — see
+        // https://github.com/microsoft/azure-pipelines-task-lib/issues/1072.
+        //
+        // BuildServer.AddBuildTag must call the bulk BuildHttpClient.AddBuildTagsAsync overload
+        // (which transports tags in the request body) instead of the legacy single-tag
+        // AddBuildTagAsync overload (which encodes the tag into the URL path and corrupts
+        // characters like ';').
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AddBuildTag_UsesBodyApi_AndPreservesSemicolonInTag()
+        {
+            const string tag = "foo;bar";
+            const int buildId = 42;
+            Guid projectId = Guid.NewGuid();
+
+            var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
+
+            IEnumerable<string> capturedTags = null;
+            Guid capturedProject = Guid.Empty;
+            int capturedBuildId = 0;
+
+            mockClient
+                .Setup(x => x.AddBuildTagsAsync(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<string>, Guid, int, object, CancellationToken>(
+                    (tags, project, id, _, __) =>
+                    {
+                        capturedTags = tags?.ToArray();
+                        capturedProject = project;
+                        capturedBuildId = id;
+                    })
+                .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
+
+            var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
+            {
+                _buildHttpClient = mockClient.Object
+            };
+
+            var result = await server.AddBuildTag(buildId, projectId, tag);
+
+            Assert.NotNull(capturedTags);
+            Assert.Equal(new[] { tag }, capturedTags);
+            Assert.Equal(projectId, capturedProject);
+            Assert.Equal(buildId, capturedBuildId);
+            Assert.Contains(tag, result);
+
+            mockClient.Verify(
+                x => x.AddBuildTagsAsync(
+                    It.IsAny<IEnumerable<string>>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            // Guard against accidental revert to the URL-path single-tag overload.
+            mockClient.Verify(
+                x => x.AddBuildTagAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+}

--- a/src/Test/L0/Worker/Build/BuildServerL0.cs
+++ b/src/Test/L0/Worker/Build/BuildServerL0.cs
@@ -15,6 +15,8 @@ namespace Test.L0.Worker.Build
 {
     public sealed class BuildServerL0
     {
+        private const string UseBuildTagsBodyApiEnvVar = "AGENT_USE_BUILD_TAGS_BODY_API";
+
         // Regression test for tags containing reserved URL characters such as ';' — see
         // https://github.com/microsoft/azure-pipelines-task-lib/issues/1072.
         //
@@ -27,63 +29,152 @@ namespace Test.L0.Worker.Build
         [Trait("Category", "Worker")]
         public async Task AddBuildTag_UsesBodyApi_AndPreservesSemicolonInTag()
         {
-            const string tag = "foo;bar";
-            const int buildId = 42;
-            Guid projectId = Guid.NewGuid();
-
-            var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
-
-            IEnumerable<string> capturedTags = null;
-            Guid capturedProject = Guid.Empty;
-            int capturedBuildId = 0;
-
-            mockClient
-                .Setup(x => x.AddBuildTagsAsync(
-                    It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<Guid>(),
-                    It.IsAny<int>(),
-                    It.IsAny<object>(),
-                    It.IsAny<CancellationToken>()))
-                .Callback<IEnumerable<string>, Guid, int, object, CancellationToken>(
-                    (tags, project, id, _, __) =>
-                    {
-                        capturedTags = tags?.ToArray();
-                        capturedProject = project;
-                        capturedBuildId = id;
-                    })
-                .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
-
-            var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
+            string previous = Environment.GetEnvironmentVariable(UseBuildTagsBodyApiEnvVar);
+            try
             {
-                _buildHttpClient = mockClient.Object
-            };
+                // Force-clear the env var so the BuiltInDefault ("true") wins, regardless of
+                // anything the host machine may have set.
+                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, null);
 
-            var result = await server.AddBuildTag(buildId, projectId, tag);
+                const string tag = "foo;bar";
+                const int buildId = 42;
+                Guid projectId = Guid.NewGuid();
 
-            Assert.NotNull(capturedTags);
-            Assert.Equal(new[] { tag }, capturedTags);
-            Assert.Equal(projectId, capturedProject);
-            Assert.Equal(buildId, capturedBuildId);
-            Assert.Contains(tag, result);
+                var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
 
-            mockClient.Verify(
-                x => x.AddBuildTagsAsync(
-                    It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<Guid>(),
-                    It.IsAny<int>(),
-                    It.IsAny<object>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
+                IEnumerable<string> capturedTags = null;
+                Guid capturedProject = Guid.Empty;
+                int capturedBuildId = 0;
 
-            // Guard against accidental revert to the URL-path single-tag overload.
-            mockClient.Verify(
-                x => x.AddBuildTagAsync(
-                    It.IsAny<Guid>(),
-                    It.IsAny<int>(),
-                    It.IsAny<string>(),
-                    It.IsAny<object>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Never);
+                mockClient
+                    .Setup(x => x.AddBuildTagsAsync(
+                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<int>(),
+                        It.IsAny<object>(),
+                        It.IsAny<CancellationToken>()))
+                    .Callback<IEnumerable<string>, Guid, int, object, CancellationToken>(
+                        (tags, project, id, _, __) =>
+                        {
+                            capturedTags = tags?.ToArray();
+                            capturedProject = project;
+                            capturedBuildId = id;
+                        })
+                    .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
+
+                var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
+                {
+                    _buildHttpClient = mockClient.Object
+                };
+
+                var result = await server.AddBuildTag(buildId, projectId, tag);
+
+                Assert.NotNull(capturedTags);
+                Assert.Equal(new[] { tag }, capturedTags);
+                Assert.Equal(projectId, capturedProject);
+                Assert.Equal(buildId, capturedBuildId);
+                Assert.Contains(tag, result);
+
+                mockClient.Verify(
+                    x => x.AddBuildTagsAsync(
+                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<int>(),
+                        It.IsAny<object>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+
+                // Guard against accidental revert to the URL-path single-tag overload.
+                mockClient.Verify(
+                    x => x.AddBuildTagAsync(
+                        It.IsAny<Guid>(),
+                        It.IsAny<int>(),
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, previous);
+            }
+        }
+
+        // Kill-switch test: when AGENT_USE_BUILD_TAGS_BODY_API=false, BuildServer.AddBuildTag must
+        // fall back to the legacy single-tag URL-path overload (AddBuildTagAsync) — providing an
+        // operator-controlled rollback path for older on-prem Azure DevOps Server versions that do
+        // not accept the body-based endpoint.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task AddBuildTag_FallsBackToLegacyApi_WhenKnobDisabled()
+        {
+            string previous = Environment.GetEnvironmentVariable(UseBuildTagsBodyApiEnvVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, "false");
+
+                const string tag = "simple-tag";
+                const int buildId = 7;
+                Guid projectId = Guid.NewGuid();
+
+                var mockClient = new Mock<BuildHttpClient>(new Uri("http://localhost"), new VssCredentials());
+
+                string capturedTag = null;
+                Guid capturedProject = Guid.Empty;
+                int capturedBuildId = 0;
+
+                mockClient
+                    .Setup(x => x.AddBuildTagAsync(
+                        It.IsAny<Guid>(),
+                        It.IsAny<int>(),
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.IsAny<CancellationToken>()))
+                    .Callback<Guid, int, string, object, CancellationToken>(
+                        (project, id, t, _, __) =>
+                        {
+                            capturedProject = project;
+                            capturedBuildId = id;
+                            capturedTag = t;
+                        })
+                    .Returns(Task.FromResult<List<string>>(new List<string> { tag }));
+
+                var server = new Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildServer
+                {
+                    _buildHttpClient = mockClient.Object
+                };
+
+                var result = await server.AddBuildTag(buildId, projectId, tag);
+
+                Assert.Equal(tag, capturedTag);
+                Assert.Equal(projectId, capturedProject);
+                Assert.Equal(buildId, capturedBuildId);
+                Assert.Contains(tag, result);
+
+                mockClient.Verify(
+                    x => x.AddBuildTagAsync(
+                        It.IsAny<Guid>(),
+                        It.IsAny<int>(),
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+
+                mockClient.Verify(
+                    x => x.AddBuildTagsAsync(
+                        It.IsAny<IEnumerable<string>>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<int>(),
+                        It.IsAny<object>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(UseBuildTagsBodyApiEnvVar, previous);
+            }
         }
     }
 }
+

--- a/src/Test/L1/Mock/FakeBuildServer.cs
+++ b/src/Test/L1/Mock/FakeBuildServer.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System;
+using Agent.Sdk.Knob;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Worker.Build;
 using Build2 = Microsoft.TeamFoundation.Build.WebApi;
@@ -62,6 +63,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             int buildId,
             Guid projectId,
             string buildTag,
+            IKnobValueContext knobContext,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             BuildTags.Add(buildTag);


### PR DESCRIPTION
### **Context**
The `##vso[build.addbuildtag]` logging command fails when the tag contains reserved URL characters such as `;`, `:`, etc.. The agent calls `BuildHttpClient.AddBuildTagAsync`, which encodes the tag into the URL **path**; the server then stores a different (split/encoded) value than was sent. The post-call verification in `BuildAddBuildTagCommand` (`tags.Any(t => t.Equals(buildTag, OrdinalIgnoreCase))`) consequently fails and the user sees a `BuildTagAddFailed` exception.

Tracked in: [azure-pipelines-task-lib#1072](https://github.com/microsoft/azure-pipelines-task-lib/issues/1072).

---

### **Description**
- `BuildServer.AddBuildTag` now optionally calls the bulk `BuildHttpClient.AddBuildTagsAsync` overload, which transports tags in the **request body**, preserving all characters verbatim.
- Behavior is gated by a new knob `UseBuildTagsBodyApi` (default **off**). Operators can opt in per agent (env var) or per pipeline (runtime variable) without redeploying.
- `IBuildServer.AddBuildTag` gains a required `IKnobValueContext knobContext` parameter so the knob can be evaluated against the calling pipeline's runtime variables. `FakeBuildServer` and the single in-tree caller (`BuildCommandExtension`) are updated accordingly. No other callers exist in this repo.

Repro yaml
```yml
jobs:
- job: common
  displayName: Common cases
  steps:
  - pwsh: |
      Write-Host "##vso[build.addbuildtag]foo;bar"
    displayName: Add tag with semicolon
  - pwsh: |
      Write-Host "##vso[build.addbuildtag]plainTag"
    displayName: Add tag without semicolon (control)
- job: disabled
  displayName: Disabled FF
  variables:
    AGENT_USE_BUILD_TAGS_BODY_API: false
  steps:
  - pwsh: |
      $last_scanned = "last_scanned:$(Get-Date -Format yyyyMMdd)"
      Write-Host "##vso[build.addbuildtag]$last_scanned"
    displayName: "Apply last scanned tag"
    continueOnError: true
- job: enabled
  displayName: Enabled FF
  variables:
    AGENT_USE_BUILD_TAGS_BODY_API: true
  steps:
  - pwsh: |
      $last_scanned = "last_scanned:$(Get-Date -Format yyyyMMdd)"
      Write-Host "##vso[build.addbuildtag]$last_scanned"
    displayName: "Apply last scanned tag"
```

---

### **Risk Assessment** (Low / Medium / High)
**Low.**
- Default off → byte-identical behavior to before this PR until explicitly enabled.
- Production caller path adds one knob read and a branch; no new dependencies, no init side effects.
- `IBuildServer` surface change is contained to the worker assembly; all in-tree implementations updated.

---

### **Unit Tests Added or Updated** (Yes / No)
**Yes.** New L0 test file `src/Test/L0/Worker/Build/BuildServerL0.cs` with three tests:
- `AddBuildTag_UsesBodyApi_AndPreservesSemicolonInTag_WhenKnobEnabledViaRuntimeVariable` — knob enabled via pipeline runtime variable; asserts `AddBuildTagsAsync` is called with the unmodified `"foo;bar"` tag and `AddBuildTagAsync` is never called.
- `AddBuildTag_UsesBodyApi_WhenKnobEnabledViaEnvironmentVariable` — knob enabled via agent-host env var; asserts the same body-API behavior (covers the `EnvironmentKnobSource` path).
- `AddBuildTag_UsesLegacyApi_ByDefault` — knob unset (BuiltInDefault `"false"`); asserts the legacy `AddBuildTagAsync` URL-path overload is invoked, guarding the default.

---

### **Additional Testing Performed**
- Local L0 run: `./dev.cmd testl0 net8.0 Debug win-x64 "FullyQualifiedName~BuildServerL0"` → **Passed 3, Failed 0**.
- Manual repro to be performed against a private agent: set `variables: AGENT_USE_BUILD_TAGS_BODY_API: true` and emit `##vso[build.addbuildtag]foo;bar`; confirm the tag appears unmodified on the build.

---

### **Change Behind Feature Flag** (Yes / No)
**Yes.** New knob `AgentKnobs.UseBuildTagsBodyApi`:
- Default: **`false`** (legacy URL-path behavior preserved).
- Pipeline-scoped opt-in (preferred for testing/canary): set the runtime variable `AGENT_USE_BUILD_TAGS_BODY_API` to `true` at pipeline / stage / job level.
- Agent-scoped opt-in (preferred for fleet rollout): set the environment variable `AGENT_USE_BUILD_TAGS_BODY_API=true` on the agent host and restart the agent service.
- Plan: roll out at default off, validate with selected pipelines, then flip default to `true` in a follow-up.

---

### **Tech Design / Approach**
- Swap the client overload only when the knob says so, keeping the legacy code path as the documented kill-switch.
- Plumb `IKnobValueContext` through `IBuildServer.AddBuildTag` so `RuntimeKnobSource` can resolve pipeline variables. `IAsyncCommandContext` (which `BuildCommandExtension` already holds) implements `IKnobValueContext`, so the new argument adds no new state to thread.
- `knobContext` is **required** (no `= null` default). This avoids the `UtilKnobValueContext.Instance()` fallback, which throws `NotSupportedException` from `GetVariableValueOrDefault` and would surprise any future caller that omitted the argument.
- `_buildHttpClient` is now `internal` to allow mock injection from the `Test` assembly via `[assembly: InternalsVisibleTo("Test")]`.
- Inline comment on the method documents *why* the bulk overload is used with a single-element array, to prevent a well-meaning "simplification" back to the broken path.

---

### **Documentation Changes Required** (Yes/No)
**No.** The knob is documented inline in `AgentKnobs.cs` (the canonical source for agent knobs). Behavior change is transparent to pipeline authors once enabled.

---

### **Logging Added/Updated** (Yes/No)
**Yes (Trace only).** `BuildServer.AddBuildTag` now emits one `Trace.Info` per call indicating which transport was used ("body-based API" vs "legacy URL-path API"). No new structured telemetry, no sensitive data.

---

### **Telemetry Added/Updated** (Yes/No)
**No.** Failure remains observable via the existing thrown exception, which surfaces in job logs.

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.**
1. **Preferred (no deployment):** because the knob defaults to `false`, no rollback is required for the body-API behavior — it does not run unless explicitly opted in.
2. If a pipeline opted in and hits an unsupported server, remove the `AGENT_USE_BUILD_TAGS_BODY_API` variable from that pipeline (or set it to `false`).
3. If a fleet operator opted in via env var, set `AGENT_USE_BUILD_TAGS_BODY_API=false` (or unset) on the agent host and restart the agent.
4. **Last resort:** revert this PR and ship a hotfix agent build.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.**
- No package/dependency changes; both `BuildHttpClient.AddBuildTagAsync` and `AddBuildTagsAsync` already ship in the `Microsoft.TeamFoundationServer.Client` version this repo references.
- `IBuildServer.AddBuildTag` adds a required `IKnobValueContext` parameter. The in-tree caller (`BuildCommandExtension`) and mock (`FakeBuildServer`) are updated; no other implementations exist in the repo.
- L0 + L1 build verified.
