### PR TITLE
Changes to skip Not Executed state test in result.publish() command

### DIFF
--- a/src/Agent.Worker/TestResults/TestDataPublisher.cs
+++ b/src/Agent.Worker/TestResults/TestDataPublisher.cs
@@ -161,19 +161,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.TestResults
 
                                 if (testResultByFQN.TryGetValue(testResultFQN, out List<TestCaseResult> inputs))
                                 {
-                                    foreach (var input in inputs)
+                                    if (testRunData[testRunDataIterator].TestResults[testResultDataIterator].Outcome != "NotExecuted")
                                     {
-                                        var testCaseResultDataUpdated = TestResultUtils.CloneTestCaseResultData(testRunData[testRunDataIterator].TestResults[testResultDataIterator]);
+                                        foreach (var input in inputs)
+                                        {
+                                            var testCaseResultDataUpdated = TestResultUtils.CloneTestCaseResultData(testRunData[testRunDataIterator].TestResults[testResultDataIterator]);
 
-                                        testCaseResultDataUpdated.TestPoint = input.TestPoint;
-                                        testCaseResultDataUpdated.TestCaseTitle = input.TestCaseTitle;
-                                        testCaseResultDataUpdated.Configuration = input.Configuration;
-                                        testCaseResultDataUpdated.TestCase = input.TestCase;
-                                        testCaseResultDataUpdated.Owner = input.Owner;
-                                        testCaseResultDataUpdated.State = "5";
-                                        testCaseResultDataUpdated.TestCaseRevision = input.TestCaseRevision;
+                                            testCaseResultDataUpdated.TestPoint = input.TestPoint;
+                                            testCaseResultDataUpdated.TestCaseTitle = input.TestCaseTitle;
+                                            testCaseResultDataUpdated.Configuration = input.Configuration;
+                                            testCaseResultDataUpdated.TestCase = input.TestCase;
+                                            testCaseResultDataUpdated.Owner = input.Owner;
+                                            testCaseResultDataUpdated.State = "5";
+                                            testCaseResultDataUpdated.TestCaseRevision = input.TestCaseRevision;
 
-                                        testResultsUpdated.Add(testCaseResultDataUpdated);
+                                            testResultsUpdated.Add(testCaseResultDataUpdated);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Making a small change in the PublishAsync command, where we ignore the test results parsed with NotExecuted state. 

This change is done to prevent duplicates test results generated by the jest framework during the execution of each test result. 

Changes are tested and validation images are: 
![image](https://github.com/user-attachments/assets/ea5cb655-e7a1-4366-a050-85c85adf0b4c)

