### PR TITLE
Agent CDN - devAzure - Replaced azureedge.net references in GitHub Release Template - AB#2241315

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -3,108 +3,108 @@
         "name": "vsts-agent-win-x64-<AGENT_VERSION>.zip",
         "platform": "win-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip"
     },
     {
         "name": "pipelines-agent-win-x64-<AGENT_VERSION>.zip",
         "platform": "win-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip"
     },
     {
         "name": "vsts-agent-win-x86-<AGENT_VERSION>.zip",
         "platform": "win-x86",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip"
     },
     {
         "name": "pipelines-agent-win-x86-<AGENT_VERSION>.zip",
         "platform": "win-x86",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip"
     },
     {
         "name": "vsts-agent-win-arm64-<AGENT_VERSION>.zip",
         "platform": "win-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip"
     },
     {
         "name": "pipelines-agent-win-arm64-<AGENT_VERSION>.zip",
         "platform": "win-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip"
     },
     {
         "name": "vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz",
         "platform": "osx-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz",
         "platform": "osx-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz",
         "platform": "osx-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz",
         "platform": "osx-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz",
         "platform": "linux-arm",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz",
         "platform": "linux-arm",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-musl-x64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz"
     },
     {
         "name": "vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz",
         "platform": "linux-musl-arm64",
         "version": "<AGENT_VERSION>",
-        "downloadUrl": "https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz"
+        "downloadUrl": "https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz"
     }
 ]

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -3,15 +3,15 @@
 
 |                | Package | SHA-256 |
 | -------------- | ------- | ------- |
-| Windows x64    | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
-| Windows x86    | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
-| macOS x64      | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| macOS ARM64    | [vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux x64      | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux ARM      | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux ARM64    | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux musl x64 | [vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux musl ARM64 | [vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Windows x64    | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
+| Windows x86    | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| macOS x64      | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| macOS ARM64    | [vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux x64      | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM      | [vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM64    | [vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux musl x64 | [vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux musl ARM64 | [vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 
 After Download:
 
@@ -89,10 +89,10 @@ See [notes](docs/node6.md) on Node version support for more details.
 
 |             | Package | SHA-256 |
 | ----------- | ------- | ------- |
-| Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
-| Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
-| macOS x64   | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
-| Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
+| Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| macOS x64   | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM   | [pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz) | <HASH> |
+| Linux ARM64 | [pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |


### PR DESCRIPTION
**Issue:** [[Se] Migrate Agent CDN URL from Edgio endpoint to a custom URL](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2241315/)

**Description:** Azure DevOps Agent previously used Edgio CDN with the endpoint `vstsagentpackage.azureedge.net`. As part of Edgio's retirement, the `*.azureedge.net` domain is being decommissioned. To ensure continued availability, we have migrated to an Akamai-backed CDN and are setting up a new endpoint `download.agent.dev.azure.com`.

**Risk Assessment (Low/Medium/High)**: Low (This PR only revises the template using which the GitHub release is created)

**Added Unit-Tests?:** (Y/N) NA

**Additional Tests Performed:**
Although no specific validation was done specifically for the change in this PR, the new Agent CDN endpoint has been tested in the following manner.
- Testing of new endpoint by manually downloading the Agent binaries
- Testing of Agent creation via TFS by pointing to the new endpoint
- Build validation of Agent
- Sample URL: https://download.agent.dev.azure.com/agent/4.252.0/vsts-agent-win-x64-4.252.0.zip