### PR TITLE
Updated Agent code to handling '+' sign in file path for build configs

### DIFF
--- a/src/Agent.Worker/TaskManager.cs
+++ b/src/Agent.Worker/TaskManager.cs
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 return;
             }
 
-            String taskZipPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.TaskZips), $"{task.Name}_{task.Id}_{task.Version}.zip");
+            String taskZipPath = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.TaskZips), $"{task.Name}_{task.Id}_{NormalizeTaskVersion(task)}.zip");
             if (alwaysExtractTask && File.Exists(taskZipPath))
             {
                 executionContext.Debug($"Task '{task.Name}' already downloaded at '{taskZipPath}'.");
@@ -472,7 +472,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             return Path.Combine(
                 HostContext.GetDirectory(WellKnownDirectory.Tasks),
                 $"{task.Name}_{task.Id}",
-                task.Version);
+                NormalizeTaskVersion(task));
+        }
+
+        private string NormalizeTaskVersion(Pipelines.TaskStepDefinitionReference task) 
+        {
+            ArgUtil.NotNullOrEmpty(task.Version, nameof(task.Version));
+            return task.Version.Replace("+", "_");
         }
 
         private string GetTaskZipPath(Pipelines.TaskStepDefinitionReference task)
@@ -482,7 +488,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             ArgUtil.NotNullOrEmpty(task.Version, nameof(task.Version));
             return Path.Combine(
                 HostContext.GetDirectory(WellKnownDirectory.TaskZips),
-                $"{task.Name}_{task.Id}_{task.Version}.zip"); // TODO: Move to shared string.
+                $"{task.Name}_{task.Id}_{NormalizeTaskVersion(task)}.zip"); // TODO: Move to shared string.
         }
 
         private Definition GetTaskDefiniton(Pipelines.TaskStep task)

--- a/src/Microsoft.VisualStudio.Services.Agent/TaskServer.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/TaskServer.cs
@@ -69,7 +69,14 @@ namespace Microsoft.VisualStudio.Services.Agent
         public Task<Stream> GetTaskContentZipAsync(Guid taskId, TaskVersion taskVersion, CancellationToken token)
         {
             CheckConnection();
-            return _taskAgentClient.GetTaskContentZipAsync(taskId, taskVersion, cancellationToken: token);
+            return _taskAgentClient.GetTaskContentZipAsync(
+                taskId,
+                versionString: taskVersion,
+                visibility: null,
+                scopeLocal: null,
+                userState: null,
+                cancellationToken: token
+            );
         }
 
         public async Task<bool> TaskDefinitionEndpointExist()


### PR DESCRIPTION

**Issue:** Updating tasks download path handling for build configs

**Description:**
> PowerShellV2
> ------- 2.256.0.completed (to use the cached task files)
> ------- 2.256.0 (task code folder)

With Build configs
> PowerShellV2
> ------- 2.256.0+BuildConfig.completed (to use the cached task files)
> ------- 2.256.0+BuildConfig (task code folder)

'+' sign can be a special character and prevent file creation in different OS. To prevent this we are replacing '+' sign with '_'

Update code with Build configs
> PowerShellV2
> ------- 2.256.0_BuildConfig.completed (to use the cached task files)
> ------- 2.256.0_BuildConfig (task code folder)

**Risk Assesment(Low/Medium/High)**: LOW (only replacing the + with _ in path)

**Added unit tests:** N

**Additional Tests Performed:** Manual Testing