### PR TITLE
Upgrade runner image in pipeline from macos-12 to macos-14

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -319,7 +319,7 @@ extends:
             displayName: macOS (x64)
             pool:
               name: Azure Pipelines
-              image: macOS-12
+              image: macos-14
               os: macOS
             os: osx
             arch: x64
@@ -340,7 +340,7 @@ extends:
             displayName: macOS (ARM64)
             pool:
               name: Azure Pipelines
-              image: macOS-12
+              image: macos-14-arm64
               os: macOS
             os: osx
             arch: arm64

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -340,7 +340,7 @@ extends:
             displayName: macOS (ARM64)
             pool:
               name: Azure Pipelines
-              image: macos-14-arm64
+              image: macos-14
               os: macOS
             os: osx
             arch: arm64


### PR DESCRIPTION
As per [https://github.com/actions/runner-images/issues/10721](https://github.com/actions/runner-images/issues/10721), the `macOS 12` runner image is now unsupported. Upgrading the runner image in pipeline.yml to `macos-14` and `macos-14-arm64` will ensure that the pipeline continues to run on supported images.