### PR TITLE
Update QueryJobHistoryForRetiredImages.ps1

### DIFF
--- a/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
+++ b/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
@@ -17,7 +17,7 @@ $vstsAuthHeader = @{"Authorization"="Basic $base64authinfo"}
 $allHeaders = $vstsAuthHeader + @{"Content-Type"="application/json"; "Accept"="application/json"}
 
 # List of deprecated images
-[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu18', 'ubuntu-18.04', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
+[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu18', 'ubuntu-18.04', 'ubuntu-20.04', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
 
 try
 {


### PR DESCRIPTION

**Issue:** Adding Ubuntu 20.02 to deprecated images link. 

**Description:** Ubuntu 20.02 image will be removed soon, so updating the script to identify jobs that are using ubuntu 20.02

**Risk Assesment(Low/Medium/High)**: Low, this is just a script change and adding additinal param. 

**Added unit tests:** (Y/N) NA

**Additional Tests Performed:** NA