### PR TITLE
Disabling Scheduled Run as we do manual release builds.

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -19,13 +19,6 @@ pr:
     - .azure-pipelines
     - .vsts.release.yml
 
-schedules:
-- cron: '0 6 * * 2'
-  displayName: Scheduled weekly run
-  branches:
-    include:
-    - master
-
 parameters:
 - name: version
   type: string

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -27,7 +27,7 @@ parameters:
 - name: targetFramework
   displayName: Target framework
   type: string
-  default: net6.0
+  default: net8.0
   values:
   - net6.0
   - net8.0


### PR DESCRIPTION
Disabling the schedule for the agent release pipeline as we are doing manual releases for .net8 and .net 6 going forward.

Also making .net8 as default for build