### PR TITLE
FIX: [CodeQL: SM02196] Weak cryptography in TrackingConfigHashAlgorithm.cs

### DIFF
--- a/src/Agent.Worker/Build/TrackingConfigHashAlgorithm.cs
+++ b/src/Agent.Worker/Build/TrackingConfigHashAlgorithm.cs
@@ -55,9 +55,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         private static string CreateHash(string hashInput)
         {
-            using (SHA1 sha1Hash = SHA1.Create())
+            using (SHA256 sha256Hash = SHA256.Create())
             {
-                byte[] data = sha1Hash.ComputeHash(Encoding.UTF8.GetBytes(hashInput));
+                byte[] data = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(hashInput));
                 StringBuilder hexString = new StringBuilder();
                 for (int i = 0; i < data.Length; i++)
                 {

--- a/src/Test/L0/Worker/Build/TrackingConfigHashAlgorithmL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingConfigHashAlgorithmL0.cs
@@ -10,7 +10,7 @@ using Moq;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
-{
+{   
     public sealed class TrackingConfigHashAlgorithmL0
     {
         // This test is the original test case and is kept to make sure back compat still works.
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 string hashKey = TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repoInfo });
 
                 // Assert.
-                Assert.Equal("5c5c3d7ac33cca6604736eb3af977f23f1cf1146", hashKey);
+                Assert.Equal("55e3171bf43a983b419387b5d952d3ee7dcb195e262fc4c78d47a92763b6b001", hashKey);
             }
         }
 
@@ -96,19 +96,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 string definitionId = "123";
 
                 // Make sure that only the coll, def, and url are used in the hash
-                Assert.Equal("9a89eaa7b8b603633ef1dd5c46464355c716268f", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1 }));
-                Assert.Equal("9a89eaa7b8b603633ef1dd5c46464355c716268f", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo2 }));
+                Assert.Equal("a42b0f8ccd83cec8294b0c861a8d769e4f7fbc53ad3d3c96d2d1b66afdcdcca7", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1 }));
+                Assert.Equal("a42b0f8ccd83cec8294b0c861a8d769e4f7fbc53ad3d3c96d2d1b66afdcdcca7", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo2 }));
                 Assert.Equal(TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1 }), TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1 }));
 
                 // Make sure that different coll creates different hash
-                Assert.Equal("2a41800cd3e7f5983a7643698f67104ed95101f3", TrackingConfigHashAlgorithm.ComputeHash("FFFA5D79-7735-49E3-87DA-02E76CF8D03A", definitionId, new[] { repo1 }));
+                Assert.Equal("55437a6c3c12ea17847e33c3d96697833a05519e06acbe90fff74a64734fca1c", TrackingConfigHashAlgorithm.ComputeHash("FFFA5D79-7735-49E3-87DA-02E76CF8D03A", definitionId, new[] { repo1 }));
 
                 // Make sure that different def creates different hash
-                Assert.Equal("84b4463d95631b4d358f4b67d8994fe7d5b0c013", TrackingConfigHashAlgorithm.ComputeHash(collectionId, "321", new[] { repo1 }));
+                Assert.Equal("72443dbf31971f84922a6f3a6c58052fc0c60d9f1eb17b83a35e6e099098c179", TrackingConfigHashAlgorithm.ComputeHash(collectionId, "321", new[] { repo1 }));
 
                 // Make sure that different url creates different hash
                 repo1.RepositoryUrl = "https://jpricket@codedev.ms/jpricket/MyFirstProject/_git/new_url";
-                Assert.Equal("6505a9272091df39b90d6fd359e3bf39a7883e9e", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1 }));
+                Assert.Equal("2b29540cb9d2b68cc068af7afd0593276fc9e0b09af4e5d7b2065cc9021070fc", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1 }));
             }
         }
 
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 string definitionId = "123";
 
                 // Make sure we get the same hash every time
-                Assert.Equal("502520817d9c9d3002a7a56526f7518709fecd6a", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1, repo2 }));
+                Assert.Equal("0a7fcd16ea54872456169a3cbf5a7d8e8efda976b755a13278b193fedaeb5784", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1, repo2 }));
 
                 // Make sure that only the coll, def, identifier, and url are used in the hash
                 Assert.Equal(
@@ -168,16 +168,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                     TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1, repo2_newPath }));
 
                 // Make sure that different coll creates different hash
-                Assert.Equal("ea81feec2216d9da8adc7f29005d44eafbd12626", TrackingConfigHashAlgorithm.ComputeHash("FFFA5D79-7735-49E3-87DA-02E76CF8D03A", definitionId, new[] { repo1, repo2 }));
+                Assert.Equal("b3956a6be8dde823bce2373fdef7358e255107bc4de986a61aeaffd11e253118", TrackingConfigHashAlgorithm.ComputeHash("FFFA5D79-7735-49E3-87DA-02E76CF8D03A", definitionId, new[] { repo1, repo2 }));
 
                 // Make sure that different def creates different hash
-                Assert.Equal("8742e9847224e2b9de3884beac15759cfd8403e0", TrackingConfigHashAlgorithm.ComputeHash(collectionId, "321", new[] { repo1, repo2 }));
+                Assert.Equal("dff47196d014b4373641e33627901f986cde0815de0122fa76f401abd1140701", TrackingConfigHashAlgorithm.ComputeHash(collectionId, "321", new[] { repo1, repo2 }));
 
                 // Make sure that different url creates different hash
-                Assert.Equal("279dd578a58faba3f6cd23c3d62d452448b1e8cc", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1_newUrl, repo2 }));
+                Assert.Equal("ce83c8cd4f9b603345d21d2a294f7126e1e37c6d13cf6225516106a69528cc95", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1_newUrl, repo2 }));
 
                 // Make sure that different alias creates different hash
-                Assert.Equal("e3553307993d00df159a011b129a7f720084ee02", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1_newAlias, repo2 }));
+                Assert.Equal("2ca4bc7221eb412db850596fc02dc4e5b61c2125c997ea07f11215bffe605d33", TrackingConfigHashAlgorithm.ComputeHash(collectionId, definitionId, new[] { repo1_newAlias, repo2 }));
 
                 // Make sure order doesn't change hash
                 Assert.Equal(

--- a/src/Test/L0/Worker/Build/TrackingConfigL0.cs
+++ b/src/Test/L0/Worker/Build/TrackingConfigL0.cs
@@ -89,7 +89,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
 
                 // Act.
                 var config = new TrackingConfig(mockExecutionContext.Object, new[] { repository }, DefinitionId);
-
                 // Assert.
                 Assert.Equal(Path.Combine("322", "a"), config.ArtifactsDirectory);
                 Assert.Equal("322", config.BuildDirectory);
@@ -99,7 +98,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 Assert.Equal(DefinitionName, config.DefinitionName);
                 Assert.Equal(3, config.FileFormatVersion);
                 Assert.Equal(null, config.FileLocation);
-                Assert.Equal("ea7c71421cca06c927f73627b66d6b4f4c3a5f4a", config.HashKey);
+                Assert.Equal("9706446cf81dbb09854838b405618476576051bf54b5cbf6ce493c180c0a0a87", config.HashKey);
                 Assert.Equal(RepositoryTypes.Git, config.RepositoryType);
                 Assert.Equal(RepositoryUrl, config.RepositoryUrl);
                 Assert.Equal(Path.Combine("322", "s"), config.SourcesDirectory);
@@ -125,7 +124,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 // Act.
                 var config = new TrackingConfig(mockExecutionContext.Object, new[] { repository }, DefinitionId);
                 var clone = config.Clone();
-
                 // Assert.
                 // Verify the original first
                 Assert.Equal(Path.Combine("322", "a"), config.ArtifactsDirectory);
@@ -136,7 +134,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 Assert.Equal(DefinitionName, config.DefinitionName);
                 Assert.Equal(3, config.FileFormatVersion);
                 Assert.Equal(null, config.FileLocation);
-                Assert.Equal("ea7c71421cca06c927f73627b66d6b4f4c3a5f4a", config.HashKey);
+                Assert.Equal("9706446cf81dbb09854838b405618476576051bf54b5cbf6ce493c180c0a0a87", config.HashKey);
                 Assert.Equal(RepositoryTypes.Git, config.RepositoryType);
                 Assert.Equal(RepositoryUrl, config.RepositoryUrl);
                 Assert.Equal(Path.Combine("322", "s"), config.SourcesDirectory);
@@ -155,7 +153,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Build
                 Assert.Equal(DefinitionName, clone.DefinitionName);
                 Assert.Equal(3, clone.FileFormatVersion);
                 Assert.Equal(null, clone.FileLocation);
-                Assert.Equal("ea7c71421cca06c927f73627b66d6b4f4c3a5f4a", clone.HashKey);
+                Assert.Equal("9706446cf81dbb09854838b405618476576051bf54b5cbf6ce493c180c0a0a87", clone.HashKey);
                 Assert.Equal(RepositoryTypes.Git, clone.RepositoryType);
                 Assert.Equal(RepositoryUrl, clone.RepositoryUrl);
                 Assert.Equal(Path.Combine("322", "s"), clone.SourcesDirectory);


### PR DESCRIPTION
### **Context**

In TrackingConfigHashAlgorithm.cs, SHA1 was being used to compute the hashKey, which is used to identify the tracking config file in the agent system and hence the workspace identifier.

### **Change Description**

The PR addresses the CodeQL warning of using a weak hash algortihm by replacing it with SHA256 based on the recommendations - [SM02196]([https://liquid.microsoft.com/codeql/issues/6618ab1f-a69f-44a2-b1b3-f93c6f4a83a0])

Also it updates the existing Unit Tests with the updated hash values from the new algorithm.

### **Validations**

- Locally debugged the agent and checked that the new hashes are being generated from the SHA256 algorithm.
- Verified that the tracking config file has the new hash in **azure-pipelines-agent\_layout\win-x64\_work\SourceRootMapping\collectionID\definitionID**
- Run the unit and functional tests.