### PR TITLE
Fix indentation in secret masking files

### DIFF
--- a/src/Agent.Sdk/SecretMasking/SecretMasker.cs
+++ b/src/Agent.Sdk/SecretMasking/SecretMasker.cs
@@ -12,379 +12,379 @@ using System.Text.RegularExpressions;
 namespace Agent.Sdk.SecretMasking;
 
 public sealed class SecretMasker : ISecretMasker, IDisposable
- {
+{
 
-     public SecretMasker()
-     {
-         MinSecretLength = 0;
-         m_originalValueSecrets = new HashSet<ValueSecret>();
-         m_regexSecrets = new HashSet<RegexSecret>();
-         m_valueEncoders = new HashSet<ValueEncoder>();
-         m_valueSecrets = new HashSet<ValueSecret>();
-     }
+    public SecretMasker()
+    {
+        MinSecretLength = 0;
+        m_originalValueSecrets = new HashSet<ValueSecret>();
+        m_regexSecrets = new HashSet<RegexSecret>();
+        m_valueEncoders = new HashSet<ValueEncoder>();
+        m_valueSecrets = new HashSet<ValueSecret>();
+    }
 
-     public SecretMasker(int minSecretLength)
-     {
-         MinSecretLength = minSecretLength;
-         m_originalValueSecrets = new HashSet<ValueSecret>();
-         m_regexSecrets = new HashSet<RegexSecret>();
-         m_valueEncoders = new HashSet<ValueEncoder>();
-         m_valueSecrets = new HashSet<ValueSecret>();
-     }
+    public SecretMasker(int minSecretLength)
+    {
+        MinSecretLength = minSecretLength;
+        m_originalValueSecrets = new HashSet<ValueSecret>();
+        m_regexSecrets = new HashSet<RegexSecret>();
+        m_valueEncoders = new HashSet<ValueEncoder>();
+        m_valueSecrets = new HashSet<ValueSecret>();
+    }
 
-     private SecretMasker(SecretMasker copy)
-     {
-         // Read section.
-         try
-         {
-             copy.m_lock.EnterReadLock();
+    private SecretMasker(SecretMasker copy)
+    {
+        // Read section.
+        try
+        {
+            copy.m_lock.EnterReadLock();
 
-             // Copy the hash sets.
-             MinSecretLength = copy.MinSecretLength;
-             m_originalValueSecrets = new HashSet<ValueSecret>(copy.m_originalValueSecrets);
-             m_regexSecrets = new HashSet<RegexSecret>(copy.m_regexSecrets);
-             m_valueEncoders = new HashSet<ValueEncoder>(copy.m_valueEncoders);
-             m_valueSecrets = new HashSet<ValueSecret>(copy.m_valueSecrets);
-         }
-         finally
-         {
-             if (copy.m_lock.IsReadLockHeld)
-             {
-                 copy.m_lock.ExitReadLock();
-             }
-         }
-     }
+            // Copy the hash sets.
+            MinSecretLength = copy.MinSecretLength;
+            m_originalValueSecrets = new HashSet<ValueSecret>(copy.m_originalValueSecrets);
+            m_regexSecrets = new HashSet<RegexSecret>(copy.m_regexSecrets);
+            m_valueEncoders = new HashSet<ValueEncoder>(copy.m_valueEncoders);
+            m_valueSecrets = new HashSet<ValueSecret>(copy.m_valueSecrets);
+        }
+        finally
+        {
+            if (copy.m_lock.IsReadLockHeld)
+            {
+                copy.m_lock.ExitReadLock();
+            }
+        }
+    }
 
-     /// <summary>
-     /// This property allows to set the minimum length of a secret for masking
-     /// </summary>
-     public int MinSecretLength { get; set; }
+    /// <summary>
+    /// This property allows to set the minimum length of a secret for masking
+    /// </summary>
+    public int MinSecretLength { get; set; }
 
     /// <summary>
     /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
     /// </summary>
     public void AddRegex(String pattern)
-     {
-         // Test for empty.
-         if (String.IsNullOrEmpty(pattern))
-         {
-             return;
-         }
+    {
+        // Test for empty.
+        if (String.IsNullOrEmpty(pattern))
+        {
+            return;
+        }
 
-         if (pattern.Length < MinSecretLength)
-         {
-             return;
-         }
+        if (pattern.Length < MinSecretLength)
+        {
+            return;
+        }
 
-         // Write section.
-         try
-         {
-             m_lock.EnterWriteLock();
+        // Write section.
+        try
+        {
+            m_lock.EnterWriteLock();
 
-             // Add the value.
-             m_regexSecrets.Add(new RegexSecret(pattern));
-         }
-         finally
-         {
-             if (m_lock.IsWriteLockHeld)
-             {
-                 m_lock.ExitWriteLock();
-             }
-         }
-     }
-
-
-     /// <summary>
-     /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
-     /// </summary>
-     public void AddValue(String value)
-     {
-         // Test for empty.
-         if (String.IsNullOrEmpty(value))
-         {
-             return;
-         }
-
-         if (value.Length < MinSecretLength)
-         {
-             return;
-         }
-
-         var valueSecrets = new List<ValueSecret>(new[] { new ValueSecret(value) });
-
-         // Read section.
-         ValueEncoder[] valueEncoders;
-         try
-         {
-             m_lock.EnterReadLock();
-
-             // Test whether already added.
-             if (m_originalValueSecrets.Contains(valueSecrets[0]))
-             {
-                 return;
-             }
-
-             // Read the value encoders.
-             valueEncoders = m_valueEncoders.ToArray();
-         }
-         finally
-         {
-             if (m_lock.IsReadLockHeld)
-             {
-                 m_lock.ExitReadLock();
-             }
-         }
-
-         // Compute the encoded values.
-         foreach (ValueEncoder valueEncoder in valueEncoders)
-         {
-             String encodedValue = valueEncoder(value);
-             if (!String.IsNullOrEmpty(encodedValue) && encodedValue.Length >= MinSecretLength)
-             {
-                 valueSecrets.Add(new ValueSecret(encodedValue));
-             }
-         }
-
-         // Write section.
-         try
-         {
-             m_lock.EnterWriteLock();
-
-             // Add the values.
-             m_originalValueSecrets.Add(valueSecrets[0]);
-             foreach (ValueSecret valueSecret in valueSecrets)
-             {
-                 m_valueSecrets.Add(valueSecret);
-             }
-         }
-         finally
-         {
-             if (m_lock.IsWriteLockHeld)
-             {
-                 m_lock.ExitWriteLock();
-             }
-         }
-     }
-
-     /// <summary>
-     /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
-     /// </summary>
-     public void AddValueEncoder(ValueEncoder encoder)
-     {
-         ValueSecret[] originalSecrets;
-
-         // Read section.
-         try
-         {
-             m_lock.EnterReadLock();
-
-             // Test whether already added.
-             if (m_valueEncoders.Contains(encoder))
-             {
-                 return;
-             }
-
-             // Read the original value secrets.
-             originalSecrets = m_originalValueSecrets.ToArray();
-         }
-         finally
-         {
-             if (m_lock.IsReadLockHeld)
-             {
-                 m_lock.ExitReadLock();
-             }
-         }
-
-         // Compute the encoded values.
-         var encodedSecrets = new List<ValueSecret>();
-         foreach (ValueSecret originalSecret in originalSecrets)
-         {
-             String encodedValue = encoder(originalSecret.m_value);
-             if (!String.IsNullOrEmpty(encodedValue) && encodedValue.Length >= MinSecretLength)
-             {
-                 encodedSecrets.Add(new ValueSecret(encodedValue));
-             }
-         }
-
-         // Write section.
-         try
-         {
-             m_lock.EnterWriteLock();
-
-             // Add the encoder.
-             m_valueEncoders.Add(encoder);
-
-             // Add the values.
-             foreach (ValueSecret encodedSecret in encodedSecrets)
-             {
-                 m_valueSecrets.Add(encodedSecret);
-             }
-         }
-         finally
-         {
-             if (m_lock.IsWriteLockHeld)
-             {
-                 m_lock.ExitWriteLock();
-             }
-         }
-     }
+            // Add the value.
+            m_regexSecrets.Add(new RegexSecret(pattern));
+        }
+        finally
+        {
+            if (m_lock.IsWriteLockHeld)
+            {
+                m_lock.ExitWriteLock();
+            }
+        }
+    }
 
 
-     public ISecretMasker Clone() => new SecretMasker(this);
+    /// <summary>
+    /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
+    /// </summary>
+    public void AddValue(String value)
+    {
+        // Test for empty.
+        if (String.IsNullOrEmpty(value))
+        {
+            return;
+        }
 
-     public void Dispose()
-     {
-         m_lock?.Dispose();
-         m_lock = null;
-     }
+        if (value.Length < MinSecretLength)
+        {
+            return;
+        }
 
-     public String MaskSecrets(String input)
-     {
-         if (String.IsNullOrEmpty(input))
-         {
-             return String.Empty;
-         }
+        var valueSecrets = new List<ValueSecret>(new[] { new ValueSecret(value) });
 
-         var secretPositions = new List<ReplacementPosition>();
+        // Read section.
+        ValueEncoder[] valueEncoders;
+        try
+        {
+            m_lock.EnterReadLock();
 
-         // Read section.
-         try
-         {
-             m_lock.EnterReadLock();
+            // Test whether already added.
+            if (m_originalValueSecrets.Contains(valueSecrets[0]))
+            {
+                return;
+            }
 
-             // Get indexes and lengths of all substrings that will be replaced.
-             foreach (RegexSecret regexSecret in m_regexSecrets)
-             {
-                 secretPositions.AddRange(regexSecret.GetPositions(input));
-             }
+            // Read the value encoders.
+            valueEncoders = m_valueEncoders.ToArray();
+        }
+        finally
+        {
+            if (m_lock.IsReadLockHeld)
+            {
+                m_lock.ExitReadLock();
+            }
+        }
 
-             foreach (ValueSecret valueSecret in m_valueSecrets)
-             {
-                 secretPositions.AddRange(valueSecret.GetPositions(input));
-             }
-         }
-         finally
-         {
-             if (m_lock.IsReadLockHeld)
-             {
-                 m_lock.ExitReadLock();
-             }
-         }
+        // Compute the encoded values.
+        foreach (ValueEncoder valueEncoder in valueEncoders)
+        {
+            String encodedValue = valueEncoder(value);
+            if (!String.IsNullOrEmpty(encodedValue) && encodedValue.Length >= MinSecretLength)
+            {
+                valueSecrets.Add(new ValueSecret(encodedValue));
+            }
+        }
 
-         // Short-circuit if nothing to replace.
-         if (secretPositions.Count == 0)
-         {
-             return input;
-         }
+        // Write section.
+        try
+        {
+            m_lock.EnterWriteLock();
 
-         // Merge positions into ranges of characters to replace.
-         List<ReplacementPosition> replacementPositions = new List<ReplacementPosition>();
-         ReplacementPosition currentReplacement = null;
-         foreach (ReplacementPosition secretPosition in secretPositions.OrderBy(x => x.Start))
-         {
-             if (currentReplacement == null)
-             {
-                 currentReplacement = new ReplacementPosition(copy: secretPosition);
-                 replacementPositions.Add(currentReplacement);
-             }
-             else
-             {
-                 if (secretPosition.Start <= currentReplacement.End)
-                 {
-                     // Overlap
-                     currentReplacement.Length = Math.Max(currentReplacement.End, secretPosition.End) - currentReplacement.Start;
-                 }
-                 else
-                 {
-                     // No overlap
-                     currentReplacement = new ReplacementPosition(copy: secretPosition);
-                     replacementPositions.Add(currentReplacement);
-                 }
-             }
-         }
+            // Add the values.
+            m_originalValueSecrets.Add(valueSecrets[0]);
+            foreach (ValueSecret valueSecret in valueSecrets)
+            {
+                m_valueSecrets.Add(valueSecret);
+            }
+        }
+        finally
+        {
+            if (m_lock.IsWriteLockHeld)
+            {
+                m_lock.ExitWriteLock();
+            }
+        }
+    }
 
-         // Replace
-         var stringBuilder = new StringBuilder();
-         Int32 startIndex = 0;
-         foreach (var replacement in replacementPositions)
-         {
-             stringBuilder.Append(input.Substring(startIndex, replacement.Start - startIndex));
-             stringBuilder.Append("***");
-             startIndex = replacement.Start + replacement.Length;
-         }
+    /// <summary>
+    /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
+    /// </summary>
+    public void AddValueEncoder(ValueEncoder encoder)
+    {
+        ValueSecret[] originalSecrets;
 
-         if (startIndex < input.Length)
-         {
-             stringBuilder.Append(input.Substring(startIndex));
-         }
+        // Read section.
+        try
+        {
+            m_lock.EnterReadLock();
 
-         return stringBuilder.ToString();
-     }
+            // Test whether already added.
+            if (m_valueEncoders.Contains(encoder))
+            {
+                return;
+            }
 
-     /// <summary>
-     /// Removes secrets from the dictionary shorter than the MinSecretLength property.
-     /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
-     /// </summary>
-     public void RemoveShortSecretsFromDictionary()
-     {
-         var filteredValueSecrets = new HashSet<ValueSecret>();
-         var filteredRegexSecrets = new HashSet<RegexSecret>();
+            // Read the original value secrets.
+            originalSecrets = m_originalValueSecrets.ToArray();
+        }
+        finally
+        {
+            if (m_lock.IsReadLockHeld)
+            {
+                m_lock.ExitReadLock();
+            }
+        }
 
-         try
-         {
-             m_lock.EnterReadLock();
+        // Compute the encoded values.
+        var encodedSecrets = new List<ValueSecret>();
+        foreach (ValueSecret originalSecret in originalSecrets)
+        {
+            String encodedValue = encoder(originalSecret.m_value);
+            if (!String.IsNullOrEmpty(encodedValue) && encodedValue.Length >= MinSecretLength)
+            {
+                encodedSecrets.Add(new ValueSecret(encodedValue));
+            }
+        }
 
-             foreach (var secret in m_valueSecrets)
-             {
-                 if (secret.m_value.Length < MinSecretLength)
-                 {
-                     filteredValueSecrets.Add(secret);
-                 }
-             }
+        // Write section.
+        try
+        {
+            m_lock.EnterWriteLock();
 
-             foreach (var secret in m_regexSecrets)
-             {
-                 if (secret.Pattern.Length < MinSecretLength)
-                 {
-                     filteredRegexSecrets.Add(secret);
-                 }
-             }
-         }
-         finally
-         {
-             if (m_lock.IsReadLockHeld)
-             {
-                 m_lock.ExitReadLock();
-             }
-         }
+            // Add the encoder.
+            m_valueEncoders.Add(encoder);
 
-         try
-         {
-             m_lock.EnterWriteLock();
+            // Add the values.
+            foreach (ValueSecret encodedSecret in encodedSecrets)
+            {
+                m_valueSecrets.Add(encodedSecret);
+            }
+        }
+        finally
+        {
+            if (m_lock.IsWriteLockHeld)
+            {
+                m_lock.ExitWriteLock();
+            }
+        }
+    }
 
-             foreach (var secret in filteredValueSecrets)
-             {
-                 m_valueSecrets.Remove(secret);
-             }
 
-             foreach (var secret in filteredRegexSecrets)
-             {
-                 m_regexSecrets.Remove(secret);
-             }
+    public ISecretMasker Clone() => new SecretMasker(this);
 
-             foreach (var secret in filteredValueSecrets)
-             {
-                 m_originalValueSecrets.Remove(secret);
-             }
-         }
-         finally
-         {
-             if (m_lock.IsWriteLockHeld)
-             {
-                 m_lock.ExitWriteLock();
-             }
-         }
-     }
+    public void Dispose()
+    {
+        m_lock?.Dispose();
+        m_lock = null;
+    }
+
+    public String MaskSecrets(String input)
+    {
+        if (String.IsNullOrEmpty(input))
+        {
+            return String.Empty;
+        }
+
+        var secretPositions = new List<ReplacementPosition>();
+
+        // Read section.
+        try
+        {
+            m_lock.EnterReadLock();
+
+            // Get indexes and lengths of all substrings that will be replaced.
+            foreach (RegexSecret regexSecret in m_regexSecrets)
+            {
+                secretPositions.AddRange(regexSecret.GetPositions(input));
+            }
+
+            foreach (ValueSecret valueSecret in m_valueSecrets)
+            {
+                secretPositions.AddRange(valueSecret.GetPositions(input));
+            }
+        }
+        finally
+        {
+            if (m_lock.IsReadLockHeld)
+            {
+                m_lock.ExitReadLock();
+            }
+        }
+
+        // Short-circuit if nothing to replace.
+        if (secretPositions.Count == 0)
+        {
+            return input;
+        }
+
+        // Merge positions into ranges of characters to replace.
+        List<ReplacementPosition> replacementPositions = new List<ReplacementPosition>();
+        ReplacementPosition currentReplacement = null;
+        foreach (ReplacementPosition secretPosition in secretPositions.OrderBy(x => x.Start))
+        {
+            if (currentReplacement == null)
+            {
+                currentReplacement = new ReplacementPosition(copy: secretPosition);
+                replacementPositions.Add(currentReplacement);
+            }
+            else
+            {
+                if (secretPosition.Start <= currentReplacement.End)
+                {
+                    // Overlap
+                    currentReplacement.Length = Math.Max(currentReplacement.End, secretPosition.End) - currentReplacement.Start;
+                }
+                else
+                {
+                    // No overlap
+                    currentReplacement = new ReplacementPosition(copy: secretPosition);
+                    replacementPositions.Add(currentReplacement);
+                }
+            }
+        }
+
+        // Replace
+        var stringBuilder = new StringBuilder();
+        Int32 startIndex = 0;
+        foreach (var replacement in replacementPositions)
+        {
+            stringBuilder.Append(input.Substring(startIndex, replacement.Start - startIndex));
+            stringBuilder.Append("***");
+            startIndex = replacement.Start + replacement.Length;
+        }
+
+        if (startIndex < input.Length)
+        {
+            stringBuilder.Append(input.Substring(startIndex));
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Removes secrets from the dictionary shorter than the MinSecretLength property.
+    /// This implementation assumes no more than one thread is adding regexes, values, or encoders at any given time.
+    /// </summary>
+    public void RemoveShortSecretsFromDictionary()
+    {
+        var filteredValueSecrets = new HashSet<ValueSecret>();
+        var filteredRegexSecrets = new HashSet<RegexSecret>();
+
+        try
+        {
+            m_lock.EnterReadLock();
+
+            foreach (var secret in m_valueSecrets)
+            {
+                if (secret.m_value.Length < MinSecretLength)
+                {
+                    filteredValueSecrets.Add(secret);
+                }
+            }
+
+            foreach (var secret in m_regexSecrets)
+            {
+                if (secret.Pattern.Length < MinSecretLength)
+                {
+                    filteredRegexSecrets.Add(secret);
+                }
+            }
+        }
+        finally
+        {
+            if (m_lock.IsReadLockHeld)
+            {
+                m_lock.ExitReadLock();
+            }
+        }
+
+        try
+        {
+            m_lock.EnterWriteLock();
+
+            foreach (var secret in filteredValueSecrets)
+            {
+                m_valueSecrets.Remove(secret);
+            }
+
+            foreach (var secret in filteredRegexSecrets)
+            {
+                m_regexSecrets.Remove(secret);
+            }
+
+            foreach (var secret in filteredValueSecrets)
+            {
+                m_originalValueSecrets.Remove(secret);
+            }
+        }
+        finally
+        {
+            if (m_lock.IsWriteLockHeld)
+            {
+                m_lock.ExitWriteLock();
+            }
+        }
+    }
 
     public void AddRegex(string pattern, RegexOptions options)
     {
@@ -427,4 +427,4 @@ public sealed class SecretMasker : ISecretMasker, IDisposable
     private readonly HashSet<ValueEncoder> m_valueEncoders;
     private readonly HashSet<ValueSecret> m_valueSecrets;
     private ReaderWriterLockSlim m_lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
- }
+}

--- a/src/Test/L0/SecretMaskerTests/SecretMaskerL0.cs
+++ b/src/Test/L0/SecretMaskerTests/SecretMaskerL0.cs
@@ -113,9 +113,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                "https://username%AZP2510%AZP25A3%AZP25F6:***@example.com",
                testSecretMasker.MaskSecrets(@"https://username%AZP2510%AZP25A3%AZP25F6:password123@example.com"));
         }
-        
+
         [Fact]
-        [Trait("Level","L0")]
+        [Trait("Level", "L0")]
         [Trait("Category", "SecretMasker")]
         public void SecretMaskerTests_CopyConstructor()
         {
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             Assert.Equal("***masker-1-encoder-3", secretMasker2.MaskSecrets("masker-1-value-1_masker-1-encoder-3")); // separate encoder storage from original
         }
         [Fact]
-        [Trait("Level","L0")]
+        [Trait("Level", "L0")]
         [Trait("Category", "SecretMasker")]
         public void SecretMaskerTests_Encoder()
         {
@@ -198,429 +198,429 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             Assert.Equal("***", secretMasker.MaskSecrets("value_3"));
             Assert.Equal("***", secretMasker.MaskSecrets("value 3"));
         }
-        
+
         [Fact]
-        [Trait("Level","L0")]
+        [Trait("Level", "L0")]
         [Trait("Category", "SecretMasker")]
         public void SecretMaskerTests_Encoder_JsonStringEscape()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValueEncoder(ValueEncoders.JsonStringEscape);
-             secretMasker.AddValue("carriage-return\r_newline\n_tab\t_backslash\\_double-quote\"");
-             Assert.Equal("***", secretMasker.MaskSecrets("carriage-return\r_newline\n_tab\t_backslash\\_double-quote\""));
-             Assert.Equal("***", secretMasker.MaskSecrets("carriage-return\\r_newline\\n_tab\\t_backslash\\\\_double-quote\\\""));
-         }
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValueEncoder(ValueEncoders.JsonStringEscape);
+            secretMasker.AddValue("carriage-return\r_newline\n_tab\t_backslash\\_double-quote\"");
+            Assert.Equal("***", secretMasker.MaskSecrets("carriage-return\r_newline\n_tab\t_backslash\\_double-quote\""));
+            Assert.Equal("***", secretMasker.MaskSecrets("carriage-return\\r_newline\\n_tab\\t_backslash\\\\_double-quote\\\""));
+        }
 
         [Fact]
-        [Trait("Level","L0")]
+        [Trait("Level", "L0")]
         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_Encoder_BackslashEscape()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValueEncoder(ValueEncoders.BackslashEscape);
-             secretMasker.AddValue(@"abc\\def\'\""ghi\t");
-             Assert.Equal("***", secretMasker.MaskSecrets(@"abc\\def\'\""ghi\t"));
-             Assert.Equal("***", secretMasker.MaskSecrets(@"abc\def'""ghi" + "\t"));
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_Encoder_UriDataEscape()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValueEncoder(ValueEncoders.UriDataEscape);
-             secretMasker.AddValue("hello world");
-             Assert.Equal("***", secretMasker.MaskSecrets("hello world"));
-             Assert.Equal("***", secretMasker.MaskSecrets("hello%20world"));
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_Encoder_UriDataEscape_LargeString()
-         {
-             // Uri.EscapeDataString cannot receive a string longer than 65519 characters.
-             // For unit testing we call a different overload with a smaller segment size (improve unit test speed).
-
-             ValueEncoder encoder = x => ValueEncoders.UriDataEscape(x);
-
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(1, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(2, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(3, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(4, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(5, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(5, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(6, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = String.Empty.PadRight(7, ' ');
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-                 Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = "𐐷𐐷𐐷𐐷"; // surrogate pair
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-             }
-             
-             using (var secretMasker = new SecretMasker())
-             {
-                 secretMasker.AddValueEncoder(encoder);
-                 var value = " 𐐷𐐷𐐷𐐷"; // shift by one non-surrogate character to ensure surrogate across segment boundary handled correctly
-                 secretMasker.AddValue(value);
-                 Assert.Equal("***", secretMasker.MaskSecrets(value));
-             }
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_HandlesEmptyInput()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("abcd");
-
-             var result = secretMasker.MaskSecrets(null);
-             Assert.Equal(string.Empty, result);
-
-             result = secretMasker.MaskSecrets(string.Empty);
-             Assert.Equal(string.Empty, result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_HandlesNoMasks()
-         {
-             using var secretMasker = new SecretMasker();
-             var expected = "abcdefg";
-             var actual = secretMasker.MaskSecrets(expected);
-             Assert.Equal(expected, actual);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_ReplacesValue()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("def");
-
-             var input = "abcdefg";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("abc***g", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_ReplacesMultipleInstances()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("def");
-
-             var input = "abcdefgdef";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("abc***g***", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_ReplacesMultipleAdjacentInstances()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("abc");
-
-             var input = "abcabcdef";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("***def", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_ReplacesMultipleSecrets()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("bcd");
-             secretMasker.AddValue("fgh");
-
-             var input = "abcdefghi";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("a***e***i", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_ReplacesOverlappingSecrets()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("def");
-             secretMasker.AddValue("bcd");
-
-             var input = "abcdefg";
-             var result = secretMasker.MaskSecrets(input);
-
-             // a naive replacement would replace "def" first, and never find "bcd", resulting in "abc***g"
-             // or it would replace "bcd" first, and never find "def", resulting in "a***efg"
-
-             Assert.Equal("a***g", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_ReplacesAdjacentSecrets()
-         {
-             using var secretMasker = new SecretMasker();
-             secretMasker.AddValue("efg");
-             secretMasker.AddValue("bcd");
-
-             var input = "abcdefgh";
-             var result = secretMasker.MaskSecrets(input);
-
-             // two adjacent secrets are basically one big secret
-
-             Assert.Equal("a***h", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_MinLengthSetThroughConstructor()
-         {
-             using var secretMasker = new SecretMasker() { MinSecretLength = 9 };
-
-             secretMasker.AddValue("efg");
-             secretMasker.AddValue("bcd");
-
-             var input = "abcdefgh";
-             var result = secretMasker.MaskSecrets(input);
-
-             // two adjacent secrets are basically one big secret
-
-             Assert.Equal("abcdefgh", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_MinLengthSetThroughProperty()
-         {
-             using var secretMasker = new SecretMasker { MinSecretLength = 9 };
-
-             secretMasker.AddValue("efg");
-             secretMasker.AddValue("bcd");
-
-             var input = "abcdefgh";
-             var result = secretMasker.MaskSecrets(input);
-
-             // two adjacent secrets are basically one big secret
-
-             Assert.Equal("abcdefgh", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_MinLengthSetThroughPropertySetTwice()
-         {
-             using var secretMasker = new SecretMasker();
-
-             var minSecretLenFirst = 9;
-             secretMasker.MinSecretLength = minSecretLenFirst;
-
-             var minSecretLenSecond = 2;
-             secretMasker.MinSecretLength = minSecretLenSecond;
-
-             Assert.Equal(secretMasker.MinSecretLength, minSecretLenSecond);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_NegativeMinSecretLengthSet()
-         {
-             using var secretMasker = new SecretMasker() { MinSecretLength = -3 };
-             secretMasker.AddValue("efg");
-             secretMasker.AddValue("bcd");
-
-             var input = "abcdefgh";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("a***h", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_RemoveShortSecrets()
-         {
-             using var secretMasker = new SecretMasker() { MinSecretLength = 3 };
-             secretMasker.AddValue("efg");
-             secretMasker.AddValue("bcd");
-
-             var input = "abcdefgh";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("a***h", result);
-
-             secretMasker.MinSecretLength = 4;
-             secretMasker.RemoveShortSecretsFromDictionary();
-
-             var result2 = secretMasker.MaskSecrets(input);
-
-             Assert.Equal(input, result2);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_RemoveShortSecretsBoundaryValues()
-         {
-             using var secretMasker = new SecretMasker(0);
-             secretMasker.AddValue("bc");
-             secretMasker.AddValue("defg");
-             secretMasker.AddValue("h12");
-
-             var input = "abcdefgh123";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("a***3", result);
-
-             secretMasker.MinSecretLength = 3;
-             secretMasker.RemoveShortSecretsFromDictionary();
-
-             var result2 = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("abc***3", result2);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_RemoveShortRegexes()
-         {
-             using var secretMasker = new SecretMasker(0);
-             secretMasker.AddRegex("bc");
-             secretMasker.AddRegex("defg");
-             secretMasker.AddRegex("h12");
-
-             secretMasker.MinSecretLength = 3;
-             secretMasker.RemoveShortSecretsFromDictionary();
-
-             var input = "abcdefgh123";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("abc***3", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_RemoveEncodedSecrets()
-         {
-             using var secretMasker = new SecretMasker(0);
-             secretMasker.AddValue("1");
-             secretMasker.AddValue("2");
-             secretMasker.AddValue("3");
-             secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("1", "123")));
-             secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("2", "45")));
-             secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("3", "6789")));
-
-             secretMasker.MinSecretLength = 3;
-             secretMasker.RemoveShortSecretsFromDictionary();
-
-             var input = "123456789";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("***45***", result);
-         }
-
-         [Fact]
-         [Trait("Level","L0")]
-         [Trait("Category", "SecretMasker")]
-         public void SecretMaskerTests_NotAddShortEncodedSecrets()
-         {
-             using var secretMasker = new SecretMasker() { MinSecretLength = 3 };
-             secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("123", "ab")));
-             secretMasker.AddValue("123");
-             secretMasker.AddValue("345");
-             secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("345", "cd")));
-
-             var input = "ab123cd345";
-             var result = secretMasker.MaskSecrets(input);
-
-             Assert.Equal("ab***cd***", result);
-         }
+        public void SecretMaskerTests_Encoder_BackslashEscape()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValueEncoder(ValueEncoders.BackslashEscape);
+            secretMasker.AddValue(@"abc\\def\'\""ghi\t");
+            Assert.Equal("***", secretMasker.MaskSecrets(@"abc\\def\'\""ghi\t"));
+            Assert.Equal("***", secretMasker.MaskSecrets(@"abc\def'""ghi" + "\t"));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_Encoder_UriDataEscape()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValueEncoder(ValueEncoders.UriDataEscape);
+            secretMasker.AddValue("hello world");
+            Assert.Equal("***", secretMasker.MaskSecrets("hello world"));
+            Assert.Equal("***", secretMasker.MaskSecrets("hello%20world"));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_Encoder_UriDataEscape_LargeString()
+        {
+            // Uri.EscapeDataString cannot receive a string longer than 65519 characters.
+            // For unit testing we call a different overload with a smaller segment size (improve unit test speed).
+
+            ValueEncoder encoder = x => ValueEncoders.UriDataEscape(x);
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(1, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(2, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(3, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(4, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(5, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(5, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(6, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = String.Empty.PadRight(7, ' ');
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+                Assert.Equal("***", secretMasker.MaskSecrets(value.Replace(" ", "%20")));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = "𐐷𐐷𐐷𐐷"; // surrogate pair
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+            }
+
+            using (var secretMasker = new SecretMasker())
+            {
+                secretMasker.AddValueEncoder(encoder);
+                var value = " 𐐷𐐷𐐷𐐷"; // shift by one non-surrogate character to ensure surrogate across segment boundary handled correctly
+                secretMasker.AddValue(value);
+                Assert.Equal("***", secretMasker.MaskSecrets(value));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_HandlesEmptyInput()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("abcd");
+
+            var result = secretMasker.MaskSecrets(null);
+            Assert.Equal(string.Empty, result);
+
+            result = secretMasker.MaskSecrets(string.Empty);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_HandlesNoMasks()
+        {
+            using var secretMasker = new SecretMasker();
+            var expected = "abcdefg";
+            var actual = secretMasker.MaskSecrets(expected);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_ReplacesValue()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("def");
+
+            var input = "abcdefg";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("abc***g", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_ReplacesMultipleInstances()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("def");
+
+            var input = "abcdefgdef";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("abc***g***", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_ReplacesMultipleAdjacentInstances()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("abc");
+
+            var input = "abcabcdef";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("***def", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_ReplacesMultipleSecrets()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("bcd");
+            secretMasker.AddValue("fgh");
+
+            var input = "abcdefghi";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("a***e***i", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_ReplacesOverlappingSecrets()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("def");
+            secretMasker.AddValue("bcd");
+
+            var input = "abcdefg";
+            var result = secretMasker.MaskSecrets(input);
+
+            // a naive replacement would replace "def" first, and never find "bcd", resulting in "abc***g"
+            // or it would replace "bcd" first, and never find "def", resulting in "a***efg"
+
+            Assert.Equal("a***g", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_ReplacesAdjacentSecrets()
+        {
+            using var secretMasker = new SecretMasker();
+            secretMasker.AddValue("efg");
+            secretMasker.AddValue("bcd");
+
+            var input = "abcdefgh";
+            var result = secretMasker.MaskSecrets(input);
+
+            // two adjacent secrets are basically one big secret
+
+            Assert.Equal("a***h", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_MinLengthSetThroughConstructor()
+        {
+            using var secretMasker = new SecretMasker() { MinSecretLength = 9 };
+
+            secretMasker.AddValue("efg");
+            secretMasker.AddValue("bcd");
+
+            var input = "abcdefgh";
+            var result = secretMasker.MaskSecrets(input);
+
+            // two adjacent secrets are basically one big secret
+
+            Assert.Equal("abcdefgh", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_MinLengthSetThroughProperty()
+        {
+            using var secretMasker = new SecretMasker { MinSecretLength = 9 };
+
+            secretMasker.AddValue("efg");
+            secretMasker.AddValue("bcd");
+
+            var input = "abcdefgh";
+            var result = secretMasker.MaskSecrets(input);
+
+            // two adjacent secrets are basically one big secret
+
+            Assert.Equal("abcdefgh", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_MinLengthSetThroughPropertySetTwice()
+        {
+            using var secretMasker = new SecretMasker();
+
+            var minSecretLenFirst = 9;
+            secretMasker.MinSecretLength = minSecretLenFirst;
+
+            var minSecretLenSecond = 2;
+            secretMasker.MinSecretLength = minSecretLenSecond;
+
+            Assert.Equal(secretMasker.MinSecretLength, minSecretLenSecond);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_NegativeMinSecretLengthSet()
+        {
+            using var secretMasker = new SecretMasker() { MinSecretLength = -3 };
+            secretMasker.AddValue("efg");
+            secretMasker.AddValue("bcd");
+
+            var input = "abcdefgh";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("a***h", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_RemoveShortSecrets()
+        {
+            using var secretMasker = new SecretMasker() { MinSecretLength = 3 };
+            secretMasker.AddValue("efg");
+            secretMasker.AddValue("bcd");
+
+            var input = "abcdefgh";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("a***h", result);
+
+            secretMasker.MinSecretLength = 4;
+            secretMasker.RemoveShortSecretsFromDictionary();
+
+            var result2 = secretMasker.MaskSecrets(input);
+
+            Assert.Equal(input, result2);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_RemoveShortSecretsBoundaryValues()
+        {
+            using var secretMasker = new SecretMasker(0);
+            secretMasker.AddValue("bc");
+            secretMasker.AddValue("defg");
+            secretMasker.AddValue("h12");
+
+            var input = "abcdefgh123";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("a***3", result);
+
+            secretMasker.MinSecretLength = 3;
+            secretMasker.RemoveShortSecretsFromDictionary();
+
+            var result2 = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("abc***3", result2);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_RemoveShortRegexes()
+        {
+            using var secretMasker = new SecretMasker(0);
+            secretMasker.AddRegex("bc");
+            secretMasker.AddRegex("defg");
+            secretMasker.AddRegex("h12");
+
+            secretMasker.MinSecretLength = 3;
+            secretMasker.RemoveShortSecretsFromDictionary();
+
+            var input = "abcdefgh123";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("abc***3", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_RemoveEncodedSecrets()
+        {
+            using var secretMasker = new SecretMasker(0);
+            secretMasker.AddValue("1");
+            secretMasker.AddValue("2");
+            secretMasker.AddValue("3");
+            secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("1", "123")));
+            secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("2", "45")));
+            secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("3", "6789")));
+
+            secretMasker.MinSecretLength = 3;
+            secretMasker.RemoveShortSecretsFromDictionary();
+
+            var input = "123456789";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("***45***", result);
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void SecretMaskerTests_NotAddShortEncodedSecrets()
+        {
+            using var secretMasker = new SecretMasker() { MinSecretLength = 3 };
+            secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("123", "ab")));
+            secretMasker.AddValue("123");
+            secretMasker.AddValue("345");
+            secretMasker.AddValueEncoder(new ValueEncoder(x => x.Replace("345", "cd")));
+
+            var input = "ab123cd345";
+            var result = secretMasker.MaskSecrets(input);
+
+            Assert.Equal("ab***cd***", result);
+        }
     }
 }


### PR DESCRIPTION
Changes merged from: https://github.com/microsoft/azure-pipelines-agent/pull/5153

Co-authored-by: Nick Guerrera <nguerrera@microsoft.com>

**Issue:** `SecretMasker.cs` and `SecretMaskerL0.cs` have large portions indented to five spaces instead of four. This results in many `IDE055: Fix formatting` squiggles in VS. It is easy to fix these inadvertently while making other changes, which then makes reviewing those other changes more difficult.

**Description:** Reformat the files using `Format Document (Ctrl+K, Ctrl+D)` in VS. This also fixes some instances of a missing space between attribute arguments.

**Risk Assessment**: Low. There is no product change. Reviewing with 'ignore whitespace' should show no diff at all.

**Added unit tests:** No. N/A.

**Additional Tests Performed:** No. N/A.