### PR TITLE
Handle manual test cases associated with same automated tests

### DIFF
--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 if (testDataProvider != null)
                 {
                     var testRunData = testDataProvider.GetTestRunData();
-                    
+
                     if (!testCaseResults.IsNullOrEmpty())
                     {
                         //Dictionary because FQN to Test Case Results is 1 to many

--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
                 if (testDataProvider != null)
                 {
                     var testRunData = testDataProvider.GetTestRunData();
-
+                    
                     if (!testCaseResults.IsNullOrEmpty())
                     {
                         //Dictionary because FQN to Test Case Results is 1 to many
@@ -153,6 +153,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
                         for (testRunDataIterator = 0; testRunDataIterator < testRunData.Count; testRunDataIterator++)
                         {
+                            var testResultsUpdated = new List<TestCaseResultData>();
                             for (testResultDataIterator = 0; testResultDataIterator < testRunData[testRunDataIterator].TestResults.Count; testResultDataIterator++)
                             {
                                 var testResultFQN = testRunData[testRunDataIterator].TestResults[testResultDataIterator].AutomatedTestStorage +
@@ -160,17 +161,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
                                 if (testResultByFQN.TryGetValue(testResultFQN, out List<TestCaseResult> inputs))
                                 {
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].TestPoint = inputs[0].TestPoint;
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].TestCaseTitle = inputs[0].TestCaseTitle;
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].Configuration = inputs[0].Configuration;
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].TestCase = inputs[0].TestCase;
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].Owner = inputs[0].Owner;
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].State = "5";
-                                    testRunData[testRunDataIterator].TestResults[testResultDataIterator].TestCaseRevision = inputs[0].TestCaseRevision;
+                                    foreach (var input in inputs)
+                                    {
+                                        var testCaseResultDataUpdated = TestResultUtils.CloneTestCaseResultData(testRunData[testRunDataIterator].TestResults[testResultDataIterator]);
 
-                                    testResultByFQN[testResultFQN].RemoveAt(0);
+                                        testCaseResultDataUpdated.TestPoint = input.TestPoint;
+                                        testCaseResultDataUpdated.TestCaseTitle = input.TestCaseTitle;
+                                        testCaseResultDataUpdated.Configuration = input.Configuration;
+                                        testCaseResultDataUpdated.TestCase = input.TestCase;
+                                        testCaseResultDataUpdated.Owner = input.Owner;
+                                        testCaseResultDataUpdated.State = "5";
+                                        testCaseResultDataUpdated.TestCaseRevision = input.TestCaseRevision;
+
+                                        testResultsUpdated.Add(testCaseResultDataUpdated);
+                                    }
                                 }
                             }
+                            testRunData[testRunDataIterator].TestResults = testResultsUpdated;
                         }
                     }
 

--- a/src/Agent.Worker/TestResults/Utils/TestResultUtils.cs
+++ b/src/Agent.Worker/TestResults/Utils/TestResultUtils.cs
@@ -5,6 +5,8 @@ using Agent.Sdk.Knob;
 using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Microsoft.TeamFoundation.TestClient.PublishTestResults;
+using System.Linq;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
 {
@@ -30,6 +32,61 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults.Utils
             {
                 executionContext.Debug($"Unable to set the METADATA_* env variable, error details: {ex}");
             }
+        }
+
+        public static TestCaseResultData CloneTestCaseResultData(TestCaseResultData original)
+        {
+            return new TestCaseResultData
+            {
+                Id = original.Id,
+                Comment = original.Comment,
+                Configuration = original.Configuration,
+                Project = original.Project,
+                StartedDate = original.StartedDate,
+                CompletedDate = original.CompletedDate,
+                DurationInMs = original.DurationInMs,
+                Outcome = original.Outcome,
+                Revision = original.Revision,
+                State = original.State,
+                TestCase = original.TestCase,
+                TestPoint = original.TestPoint,
+                TestRun = original.TestRun,
+                ResolutionStateId = original.ResolutionStateId,
+                ResolutionState = original.ResolutionState,
+                LastUpdatedDate = original.LastUpdatedDate,
+                Priority = original.Priority,
+                ComputerName = original.ComputerName,
+                ResetCount = original.ResetCount,
+                Build = original.Build,
+                Release = original.Release,
+                ErrorMessage = original.ErrorMessage,
+                CreatedDate = original.CreatedDate,
+                IterationDetails = original.IterationDetails?.ToList(),
+                AssociatedBugs = original.AssociatedBugs?.ToList(),
+                Url = original.Url,
+                FailureType = original.FailureType,
+                AutomatedTestName = original.AutomatedTestName,
+                AutomatedTestStorage = original.AutomatedTestStorage,
+                AutomatedTestType = original.AutomatedTestType,
+                AutomatedTestTypeId = original.AutomatedTestTypeId,
+                AutomatedTestId = original.AutomatedTestId,
+                Area = original.Area,
+                TestCaseTitle = original.TestCaseTitle,
+                StackTrace = original.StackTrace,
+                CustomFields = original.CustomFields?.ToList(),
+                BuildReference = original.BuildReference,
+                ReleaseReference = original.ReleaseReference,
+                TestPlan = original.TestPlan,
+                TestSuite = original.TestSuite,
+                TestCaseReferenceId = original.TestCaseReferenceId,
+                Owner = original.Owner,
+                RunBy = original.RunBy,
+                LastUpdatedBy = original.LastUpdatedBy,
+                ResultGroupType = original.ResultGroupType,
+                TestCaseRevision = original.TestCaseRevision,
+                TestCaseSubResultData = original.TestCaseSubResultData?.ToList(),
+                AttachmentData = original.AttachmentData
+            };
         }
 
         private static string GetEvidenceStoreMetadata(IExecutionContext executionContext, TestRunSummary testRunSummary, string testRunner, string name, string description)


### PR DESCRIPTION
Changes in PR are specifically for Test Result publish flow from ATP task.

We see that when same _AutomatedTest_ is associated with different manual test cases - _Tc1_ and _Tc2_, in the output test tab, we only see _Tc1_ as per below, (Mapping: Tc1 -> AutomatedTest1, Tc2 -> AutomatedTest1, Tc3 -> AutomatedTest2)

![image](https://github.com/user-attachments/assets/61cc0789-a6d8-41ba-870f-18a1ae3b56da)

We are adding changes to ensure that test is published if present in list of automated test points passed to publish command in agent and result xml file has result corresponding to that automatedTestName

After fix,

![image](https://github.com/user-attachments/assets/e3bb20bd-a2e2-4f84-9c4e-e222ca704a20)

We are now publishing test results based on list of input tests given by user rather than relying on result xml file that will have results as per one automated test executed only once even if specified multiple times by user for execution.
