### PR TITLE
Fix connection getting disposed

### DIFF
--- a/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
@@ -60,6 +60,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
 
         public async Task<bool> PublishAsync(TestRunContext runContext, List<string> testResultFiles, string runTitle, int? buildId, bool mergeResults)
         {
+            await Task.Delay(50000);
             ArgUtil.NotNull(runContext, nameof(runContext));
             ArgUtil.NotNull(testResultFiles, nameof(testResultFiles));
             if (mergeResults)

--- a/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
@@ -62,7 +62,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
 
         public async Task<bool> PublishAsync(TestRunContext runContext, List<string> testResultFiles, string runTitle, int? buildId, bool mergeResults)
         {
-            await Task.Delay(50000);
             ArgUtil.NotNull(runContext, nameof(runContext));
             ArgUtil.NotNull(testResultFiles, nameof(testResultFiles));
             if (mergeResults)

--- a/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/Legacy/LegacyTestRunDataPublisher.cs
@@ -36,6 +36,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
         private int _runCounter = 0;
         private IFeatureFlagService _featureFlagService;
         private bool _calculateTestRunSummary;
+        private bool _isFlakyCheckEnabled;
         private string _testRunner;
         private ITestResultsServer _testResultsServer;
         private TestRunDataPublisherHelper _testRunPublisherHelper;
@@ -54,6 +55,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
             _testResultsServer = HostContext.GetService<ITestResultsServer>();
             _testResultsServer.InitializeServer(connection, _executionContext);
             _calculateTestRunSummary = _featureFlagService.GetFeatureFlagState(TestResultsConstants.CalculateTestRunSummaryFeatureFlag, TestResultsConstants.TFSServiceInstanceGuid);
+            _isFlakyCheckEnabled = _featureFlagService.GetFeatureFlagState(TestResultsConstants.EnableFlakyCheckInAgentFeatureFlag, TestResultsConstants.TCMServiceInstanceGuid);
             _testRunPublisherHelper = new TestRunDataPublisherHelper(_executionContext, null, _testRunPublisher, _testResultsServer);
             Trace.Leaving();
         }
@@ -209,9 +211,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
 
                     // Check failed results for flaky aware
                     // Fallback to flaky aware if there are any failures.
-                    bool isFlakyCheckEnabled = _featureFlagService.GetFeatureFlagState(TestResultsConstants.EnableFlakyCheckInAgentFeatureFlag, TestResultsConstants.TCMServiceInstanceGuid);
-
-                    if (isTestRunOutcomeFailed && isFlakyCheckEnabled)
+                    if (isTestRunOutcomeFailed && _isFlakyCheckEnabled)
                     {
                         IList<TestRun> publishedRuns = new List<TestRun>();
                         publishedRuns.Add(updatedRun);
@@ -314,9 +314,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.LegacyTestResults
 
                 // Check failed results for flaky aware
                 // Fallback to flaky aware if there are any failures.
-                bool isFlakyCheckEnabled = _featureFlagService.GetFeatureFlagState(TestResultsConstants.EnableFlakyCheckInAgentFeatureFlag, TestResultsConstants.TCMServiceInstanceGuid);
-
-                if (isTestRunOutcomeFailed && isFlakyCheckEnabled)
+                if (isTestRunOutcomeFailed && _isFlakyCheckEnabled)
                 {
                     var runOutcome = _testRunPublisherHelper.CheckRunsForFlaky(publishedRuns, _projectName);
                     if (runOutcome != null && runOutcome.HasValue)

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -311,17 +311,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private async Task PublishTestRunDataAsync(string teamProject, TestRunContext testRunContext)
         {
             bool isTestRunOutcomeFailed = false;
-        
+
             _telemetryProperties.Add("UsePublishTestResultsLib", _publishTestResultsLibFeatureState);
             var connection = WorkerUtilities.GetVssConnection(_executionContext);
-        
+
             try
             {
                 if (_publishTestResultsLibFeatureState)
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ITestDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner);
-        
+
                     if (_enableAzureTestPlanFeatureState && !_testCaseResults.IsNullOrEmpty() && !_testPlanId.IsNullOrEmpty())
                     {
                         isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _testCaseResults, GetPublishOptions(), _executionContext.CancellationToken);
@@ -335,16 +335,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ILegacyTestRunDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner, _publishRunLevelAttachments);
-        
+
                     isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);
                 }
-        
+
                 if (isTestRunOutcomeFailed && _failTaskOnFailedTests)
                 {
                     _executionContext.Result = TaskResult.Failed;
                     _executionContext.Error(StringUtil.Loc("FailedTestsInResults"));
                 }
-        
+
                 await PublishEventsAsync(connection);
                 if (_triggerCoverageMergeJobFeatureState)
                 {

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -311,17 +311,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private async Task PublishTestRunDataAsync(string teamProject, TestRunContext testRunContext)
         {
             bool isTestRunOutcomeFailed = false;
-
+        
             _telemetryProperties.Add("UsePublishTestResultsLib", _publishTestResultsLibFeatureState);
-            using (var connection = WorkerUtilities.GetVssConnection(_executionContext))
+            var connection = WorkerUtilities.GetVssConnection(_executionContext);
+        
+            try
             {
-
-                //This check is to determine to use "Microsoft.TeamFoundation.PublishTestResults" Library or the agent code to parse and publish the test results.
                 if (_publishTestResultsLibFeatureState)
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ITestDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner);
-
+        
                     if (_enableAzureTestPlanFeatureState && !_testCaseResults.IsNullOrEmpty() && !_testPlanId.IsNullOrEmpty())
                     {
                         isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _testCaseResults, GetPublishOptions(), _executionContext.CancellationToken);
@@ -335,21 +335,25 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ILegacyTestRunDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner, _publishRunLevelAttachments);
-
+        
                     isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);
                 }
-
+        
                 if (isTestRunOutcomeFailed && _failTaskOnFailedTests)
                 {
                     _executionContext.Result = TaskResult.Failed;
                     _executionContext.Error(StringUtil.Loc("FailedTestsInResults"));
                 }
-
+        
                 await PublishEventsAsync(connection);
                 if (_triggerCoverageMergeJobFeatureState)
                 {
                     TriggerCoverageMergeJob(_testResultFiles, _executionContext);
                 }
+            }
+            finally
+            {
+                connection?.Dispose();
             }
         }
 

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -311,17 +311,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private async Task PublishTestRunDataAsync(string teamProject, TestRunContext testRunContext)
         {
             bool isTestRunOutcomeFailed = false;
-        
+
             _telemetryProperties.Add("UsePublishTestResultsLib", _publishTestResultsLibFeatureState);
-            var connection = WorkerUtilities.GetVssConnection(_executionContext);
-        
-            try
+            using (var connection = WorkerUtilities.GetVssConnection(_executionContext))
             {
+
+                //This check is to determine to use "Microsoft.TeamFoundation.PublishTestResults" Library or the agent code to parse and publish the test results.
                 if (_publishTestResultsLibFeatureState)
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ITestDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner);
-        
+
                     if (_enableAzureTestPlanFeatureState && !_testCaseResults.IsNullOrEmpty() && !_testPlanId.IsNullOrEmpty())
                     {
                         isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _testCaseResults, GetPublishOptions(), _executionContext.CancellationToken);
@@ -335,25 +335,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ILegacyTestRunDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner, _publishRunLevelAttachments);
-        
+
                     isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);
                 }
-        
+
                 if (isTestRunOutcomeFailed && _failTaskOnFailedTests)
                 {
                     _executionContext.Result = TaskResult.Failed;
                     _executionContext.Error(StringUtil.Loc("FailedTestsInResults"));
                 }
-        
+
                 await PublishEventsAsync(connection);
                 if (_triggerCoverageMergeJobFeatureState)
                 {
                     TriggerCoverageMergeJob(_testResultFiles, _executionContext);
                 }
-            }
-            finally
-            {
-                connection?.Dispose();
             }
         }
 

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -311,17 +311,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private async Task PublishTestRunDataAsync(string teamProject, TestRunContext testRunContext)
         {
             bool isTestRunOutcomeFailed = false;
-
+        
             _telemetryProperties.Add("UsePublishTestResultsLib", _publishTestResultsLibFeatureState);
             var connection = WorkerUtilities.GetVssConnection(_executionContext);
-
+        
             try
             {
                 if (_publishTestResultsLibFeatureState)
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ITestDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner);
-
+        
                     if (_enableAzureTestPlanFeatureState && !_testCaseResults.IsNullOrEmpty() && !_testPlanId.IsNullOrEmpty())
                     {
                         isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _testCaseResults, GetPublishOptions(), _executionContext.CancellationToken);
@@ -335,16 +335,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ILegacyTestRunDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner, _publishRunLevelAttachments);
-
+        
                     isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);
                 }
-
+        
                 if (isTestRunOutcomeFailed && _failTaskOnFailedTests)
                 {
                     _executionContext.Result = TaskResult.Failed;
                     _executionContext.Error(StringUtil.Loc("FailedTestsInResults"));
                 }
-
+        
                 await PublishEventsAsync(connection);
                 if (_triggerCoverageMergeJobFeatureState)
                 {

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -313,11 +313,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             bool isTestRunOutcomeFailed = false;
 
             _telemetryProperties.Add("UsePublishTestResultsLib", _publishTestResultsLibFeatureState);
-            using (var connection = WorkerUtilities.GetVssConnection(_executionContext))
-            {
-                _executionContext.Warning("HELLO");
+            var connection = WorkerUtilities.GetVssConnection(_executionContext);
 
-                //This check is to determine to use "Microsoft.TeamFoundation.PublishTestResults" Library or the agent code to parse and publish the test results.
+            try
+            {
                 if (_publishTestResultsLibFeatureState)
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ITestDataPublisher>();
@@ -337,7 +336,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     var publisher = _executionContext.GetHostContext().GetService<ILegacyTestRunDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner, _publishRunLevelAttachments);
 
-                    isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);                    
+                    isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);
                 }
 
                 if (isTestRunOutcomeFailed && _failTaskOnFailedTests)
@@ -351,6 +350,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     TriggerCoverageMergeJob(_testResultFiles, _executionContext);
                 }
+            }
+            finally
+            {
+                connection?.Dispose();
             }
         }
 

--- a/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
+++ b/src/Agent.Worker/TestResults/ResultsCommandExtension.cs
@@ -313,10 +313,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             bool isTestRunOutcomeFailed = false;
 
             _telemetryProperties.Add("UsePublishTestResultsLib", _publishTestResultsLibFeatureState);
-            var connection = WorkerUtilities.GetVssConnection(_executionContext);
-
-            try
+            using (var connection = WorkerUtilities.GetVssConnection(_executionContext))
             {
+                _executionContext.Warning("HELLO");
+
+                //This check is to determine to use "Microsoft.TeamFoundation.PublishTestResults" Library or the agent code to parse and publish the test results.
                 if (_publishTestResultsLibFeatureState)
                 {
                     var publisher = _executionContext.GetHostContext().GetService<ITestDataPublisher>();
@@ -336,7 +337,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                     var publisher = _executionContext.GetHostContext().GetService<ILegacyTestRunDataPublisher>();
                     publisher.InitializePublisher(_executionContext, teamProject, connection, _testRunner, _publishRunLevelAttachments);
 
-                    isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);
+                    isTestRunOutcomeFailed = await publisher.PublishAsync(testRunContext, _testResultFiles, _runTitle, _executionContext.Variables.Build_BuildId, _mergeResults);                    
                 }
 
                 if (isTestRunOutcomeFailed && _failTaskOnFailedTests)
@@ -350,10 +351,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 {
                     TriggerCoverageMergeJob(_testResultFiles, _executionContext);
                 }
-            }
-            finally
-            {
-                connection?.Dispose();
             }
         }
 

--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -120,7 +120,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
         public async Task<bool> PublishAsync(TestRunContext runContext, List<string> testResultFiles, TestCaseResult[] testCaseResults, PublishOptions publishOptions, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await Task.Delay(50000);
             try
             {
                 TestDataProvider testDataProvider = ParseTestResultsFile(runContext, testResultFiles);

--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -97,6 +97,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                         TestResultUtils.StoreTestRunSummaryInEnvVar(_executionContext, testRunSummary, _testRunner, "PublishTestResults");
                     }
 
+                    // Check failed results for flaky aware
+                    // Fallback to flaky aware if there are any failures.
                     if (isTestRunOutcomeFailed && _isFlakyCheckEnabled)
                     {
                         var runOutcome = _testRunPublisherHelper.CheckRunsForFlaky(publishedRuns, _projectName);

--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
         private IFeatureFlagService _featureFlagService;
         private string _testRunner;
         private bool _calculateTestRunSummary;
+        private bool _
         private TestRunDataPublisherHelper _testRunPublisherHelper;
         private ITestResultsServer _testResultsServer;
 
@@ -58,6 +59,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
             var extensionManager = HostContext.GetService<IExtensionManager>();
             _featureFlagService = HostContext.GetService<IFeatureFlagService>();
             _featureFlagService.InitializeFeatureService(_executionContext, connection);
+            _calculateTestRunSummary = _featureFlagService.GetFeatureFlagState(TestResultsConstants.CalculateTestRunSummaryFeatureFlag, TestResultsConstants.TFSServiceInstanceGuid);
             _parser = (extensionManager.GetExtensions<IParser>()).FirstOrDefault(x => _testRunner.Equals(x.Name, StringComparison.OrdinalIgnoreCase));
             _testRunPublisherHelper = new TestRunDataPublisherHelper(_executionContext, _testRunPublisher, null, _testResultsServer);
             Trace.Leaving();
@@ -123,6 +125,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
         public async Task<bool> PublishAsync(TestRunContext runContext, List<string> testResultFiles, TestCaseResult[] testCaseResults, PublishOptions publishOptions, CancellationToken cancellationToken = default(CancellationToken))
         {
+            await Task.Delay(50000);
             try
             {
                 TestDataProvider testDataProvider = ParseTestResultsFile(runContext, testResultFiles);


### PR DESCRIPTION
For fixing CRI: [Incident-558584096 Details - IcM](https://portal.microsofticm.com/imp/v5/incidents/details/558584096/summary)

In the current design, we face the issue of connection getting disposed, when it is needed by feature flag service inside PublishAsync method in publisher. I am switching to get feature flag states and setting boolean accordingly during initialization in InitializePublisher method. This will improve the design as we were earlier making multiple calls for same feature flag and should also potentially fix the issue as during initialization we see feature flag service used to get state in other places does not throw warning currently.

Testing Screenshot

![image](https://github.com/user-attachments/assets/38b949b5-c07f-4abe-bc9f-2eb145f8b19a)

Warning screenshot

![image](https://github.com/user-attachments/assets/602e0053-5159-4bc9-805e-84d110067336)

I am not able to repro the error locally, in the error cases we currently receive error logs as per below as shared in the CRI.

1.

##[warning]Failed to get FF TestManagement.Agent.PTR.EnableFlakyCheck Value. Error: System.AggregateException: One or more errors occurred. (A task was canceled.)
 ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Threading.Tasks.Task.GetExceptions(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils.FeatureFlagService.GetFeatureFlagState(String featureFlagName, Guid serviceInstanceId) in D:\a\_work\1\s\src\Agent.Worker\TestResults\Utils\FeatureFlagService.cs:line 39
   at Microsoft.VisualStudio.Services.Agent.Worker.TestResults.TestDataPublisher.PublishAsync(TestRunContext runContext, List`1 testResultFiles, PublishOptions publishOptions, CancellationToken cancellationToken) in D:\a\_work\1\s\src\Agent.Worker\TestResults\TestDataPublisher.cs:line 101
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task.TrySetResult()
   at System.Threading.Tasks.Task.WhenAllPromise.Invoke(Task completedTask)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Threading.Tasks.UnwrapPromise`1.TrySetFromTask(Task task, Boolean lookForOce)
   at System.Threading.Tasks.UnwrapPromise`1.Invoke(Task completingTask)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at Microsoft.TeamFoundation.TestClient.PublishTestResults.TestRunPublisher.PublishTestRunDataAsync(TestRunContext runContext, String projectName, IList`1 testRuns, PublishOptions publishOptions, CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
...
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pNativeOverlapped)
--- End of stack trace from previous location ---

   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils.FeatureFlagService.GetFeatureFlagState(String featureFlagName, Guid serviceInstanceId) in D:\a\_work\1\s\src\Agent.Worker\TestResults\Utils\FeatureFlagService.cs:line 39
   

2.

##[warning]Failed to get FF TestManagement.PTR.CalculateTestRunSummary Value. Error: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'VssConnection'.
   at Microsoft.VisualStudio.Services.WebApi.VssConnection.CheckForDisposed()
   at Microsoft.VisualStudio.Services.WebApi.VssConnection.GetClientServiceImplAsync(Type requestedType, Guid serviceIdentifier, Func`4 getInstanceAsync, CancellationToken cancellationToken)
   at Microsoft.VisualStudio.Services.WebApi.VssConnection.GetClientAsync[T](Guid serviceIdentifier, CancellationToken cancellationToken)
   at Microsoft.VisualStudio.Services.WebApi.TaskExtensions.SyncResult[T](Task`1 task)
   at Microsoft.VisualStudio.Services.WebApi.VssConnection.GetClient[T](Guid serviceIdentifier)
   at Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils.FeatureFlagService.GetFeatureFlagState(String featureFlagName, Guid serviceInstanceId