### PR TITLE
Revert "Disable Windows ARM64 from the release pipeline and notes" - AB#2143637

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -44,7 +44,7 @@ parameters:
   default: true
 - name: win_arm64
   type: boolean
-  default: false
+  default: true
 - name: linux_x64
   type: boolean
   default: true

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -17,7 +17,7 @@ parameters:
 - name: win_arm64
   type: boolean
   displayName: Windows (ARM64)
-  default: false
+  default: true
 - name: linux_x64
   type: boolean
   displayName: Linux (x64)

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -5,6 +5,7 @@
 | -------------- | ------- | ------- |
 | Windows x64    | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86    | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| Windows ARM64    | [vsts-agent-win-arm64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64      | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | macOS ARM64    | [vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64      | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
@@ -27,6 +28,13 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 ``` bash
 C:\> mkdir myagent && cd myagent
 C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\vsts-agent-win-x86-<AGENT_VERSION>.zip", "$PWD")
+```
+
+## Windows ARM64
+
+``` bash
+C:\> mkdir myagent && cd myagent
+C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\vsts-agent-win-arm64-<AGENT_VERSION>.zip", "$PWD")
 ```
 
 ## macOS x64
@@ -91,6 +99,7 @@ See [notes](docs/node6.md) on Node version support for more details.
 | ----------- | ------- | ------- |
 | Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| Windows ARM64 | [pipelines-agent-win-arm64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64   | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |


### PR DESCRIPTION
# Description

Reverts the PR [microsoft/azure-pipelines-agent#5080](https://github.com/microsoft/azure-pipelines-agent/pull/5080).
