### PR TITLE
Optionally use max parallelism value from the client settings API

### DIFF
--- a/src/Agent.Plugins/Artifact/FileContainerProvider.cs
+++ b/src/Agent.Plugins/Artifact/FileContainerProvider.cs
@@ -170,7 +170,7 @@ namespace Agent.Plugins
                         (dedupClient, clientTelemetry) = DedupManifestArtifactClientFactory.Instance.CreateDedupClient(
                             this.connection,
                             domainId,
-                            DedupManifestArtifactClientFactory.Instance.GetDedupStoreClientMaxParallelism(context),
+                            DedupManifestArtifactClientFactory.Instance.GetDedupStoreClientMaxParallelism(context, clientSettings),
                             clientSettings.GetRedirectTimeout(),
                             false,
                             (str) => this.tracer.Info(str),

--- a/src/Agent.Plugins/Artifact/PipelineArtifactServer.cs
+++ b/src/Agent.Plugins/Artifact/PipelineArtifactServer.cs
@@ -60,7 +60,6 @@ namespace Agent.Plugins
                     context.IsSystemDebugTrue(),
                     (str) => context.Output(str),
                     connection,
-                    DedupManifestArtifactClientFactory.Instance.GetDedupStoreClientMaxParallelism(context),
                     domainId,
                     clientSettings,
                     context,

--- a/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobstoreClientSettings.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Blob/BlobstoreClientSettings.cs
@@ -2,18 +2,18 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Agent.Sdk;
+using Agent.Sdk.Knob;
+using BuildXL.Cache.ContentStore.Hashing;
+using Microsoft.VisualStudio.Services.BlobStore.Common;
 using Microsoft.VisualStudio.Services.BlobStore.WebApi;
+using Microsoft.VisualStudio.Services.BlobStore.WebApi.Contracts;
+using Microsoft.VisualStudio.Services.Content.Common;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
 using Microsoft.VisualStudio.Services.WebApi;
-using Microsoft.VisualStudio.Services.Content.Common;
-using Agent.Sdk;
-using Microsoft.VisualStudio.Services.BlobStore.Common;
-using BuildXL.Cache.ContentStore.Hashing;
-using Microsoft.VisualStudio.Services.BlobStore.WebApi.Contracts;
-using Agent.Sdk.Knob;
-using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.Services.Agent.Blob
 {
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
     {
         private readonly ClientSettingsInfo clientSettings;
         private readonly IAppTraceSource tracer;
-        
+
         private BlobstoreClientSettings(ClientSettingsInfo settings, IAppTraceSource tracer)
         {
             clientSettings = settings;
@@ -37,8 +37,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             BlobStore.WebApi.Contracts.Client? client,
             IAppTraceSource tracer,
             CancellationToken cancellationToken)
-        {            
-            if(client.HasValue)
+        {
+            if (client.HasValue)
             {
                 try
                 {
@@ -75,8 +75,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
                 {
                     tracer.Info($"Error converting the domain id '{clientSettings.Properties[ClientSettingsConstants.DefaultDomainId]}': {exception.Message}.  Falling back to default.");
                 }
-            } 
-            else 
+            }
+            else
             {
                 tracer.Verbose($"No client settings found, using the default domain id '{domainId}'.");
             }
@@ -111,6 +111,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Blob
             if (int.TryParse(clientSettings?.Properties.GetValueOrDefault(ClientSettingsConstants.RedirectTimeout), out int redirectTimeoutSeconds))
             {
                 return redirectTimeoutSeconds;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public int? GetMaxParallelism()
+        {
+            const string MaxParallelism = "MaxParallelism";
+            if (int.TryParse(clientSettings?.Properties.GetValueOrDefault(MaxParallelism), out int maxParallelism))
+            {
+                return maxParallelism;
             }
             else
             {

--- a/src/Test/L0/Plugin/TestFileShareProvider/MockDedupManifestArtifactClientFactory.cs
+++ b/src/Test/L0/Plugin/TestFileShareProvider/MockDedupManifestArtifactClientFactory.cs
@@ -6,13 +6,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Agent.Sdk;
 using Microsoft.VisualStudio.Services.Agent.Blob;
+using Microsoft.VisualStudio.Services.BlobStore.Common;
+using Microsoft.VisualStudio.Services.BlobStore.Common.Telemetry;
 using Microsoft.VisualStudio.Services.BlobStore.WebApi;
-using Microsoft.VisualStudio.Services.BlobStore.WebApi.Contracts;
 using Microsoft.VisualStudio.Services.Content.Common.Tracing;
 using Microsoft.VisualStudio.Services.WebApi;
-using Microsoft.VisualStudio.Services.BlobStore.Common.Telemetry;
-using Agent.Plugins.PipelineArtifact;
-using Microsoft.VisualStudio.Services.BlobStore.Common;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests
 {
@@ -40,7 +38,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             bool verbose,
             Action<string> traceOutput,
             VssConnection connection,
-            int maxParallelism,
             IDomainId domainId,
             BlobstoreClientSettings clientSettings,
             AgentTaskPluginExecutionContext context,


### PR DESCRIPTION
**Issue:** Currently the default parallelism is set to 192, which is very high for busy machines.  This causes timeouts and out of memory errors.  There is an existing per-pipeline variable that can override this, but we cannot override the default globally without changing the agent.
[Bug 2247830](https://dev.azure.com/mseng/1ES/_workitems/edit/2247830): DownloadPipelineArtifact throws OOMException

**Description:** This uses our existing client settings API to set the default if it is not overridden on a pipeline level.  if the client setting is not available, it remains at the 192 default.

**Risk Assesment(Low)**: We already use client settings for multiple other variables and it is only used if it is set and available and the value is not already overridden.

**Added unit tests:** (N)

**Additional Tests Performed:** Manually tested all permutations of pipeline variable override set/not set and client setting set/not set.