### PR TITLE
Fix L1 test failures by upgrading nuget version

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -182,7 +182,7 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
     acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
-    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
+    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v4.6.4/nuget.exe" nuget
 
     if [[ "$INCLUDE_NODE6" == "true" ]]; then
         acquireExternalTool "${NODE_URL}/v${NODE_VERSION}/${PACKAGERUNTIME}/node.exe" node/bin
@@ -214,7 +214,7 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
     acquireExternalTool "$CONTAINER_URL/symstore/win-arm${BIT}/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
-    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v3.4.4/nuget.exe" nuget
+    acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v4.6.4/nuget.exe" nuget
 
     if [[ "$INCLUDE_NODE6" == "true" ]]; then
         acquireExternalTool "${NODE_URL}/v${NODE_VERSION}/${PACKAGERUNTIME}/node.exe" node/bin # Not available for Windows ARM

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -60,6 +60,7 @@ if [[ ($DOTNET_SDK_VERSION == "") || ($DOTNET_RUNTIME_VERSION == "") ]]; then
 fi
 
 DOTNET_DIR="${REPO_ROOT}/_dotnetsdk"
+NUGET_DIR="${REPO_ROOT}/_l1/externals/nuget"
 
 BUILD_CONFIG="Debug"
 if [[ "$DEV_CONFIG" == "Release" ]]; then
@@ -441,6 +442,7 @@ restore_sdk_and_runtime
 heading ".NET SDK to path"
 echo "Adding .NET SDK to PATH (${DOTNET_DIR})"
 export PATH=${DOTNET_DIR}:$PATH
+export PATH=${NUGET_DIR}:$PATH
 echo "Path = $PATH"
 echo ".NET Version = $(dotnet --version)"
 


### PR DESCRIPTION
PR fixes [AB#2241585](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2241585)

`Failed Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker.SigningL1Tests.SignatureVerification_MultipleFingerprints
Failed Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker.SigningL1Tests.SignatureVerification_Warning(writeToBlobstorageService: True)
Failed Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker.SigningL1Tests.SignatureVerification_Warning(writeToBlobstorageService: False)
Failed Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker.SigningL1Tests.SignatureVerification_PassesWhenAllTasksAreSigned(useFingerprintList: False, useTopLevelFingerprint: True)
Failed Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker.SigningL1Tests.SignatureVerification_PassesWhenAllTasksAreSigned(useFingerprintList: False, useTopLevelFingerprint: False)
Failed Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker.SigningL1Tests.SignatureVerification_PassesWhenAllTasksAreSigned(useFingerprintList: True, useTopLevelFingerprint: False)`


The above L1 tests are failing due to a dependency on the 'nuget verify' command, which requires NuGet version 4.6 or higher: https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-verify
This fix updates the NuGet version and ensures it is added to the path.

Steps to test changes:
- git clone https://github.com/microsoft/azure-pipelines-agent
- cd ./src
- ./dev.(sh/cmd) l1 (In Windows PowerShell)