### PR TITLE
Deactivate Base64 Encoded Vso Commands AB#2008236

### DIFF
--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -304,9 +304,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             try
             {
                 byte[] decodedBytes = Convert.FromBase64String(input);
-                string encodedString = Convert.ToBase64String(decodedBytes);
+                string decodedString = Encoding.UTF8.GetString(decodedBytes);
 
-                encodedString = DeactivateVsoCommands(encodedString);
+                decodedString = DeactivateVsoCommands(decodedString);
 
                 byte[] bytes = Encoding.UTF8.GetBytes(input);
                 return Convert.ToBase64String(bytes);

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -315,23 +315,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             {
                 throw new ArgumentNullException(nameof(input), "Input string cannot be null.");
             }
-
             if (input.Length == 0)
             {
                 return string.Empty;
             }
-
-            byte[] buffer = new byte[input.Length];
-            if (Convert.TryFromBase64String(input, buffer, out int bytesWritten))
-            {
-                string decodedString = Encoding.UTF8.GetString(buffer, 0, bytesWritten);
-                decodedString = ScrapVsoCommands(decodedString);
-                return Convert.ToBase64String(Encoding.UTF8.GetBytes(decodedString));
-            }
-            else
-            {
-                throw new FormatException("Input string is not a valid base64 encoded string.");
-            }
+            byte[] decodedBytes = Convert.FromBase64String(input);
+            string decodedString = Encoding.UTF8.GetString(decodedBytes);
+            decodedString = ScrapVsoCommands(decodedString);
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(decodedString));
         }
 
         private static string ScrapVsoCommands(string input)

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -296,11 +296,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
         public static string DeactivateBase64EncodedVsoCommands(string input)
         {
-            if (!IsBase64Encoded(input))
-            {
-                return input;
-            }
-
             try
             {
                 byte[] decodedBytes = Convert.FromBase64String(input);
@@ -314,20 +309,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             catch
             {
                 return input;
-            }
-        }
-
-        public static bool IsBase64Encoded(string input)
-        {
-            try
-            {
-                byte[] decodedBytes = Convert.FromBase64String(input);
-                Encoding.UTF8.GetString(decodedBytes);
-                return true;
-            }
-            catch
-            {
-                return false;
             }
         }
     }

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -293,5 +293,48 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
             return Regex.Replace(input, "##vso", "**vso", RegexOptions.IgnoreCase);
         }
+
+        public static string DeactivateBase64EncodedVsoCommands(string input)
+        {
+            if (!IsBase64Encoded(input))
+            {
+                return input;
+            }
+
+            try
+            {
+                byte[] decodedBytes = Convert.FromBase64String(input);
+                string encodedString = Convert.ToBase64String(decodedBytes);
+
+                encodedString = DeactivateVsoCommands(encodedString);
+
+                byte[] bytes = Encoding.UTF8.GetBytes(input);
+                return Convert.ToBase64String(bytes);
+            }
+            catch
+            {
+                return input;
+            }
+        }
+
+        public static bool IsBase64Encoded(string input)
+        {
+            if (string.IsNullOrEmpty(input) || input.Length % 4 != 0)
+                return false;
+
+            if (!Regex.IsMatch(input, "^[A-Za-z0-9+/]*={0,2}$"))
+                return false;
+
+            try
+            {
+                byte[] decodedBytes = Convert.FromBase64String(input);
+                string encodedString = Convert.ToBase64String(decodedBytes);
+                return input.TrimEnd('=') == encodedString.TrimEnd('=');
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -310,15 +310,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                 return string.Empty;
             }
 
-            try
+            byte[] buffer = new byte[input.Length];
+            if (Convert.TryFromBase64String(input, buffer, out int bytesWritten))
             {
-                string decodedString = Encoding.UTF8.GetString(Convert.FromBase64String(input));
+                string decodedString = Encoding.UTF8.GetString(buffer, 0, bytesWritten);
                 decodedString = ScrapVsoCommands(decodedString);
                 return Convert.ToBase64String(Encoding.UTF8.GetBytes(decodedString));
             }
-            catch(Exception ex)
+            else
             {
-                Console.WriteLine(nameof(DeactivateBase64EncodedVsoCommands) + " exception occurred :" + ex.Message);
                 return input;
             }
         }

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -316,8 +316,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                 decodedString = ScrapVsoCommands(decodedString);
                 return Convert.ToBase64String(Encoding.UTF8.GetBytes(decodedString));
             }
-            catch
+            catch(Exception ex)
             {
+                Console.WriteLine(nameof(DeactivateBase64EncodedVsoCommands) + " exception occurred :" + ex.Message);
                 return input;
             }
         }

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -304,8 +304,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         /// <returns>String without vso commands that can be executed</returns>
         public static string DeactivateBase64EncodedVsoCommands(string input)
         {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input), "Input string cannot be null.");
+            }
 
-            if (string.IsNullOrEmpty(input))
+            if (input.Length == 0)
             {
                 return string.Empty;
             }

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -292,14 +292,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                 return string.Empty;
             }
 
-            input = DeactivateVsoCommandsIfBase64Encoded(input);
+            try
+            {
+                input = DeactivateVsoCommandsIfBase64Encoded(input);
+            }
+            catch (FormatException)
+            {
+                // Ignore exception and continue to deactivate vso commands in the input string.
+            }
             return ScrapVsoCommands(input);
         }
 
         /// <summary>
         /// Tries to decode the input string assuming it to be base64 encoded and
         /// scraps vso command if any and re-encodes the updated string.
-        /// An exception is thrown for the case when the input is not base64 encoded and input is returned unmodified.
+        /// An exception is thrown for the case when the input is not base64 encoded.
         /// </summary>
         /// <returns>String without vso commands that can be executed</returns>
         public static string DeactivateVsoCommandsIfBase64Encoded(string input)
@@ -323,7 +330,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }
             else
             {
-                return input;
+                throw new FormatException("Input string is not a valid base64 encoded string.");
             }
         }
 

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
                 return string.Empty;
             }
 
-            input = DeactivateBase64EncodedVsoCommands(input);
+            input = DeactivateVsoCommandsIfBase64Encoded(input);
             return ScrapVsoCommands(input);
         }
 
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         /// An exception is thrown for the case when the input is not base64 encoded and input is returned unmodified.
         /// </summary>
         /// <returns>String without vso commands that can be executed</returns>
-        public static string DeactivateBase64EncodedVsoCommands(string input)
+        public static string DeactivateVsoCommandsIfBase64Encoded(string input)
         {
             if (input == null)
             {

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -296,6 +296,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
         public static string DeactivateBase64EncodedVsoCommands(string input)
         {
+            if (string.IsNullOrEmpty(input))
+            {
+                return string.Empty;
+            }
+
             try
             {
                 byte[] decodedBytes = Convert.FromBase64String(input);

--- a/src/Agent.Sdk/Util/StringUtil.cs
+++ b/src/Agent.Sdk/Util/StringUtil.cs
@@ -308,7 +308,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
                 decodedString = DeactivateVsoCommands(decodedString);
 
-                byte[] bytes = Encoding.UTF8.GetBytes(input);
+                byte[] bytes = Encoding.UTF8.GetBytes(decodedString);
                 return Convert.ToBase64String(bytes);
             }
             catch
@@ -319,17 +319,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
 
         public static bool IsBase64Encoded(string input)
         {
-            if (string.IsNullOrEmpty(input) || input.Length % 4 != 0)
-                return false;
-
-            if (!Regex.IsMatch(input, "^[A-Za-z0-9+/]*={0,2}$"))
-                return false;
-
             try
             {
                 byte[] decodedBytes = Convert.FromBase64String(input);
-                string encodedString = Convert.ToBase64String(decodedBytes);
-                return input.TrimEnd('=') == encodedString.TrimEnd('=');
+                Encoding.UTF8.GetString(decodedBytes);
+                return true;
             }
             catch
             {

--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -112,6 +112,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 if (deactivatedVariables.TryGetValue(variableName, out var variable))
                 {
                     var deactivatedVariable = variable ?? new VariableValue();
+
                     deactivatedVariables[variableName] = StringUtil.DeactivateVsoCommands(deactivatedVariable.Value);
                 }
             }

--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 if (deactivatedVariables.TryGetValue(variableName, out var variable))
                 {
                     var deactivatedVariable = variable ?? new VariableValue();
-
+                    deactivatedVariable.Value = StringUtil.DeactivateBase64EncodedVsoCommands(deactivatedVariable.Value);
                     deactivatedVariables[variableName] = StringUtil.DeactivateVsoCommands(deactivatedVariable.Value);
                 }
             }

--- a/src/Agent.Worker/WorkerUtilties.cs
+++ b/src/Agent.Worker/WorkerUtilties.cs
@@ -112,7 +112,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 if (deactivatedVariables.TryGetValue(variableName, out var variable))
                 {
                     var deactivatedVariable = variable ?? new VariableValue();
-                    deactivatedVariable.Value = StringUtil.DeactivateBase64EncodedVsoCommands(deactivatedVariable.Value);
                     deactivatedVariables[variableName] = StringUtil.DeactivateVsoCommands(deactivatedVariable.Value);
                 }
             }

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -39,12 +39,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_EncodedVsoCommands_Returns_DeactivatedVsoCommands()
+        public void DeactivateVsoCommandsIfBase64Encoded_EncodedVsoCommands_Returns_DeactivatedVsoCommands()
         {
             string vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
             string encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
 
-            string result = StringUtil.DeactivateBase64EncodedVsoCommands(encodedVsoCommand);
+            string result = StringUtil.DeactivateVsoCommandsIfBase64Encoded(encodedVsoCommand);
 
             string deactivatedVsoCommand = "**vso[task.setvariable variable=downloadUrl]https://www.evil.com";
             var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(deactivatedVsoCommand));
@@ -59,30 +59,30 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_NotEncodedVsoCommands_Returns_UnmodifiedVsoCommands()
+        public void DeactivateVsoCommandsIfBase64Encoded_NotEncodedVsoCommands_Returns_UnmodifiedVsoCommands()
         {
             string vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+            string result = StringUtil.DeactivateVsoCommandsIfBase64Encoded(vsoCommand);
             Assert.Equal(vsoCommand, result);
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_InputEmpty_Returns_UnmodifiedString()
+        public void DeactivateVsoCommandsIfBase64Encoded_InputEmpty_Returns_UnmodifiedString()
         {
             string vsoCommand = "";
-            string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+            string result = StringUtil.DeactivateVsoCommandsIfBase64Encoded(vsoCommand);
             Assert.Equal(vsoCommand, result);
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_InputNull_Throws_Exception()
+        public void DeactivateVsoCommandsIfBase64Encoded_InputNull_Throws_Exception()
         {
             string vsoCommand = null;
-            Assert.Throws<ArgumentNullException>(() => StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand));
+            Assert.Throws<ArgumentNullException>(() => StringUtil.DeactivateVsoCommandsIfBase64Encoded(vsoCommand));
         }
 
         [Fact]

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -59,11 +59,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateVsoCommandsIfBase64Encoded_NotEncodedVsoCommands_Returns_UnmodifiedVsoCommands()
+        public void DeactivateVsoCommandsIfBase64Encoded_NotEncodedVsoCommands_Throws_FormatException()
         {
             string vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            string result = StringUtil.DeactivateVsoCommandsIfBase64Encoded(vsoCommand);
-            Assert.Equal(vsoCommand, result);
+            Assert.Throws<FormatException>(() => StringUtil.DeactivateVsoCommandsIfBase64Encoded(vsoCommand));
         }
 
         [Fact]

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -79,11 +79,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_InputNull_Returns_UnmodifiedString()
+        public void DeactivateBase64EncodedVsoCommands_InputNull_Throws_Exception()
         {
             string vsoCommand = null;
-            string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
-            Assert.Equal(string.Empty, result);
+            Assert.Throws<ArgumentNullException>(() => StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand));
         }
 
         [Fact]

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -32,46 +32,57 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
             Assert.Equal(expected, result);
         }
 
+        /// <summary>
+        /// In this test, a vso command is encoded as a bse64 string and being passed as input to the DeactivateBase64EncodedVsoCommands
+        /// The returned string when decoded will have ## replaced with **, deactivating the vso command.
+        /// </summary>
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void DeactivateBase64EncodedVsoCommands_EncodedVsoCommands_Returns_DeactivatedVsoCommands()
+        {
+            string vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            string encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
+
+            string result = StringUtil.DeactivateBase64EncodedVsoCommands(encodedVsoCommand);
+
+            string deactivatedVsoCommand = "**vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            var expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(deactivatedVsoCommand));
+
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// In this test, a vso command is being passed as input to the DeactivateBase64EncodedVsoCommands
+        /// The unmodified string would be returned.
+        /// </summary>
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_InputValidEncoded()
+        public void DeactivateBase64EncodedVsoCommands_NotEncodedVsoCommands_Returns_UnmodifiedVsoCommands()
         {
-            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            String encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
-
-            var result = StringUtil.DeactivateBase64EncodedVsoCommands(encodedVsoCommand);
-
-            String cleanedVsoCommand = "**vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            var expectedCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(cleanedVsoCommand));
-
-            Assert.Equal(expectedCommand, result);
+            string vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+            Assert.Equal(vsoCommand, result);
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_InputNotEncoded()
+        public void DeactivateBase64EncodedVsoCommands_InputEmpty_Returns_UnmodifiedString()
         {
-            using (TestHostContext hc = new TestHostContext(this))
-            {
-                String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-
-                var result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
-
-                Assert.Equal(vsoCommand, result);
-            }
+            string vsoCommand = "";
+            string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+            Assert.Equal(vsoCommand, result);
         }
 
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
-        public void DeactivateBase64EncodedVsoCommands_InputEmpty()
+        public void DeactivateBase64EncodedVsoCommands_InputNull_Returns_UnmodifiedString()
         {
-            String vsoCommand = "";
-
-            var result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
-
+            string vsoCommand = null;
+            string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
             Assert.Equal(vsoCommand, result);
         }
 

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [InlineData("##VsO", "**vso")]
         [InlineData("", "")]
         [InlineData(null, "")]
-        [InlineData(" ", " ")]
+        [InlineData(" ", "")]
         public void DeactivateVsoCommandsFromStringTest(string input, string expected)
         {
             var result = StringUtil.DeactivateVsoCommands(input);
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         /// In this test, a vso command is encoded as a bse64 string and being passed as input to the DeactivateBase64EncodedVsoCommands
         /// The returned string when decoded will have ## replaced with **, deactivating the vso command.
         /// </summary>
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         public void DeactivateBase64EncodedVsoCommands_EncodedVsoCommands_Returns_DeactivatedVsoCommands()
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         {
             string vsoCommand = null;
             string result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
-            Assert.Equal(vsoCommand, result);
+            Assert.Equal(string.Empty, result);
         }
 
         [Fact]

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -72,43 +72,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
             Assert.Equal(vsoCommand, result);
         }
 
-        [Theory]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Common")]
-        public void IsBase64Encoded_InputValidEncoded()
-        {
-            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            String encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
-
-            var result = StringUtil.IsBase64Encoded(encodedVsoCommand);
-
-            Assert.Equal(true, result);
-        }
-
-        [Theory]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Common")]
-        public void IsBase64Encoded_InputNotEncoded()
-        {
-            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-
-            var result = StringUtil.IsBase64Encoded(vsoCommand);
-
-            Assert.Equal(false, result);
-        }
-
-        [Theory]
-        [Trait("Level", "L0")]
-        [Trait("Category", "Common")]
-        public void IsBase64Encoded_InputEmpty()
-        {
-            String vsoCommand = "";
-
-            var result = StringUtil.IsBase64Encoded(vsoCommand);
-
-            Assert.Equal(false, result);
-        }
-
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.VisualStudio.Services.Agent.Util;
+using System;
+using System.Text;
 using System.Globalization;
 using Xunit;
 
@@ -28,6 +30,83 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
             var result = StringUtil.DeactivateVsoCommands(input);
 
             Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void DeactivateBase64EncodedVsoCommands_InputValidEncoded()
+        {
+            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            String encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
+
+            var result = StringUtil.DeactivateBase64EncodedVsoCommands(encodedVsoCommand);
+
+            String cleanedVsoCommand = "**vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            var expectedCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(cleanedVsoCommand));
+
+            Assert.Equal(expectedCommand, result);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void DeactivateBase64EncodedVsoCommands_InputNotEncoded()
+        {
+            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+
+            var result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+
+            Assert.Equal(vsoCommand, result);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void DeactivateBase64EncodedVsoCommands_InputEmpty()
+        {
+            String vsoCommand = "";
+
+            var result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+
+            Assert.Equal(vsoCommand, result);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void IsBase64Encoded_InputValidEncoded()
+        {
+            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            String encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
+
+            var result = StringUtil.IsBase64Encoded(encodedVsoCommand);
+
+            Assert.Equal(true, result);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void IsBase64Encoded_InputNotEncoded()
+        {
+            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+
+            var result = StringUtil.IsBase64Encoded(vsoCommand);
+
+            Assert.Equal(false, result);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void IsBase64Encoded_InputEmpty()
+        {
+            String vsoCommand = "";
+
+            var result = StringUtil.IsBase64Encoded(vsoCommand);
+
+            Assert.Equal(false, result);
         }
 
         [Fact]

--- a/src/Test/L0/Util/StringUtilL0.cs
+++ b/src/Test/L0/Util/StringUtilL0.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
             Assert.Equal(expected, result);
         }
 
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         public void DeactivateBase64EncodedVsoCommands_InputValidEncoded()
@@ -48,19 +48,22 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
             Assert.Equal(expectedCommand, result);
         }
 
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         public void DeactivateBase64EncodedVsoCommands_InputNotEncoded()
         {
-            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
 
-            var result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
+                var result = StringUtil.DeactivateBase64EncodedVsoCommands(vsoCommand);
 
-            Assert.Equal(vsoCommand, result);
+                Assert.Equal(vsoCommand, result);
+            }
         }
 
-        [Theory]
+        [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Common")]
         public void DeactivateBase64EncodedVsoCommands_InputEmpty()

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -294,13 +294,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
             message.Variables[Constants.Variables.Build.SourceVersionMessage] = "";
             message.Variables[Constants.Variables.System.SourceVersionMessage] = null;
-            message.Variables[Constants.Variables.Build.DefinitionName] = " ";
+            message.Variables[Constants.Variables.Build.DefinitionName] = "";
 
             var scrubbedMessage = WorkerUtilities.DeactivateVsoCommandsFromJobMessageVariables(message);
 
             Assert.Equal("", scrubbedMessage.Variables[Constants.Variables.Build.SourceVersionMessage]);
             Assert.Equal("", scrubbedMessage.Variables[Constants.Variables.System.SourceVersionMessage]);
-            Assert.Equal(" ", scrubbedMessage.Variables[Constants.Variables.Build.DefinitionName]);
+            Assert.Equal("", scrubbedMessage.Variables[Constants.Variables.Build.DefinitionName]);
         }
 
         [Fact]

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -303,24 +303,28 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             Assert.Equal("", scrubbedMessage.Variables[Constants.Variables.Build.DefinitionName]);
         }
 
+
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
-        public void VerifyJobRequestMessageVsoBase64EncodedCommandsDeactivated()
+        public void VerifyJobRequestMessageVsoCommandsDeactivatedIfVariableCasesHandlesBase64EncodedVsoCommands()
         {
             Pipelines.AgentJobRequestMessage message = CreateJobRequestMessage("jobWithVsoCommands");
-
-            String vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            String encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
-
+            // Set up
+            // A build variable is assigned a VSO command encoded as base 64 string
+            string vsoCommand = "##vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            string encodedVsoCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(vsoCommand));
             message.Variables[Constants.Variables.Build.SourceVersionMessage] = encodedVsoCommand;
 
+            // Act
             var scrubbedMessage = WorkerUtilities.DeactivateVsoCommandsFromJobMessageVariables(message);
 
-            String cleanedVsoCommand = "**vso[task.setvariable variable=downloadUrl]https://www.evil.com";
-            var expectedCommand = Convert.ToBase64String(Encoding.UTF8.GetBytes(cleanedVsoCommand));
+            // Expected 
+            // Returned string in it's decode form would have ## replaced with ** to deactivate vso command
+            string deactivatedVsoCommand = "**vso[task.setvariable variable=downloadUrl]https://www.evil.com";
+            string expected = Convert.ToBase64String(Encoding.UTF8.GetBytes(deactivatedVsoCommand));
 
-            Assert.Equal(expectedCommand, scrubbedMessage.Variables[Constants.Variables.Build.SourceVersionMessage]);
+            Assert.Equal(expected, scrubbedMessage.Variables[Constants.Variables.Build.SourceVersionMessage]);
         }
 
         private bool IsMessageIdentical(Pipelines.AgentJobRequestMessage source, Pipelines.AgentJobRequestMessage target)


### PR DESCRIPTION
**Issue:** Some pipeline variables may contain encoded vso commands which will be executed if it will be specified in script as output
We want to prevent this behavior by deactivating commands in these variables

**Description:** 
Added DeactivateBase64EncodedVsoCommands util which disables all vso commands in line

**Risk Assesment(Low/Medium/High)**: low

**Added unit tests:** (Y/N) Y

**Additional Tests Performed:** N