### PR TITLE
[Agent] Bug Fix - Fixed Processor Arch Detection in Windows - AB#2232751

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Written for .NET Core in C#.
 |![Win-x86](docs/res/win_med.png) **Windows x86**|[![Build & Test][win-x86-build-badge]][build]| 
 |![Win-arm64](docs/res/win_med.png) **Windows ARM64**|[![Build & Test][win-arm64-build-badge]][build]| 
 |![macOS](docs/res/apple_med.png) **macOS**|[![Build & Test][macOS-build-badge]][build]| 
-|![Linux-x64](docs/res/linux_med.png) **Linux x64**|[![Build & Test][linux-x64-build-badge]][build]|
-|![Linux-arm](docs/res/linux_med.png) **Linux ARM**|[![Build & Test][linux-arm-build-badge]][build]|
-|![RHEL6-x64](docs/res/redhat_med.png) **RHEL 6 x64**|[![Build & Test][rhel6-x64-build-badge]][build]|
+|![Linux-x64](docs/res/linux_med.png) **Linux x64**|[![Build & Test][linux-x64-build-badge]][build]| 
+|![Linux-arm](docs/res/linux_med.png) **Linux ARM**|[![Build & Test][linux-arm-build-badge]][build]| 
+|![RHEL6-x64](docs/res/redhat_med.png) **RHEL 6 x64**|[![Build & Test][rhel6-x64-build-badge]][build]| 
 
 [win-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x64)
 [win-x86-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(x86)
-[win-arm64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(arm64)
+[win-arm64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Windows%20(ARM64)
 [macOS-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=macOS%20(x64)
 [linux-x64-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(x64)
 [linux-arm-build-badge]: https://mseng.visualstudio.com/pipelinetools/_apis/build/status/VSTS.Agent/azure-pipelines-agent.ci?branchName=master&jobname=Linux%20(ARM)

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -382,7 +382,7 @@ function detect_system_architecture() {
     if [[ "$PROCESSOR_IDENTIFIER" =~ "AMD64" || "$PROCESSOR_IDENTIFIER" =~ "Intel" ]]; then
         processor="x"
     # Check for ARM64 in the variable to classify as "ARM"
-    elif [[ "$PROCESSOR_IDENTIFIER" =~ "ARM64" ]]; then
+    elif [[ "$PROCESSOR_IDENTIFIER" =~ "ARM" || "$PROCESSOR_IDENTIFIER" =~ "Arm" ]]; then
         processor="ARM"
     # Default to "x" for unknown or unhandled cases
     else
@@ -396,6 +396,9 @@ function detect_system_architecture() {
     # "i686" or "i386" indicates a 32-bit operating system
     elif [[ "$(uname -m)" == "i686" || "$(uname -m)" == "i386" ]]; then
         os_arch="86"
+    # "aarch64" indicates a 64-bit ARM operating system
+    elif [[ "$(uname -m)" == "aarch64" ]]; then
+        os_arch="64"
     # Default to "64" for unknown or unhandled cases
     else
         os_arch="64"

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -119,7 +119,7 @@ function detect_platform_and_runtime_id() {
         CURRENT_PLATFORM=$(uname | awk '{print tolower($0)}')
     fi
     
-    local processor_type = $(get_processor_type);
+    local processor_type=$(get_processor_type)
     echo "Detected Process Arch: $processor_type"
 
     if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
@@ -371,8 +371,6 @@ function cmd_lint_verify() {
 }
 
 function get_processor_type() {
-     heading "Reading PROCESSOR_IDENTIFIER"
-
     # Retrieve the PROCESSOR_IDENTIFIER environment variable, or default to an empty string if not set
     local identifier="${PROCESSOR_IDENTIFIER:-}"
 

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -120,13 +120,11 @@ function detect_platform_and_runtime_id() {
     fi
     
     if [[ "$CURRENT_PLATFORM" == 'windows' ]]; then
-        
         local processor_type=$(detect_system_architecture)
         echo "Detected Process Arch: $processor_type"
 
         # Default to win-x64
         DETECTED_RUNTIME_ID='win-x64'
-        
         if [[ "$processor_type" == 'x86' ]]; then
             DETECTED_RUNTIME_ID='win-x86'
         elif [[ "$processor_type" == 'ARM64' ]]; then
@@ -379,7 +377,7 @@ function detect_system_architecture() {
 
     # Detect processor type using PROCESSOR_IDENTIFIER
     # Check for AMD64 or Intel in the variable to classify as "x" (covers x86 and x64 processors)
-    if [[ "$PROCESSOR_IDENTIFIER" =~ "AMD64" || "$PROCESSOR_IDENTIFIER" =~ "Intel" ]]; then
+    if [[ "$PROCESSOR_IDENTIFIER" =~ "AMD64" || "$PROCESSOR_IDENTIFIER" =~ "Intel64" ]]; then
         processor="x"
     # Check for ARM64 in the variable to classify as "ARM"
     elif [[ "$PROCESSOR_IDENTIFIER" =~ "ARM" || "$PROCESSOR_IDENTIFIER" =~ "Arm" ]]; then


### PR DESCRIPTION
## Context

Installation script of Pipeline Agent reads the `PROCESSOR_ARCHITECTURE` environment variable to determine the processor's make (AMD, Intel, ARM) and OS architecture (32 bit or 64 bit).
[function detect_platform_and_runtime_id()](https://github.com/microsoft/azure-pipelines-agent/blob/bbd4855cd69684b018e0e632497e6935a496c673/src/dev.sh#L109C1-L109C44)

## Issue

`PROCESSOR_ARCHITECTURE` environment variable will be returned as what's most capable when running the external process i.e., the returned value varies depending on **which process this environment variable is read from**. The installation script of Agent uses Bash to run the dev.sh script when being setup on any Windows machine. Doing this leads to the value always being read as AMD64 - even on 32bit Windows or ARM hardware.

![image](https://github.com/user-attachments/assets/5078e6c4-ab37-4dd0-9377-a962b8e21d47)

## Why did our CI pipeline not catch this?

`detect_platform_and_runtime_id` function is not involved when running via the CI pipeline as the target architecture is passed as an argument to the setup scripts i.e., the `PROCESSOR_ARCHITECTURE` variable is not read to determine the underlying architecture.

## Who is affected?

Anyone building the Agents on a 32bit Windows or ARM Windows is affected as the build always defaults to x64.

## How can this be fixed?

- Rely on the `PROCESSOR_IDENTIFIER` variable instead of the `PROCESSOR_ARCHITECTURE` to understand the Processor make (Intel, AMD or ARM)
- Rely on the `uname` command to understand if the OS is 32bit or 64bit.

Here are the tested combinations of these variables:

| CPU Arch | OS | PROCESSOR_IDENTIFIER | `uname -m` |
| -- | -- | -- | -- |
| Intel 64 | Windows 64 | Intel64 Family 6 Model 140 Stepping 1, GenuineIntel | x86_64 |
| AMD 64 | Windows 64 | AMD64 Family 25 Model 1 Stepping 1, AuthenticAMD | x86_64 |
| ARM 64 | Windows ARM | ARMv8 (64-bit) Family 8 Model D0C Revision 301, Ampere(R) | x86_64 |

## How was the fix tested?

- `PROCESSOR_IDENTIFIER` environment variable value does not change depending on the process it is read from.
![image](https://github.com/user-attachments/assets/0b3f306f-d5b7-406d-b478-d55e98f633d2)

### Layout output on Windows x64

![Win x64](https://github.com/user-attachments/assets/2a6c64e8-08d3-4e55-9f1c-320de928370a)

### Layout output on Windows ARM64

![Win ARM 64](https://github.com/user-attachments/assets/66a28320-d678-43e6-90ca-7aae2df89722)
