### PR TITLE
[Agent] CI Trigger for Windows ARM 64 - AB#2143637

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -186,7 +186,7 @@ extends:
             buildAlternatePackage: ${{ parameters.buildAlternatePackage }}
             targetFramework: ${{ parameters.targetFramework }}
   
-  # Windows (ARM)
+  # Windows (ARM64)
       - ${{ if parameters.win_arm64 }}:
           - template: /.azure-pipelines/build-jobs.yml@self
             parameters:

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -14,6 +14,10 @@ parameters:
   type: boolean
   displayName: Windows (x86)
   default: true
+- name: win_arm64
+  type: boolean
+  displayName: Windows (ARM64)
+  default: true
 - name: linux_x64
   type: boolean
   displayName: Linux (x64)
@@ -59,6 +63,7 @@ extends:
     testProxyAgent: ${{ parameters.testProxyAgent }}
     win_x64: ${{ parameters.win_x64 }}
     win_x86: ${{ parameters.win_x86 }}
+    win_arm64: ${{ parameters.win_arm64 }}
     linux_x64: ${{ parameters.linux_x64 }}
     linux_arm: ${{ parameters.linux_arm }}
     linux_arm64: ${{ parameters.linux_arm64 }}


### PR DESCRIPTION
## Purpose

This PR adds the CI step to build Agents for Windows ARM 64.

## Summary of Changes

1. Revised the .vsts.ci.yml to build Agents for Windows ARM 64.

## Testing

1. Build validation only

## Related PRs

1. https://github.com/microsoft/azure-pipelines-agent/pull/5021