### PR TITLE
AgentService/Windows: enable 64bit support with Prefer32Bit=false

### DIFF
--- a/src/Agent.Service/Windows/AgentService.csproj
+++ b/src/Agent.Service/Windows/AgentService.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Prefer32Bit>false</Prefer32Bit>
     <ProjectGuid>{D12EBD71-0464-46D0-8394-40BCFBA0A6F2}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>


### PR DESCRIPTION
This can save some memory when AgentService would be the last 32 bit process on a machine because WoW64 can be unloaded.

If the machine is 32 bit, it will still run as 32 bit.

Would be superceded by #4734 or #4387, but this seems less risky as it's not changing the .NET Framework version.