### PR TITLE
Adding service principal option in auth types in "config.cmd --help" command

### DIFF
--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -107,6 +107,7 @@
     "                                    negotiate  (Kerberos or NTLM)",
     "                                    alt        (Basic authentication)",
     "                                    integrated (Windows default credentials)",
+    "                                    sp         (Service Principal)",
     " --token <token>                   Used with --auth pat. Personal access token.",
     " --userName <userName>             Used with --auth negotiate or --auth alt. Specify the Windows user",
     "                                   name in the format: domain\\userName or userName@domain.com",


### PR DESCRIPTION
This pull request adds the `service principal` option to the authentication types in the `config.cmd --help` command which is available as one of the ways to register an agent (https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/service-principal-agent-registration?view=azure-devops)

Lik to Bug: [Bug 2191683](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2191683): Update Agent Config.cmd --help output

![image](https://github.com/user-attachments/assets/e1db0462-1742-4b53-8f7b-391f1e33c1a6)
