### PR TITLE
[Agent][Edgio] Remove Azure CDN Cache Commands to Unblock Pipeline Failures Due to Edgio Retirement - AB#2242851

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -283,10 +283,6 @@ extends:
                     $uploadFiles.Add("/$container/$versionDir/$execName")
                   }
                 }
-                Write-Host "Purge Azure CDN Cache"
-                Clear-AzCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -ContentPath $uploadFiles
-                Write-Host "Force Refresh Azure CDN Cache"
-                Import-AzCdnEndpointContent -EndpointName vstsagentpackage -ProfileName vstsagentpackage -ResourceGroupName vstsagentpackage -ContentPath $uploadFiles
 
           # Clean up blob container with test agent version
           - task: AzurePowerShell@5


### PR DESCRIPTION
## Description

This PR removes the steps responsible for purging and force-refreshing the Azure CDN cache from the deployment script.

## Context

The Agent Build pipeline is currently failing because the Edgio CDN is no longer functional. To temporarily unblock the release, we are removing the Azure CDN cmdlets that interact with Edgio and we plan to use the Akamai UI to purge and create the CDN records as an interim solution.