### PR TITLE
Skip removing read only attribute for Symlinks AB#2248480

### DIFF
--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -146,14 +146,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                             bool success = false;
                             try
                             {
-                                // Remove the readonly attribute.
-                                try
-                                {
+                                // Skip for Symlinks
+                                if (!item.Attributes.HasFlag(FileAttributes.ReparsePoint)) {
+                                    // Remove the readonly attribute.
                                     RemoveReadOnly(item);
-                                }
-                                catch (FileNotFoundException)
-                                {
-                                    item.Delete();
                                 }
 
                                 // Check if the item is a file.

--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -147,7 +147,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                             try
                             {
                                 // Remove the readonly attribute.
-                                RemoveReadOnly(item);
+                                try
+                                {
+                                    RemoveReadOnly(item);
+                                }
+                                catch (FileNotFoundException)
+                                {
+                                    // Allow to continue;
+                                }
 
                                 // Check if the item is a file.
                                 if (item is FileInfo)
@@ -186,6 +193,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                                 }
 
                                 success = true;
+                            }
+                            catch (FileNotFoundException)
+                            {
+                                // Allow to continue;
                             }
                             catch (Exception) when (continueOnContentDeleteError)
                             {

--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                                 }
                                 catch (FileNotFoundException)
                                 {
-                                    // Allow to continue;
+                                    item.Delete();
                                 }
 
                                 // Check if the item is a file.
@@ -193,10 +193,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                                 }
 
                                 success = true;
-                            }
-                            catch (FileNotFoundException)
-                            {
-                                // Allow to continue;
                             }
                             catch (Exception) when (continueOnContentDeleteError)
                             {

--- a/src/Test/L0/Util/IOUtilL0.cs
+++ b/src/Test/L0/Util/IOUtilL0.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public async void DeleteDirectory_DeleteTargetFileBeforeSymlink()
+        public async void DeleteDirectory_DeleteTargetFileWithASymlink()
         {
             using (TestHostContext hc = new TestHostContext(this))
             {
@@ -104,8 +104,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
                     await CreateFileReparsePoint(context: hc, link: symlink, target: targetFile);
 
                     // Act.
-                    IOUtil.Delete(targetFile, CancellationToken.None);
-                    IOUtil.Delete(symlink, CancellationToken.None);
+                    IOUtil.DeleteDirectory(directory, CancellationToken.None);
 
                     // Assert.
                     Assert.False(File.Exists(targetFile));

--- a/src/Test/L0/Util/IOUtilL0.cs
+++ b/src/Test/L0/Util/IOUtilL0.cs
@@ -104,6 +104,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
                     await CreateFileReparsePoint(context: hc, link: symlink, target: targetFile);
 
                     // Act.
+                    IOUtil.DeleteFile(targetFile);
                     IOUtil.DeleteDirectory(directory, CancellationToken.None);
 
                     // Assert.

--- a/src/Test/L0/Util/IOUtilL0.cs
+++ b/src/Test/L0/Util/IOUtilL0.cs
@@ -85,6 +85,47 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
+        public async void DeleteDirectory_DeleteTargetFileBeforeSymlink()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                Tracing trace = hc.GetTrace();
+
+                // Arrange: Create a directory with a file.
+                string directory = Path.Combine(hc.GetDirectory(WellKnownDirectory.Bin), Path.GetRandomFileName());
+                string targetFile = Path.Combine(directory, "somefile");
+                string symlink = Path.Combine(directory, "symlink");
+                try
+                {
+                    Directory.CreateDirectory(directory);
+                    File.WriteAllText(path: targetFile, contents: "some contents");
+                    File.SetAttributes(targetFile, File.GetAttributes(targetFile) | FileAttributes.ReadOnly);
+
+                    await CreateFileReparsePoint(context: hc, link: symlink, target: targetFile);
+
+                    // Act.
+                    IOUtil.Delete(targetFile, CancellationToken.None);
+                    IOUtil.Delete(symlink, CancellationToken.None);
+
+                    // Assert.
+                    Assert.False(File.Exists(targetFile));
+                    Assert.False(File.Exists(symlink));
+
+                }
+                finally
+                {
+                    // Cleanup.
+                    if (Directory.Exists(directory))
+                    {
+                        Directory.Delete(directory, recursive: true);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
         public void DeleteDirectory_DeletesDirectoriesRecursively()
         {
             using (TestHostContext hc = new TestHostContext(this))
@@ -1267,6 +1308,29 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
                     var expected = testcases[i, 1];
                     Assert.Equal(expected, path);
                 }
+            }
+        }
+
+        private static async Task CreateFileReparsePoint(IHostContext context, string link, string target)
+        {
+            string fileName = (TestUtil.IsWindows())
+                ? Environment.GetEnvironmentVariable("ComSpec")
+                : "/bin/ln";
+            string arguments = (TestUtil.IsWindows())
+                ? $@"/c ""mklink ""{link}"" ""{target}"""""
+                : $@"-s ""{target}"" ""{link}""";
+
+            ArgUtil.File(fileName, nameof(fileName));
+            using (var processInvoker = new ProcessInvokerWrapper())
+            {
+                processInvoker.Initialize(context);
+                await processInvoker.ExecuteAsync(
+                    workingDirectory: context.GetDirectory(WellKnownDirectory.Bin),
+                    fileName: fileName,
+                    arguments: arguments,
+                    environment: null,
+                    requireExitCodeZero: true,
+                    cancellationToken: CancellationToken.None);
             }
         }
     }


### PR DESCRIPTION
**Issue:** https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2248480
ICM : https://portal.microsofticm.com/imp/v5/incidents/details/572407426/summary
Github Issue : https://github.com/microsoft/azure-pipelines-agent/issues/5104

**Description:** The initialize job is failing while cleanup due to FileNotFoundException. This is happening intermittently for Symlink files in 4.x.x agent versions but not in 3.x.x agent versions. Root cause of this issue is the race condition between the deletion of target file and symlink file. If the target file is deleted, and then we are trying to set FileAttributes on Symlink, it would throw FileNotFoundException.

**Risk Assesment(Low/Medium/High)**: LOW

**Added unit tests:** (Y/N) N

**Additional Tests Performed:** Did manual testing using a c# script by creating a fileInfo object for the target file and its symlink. Verified both on Linux and Windows, the removereadonly function is being skipped for Symlink File object

![image](https://github.com/user-attachments/assets/e45fadf6-49ab-4cf4-85fb-9c08178fff64)

![image](https://github.com/user-attachments/assets/12819772-ff0f-4c52-9630-8a50a208dcca)
