### PR TITLE
Prevent using vso commands with Build.SourceVersionAuthor variable

### DIFF
--- a/src/Agent.Worker/Variables.cs
+++ b/src/Agent.Worker/Variables.cs
@@ -270,6 +270,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         {
             Constants.Variables.Build.SourceVersionMessage,
             Constants.Variables.Build.DefinitionName,
+            Constants.Variables.Build.SourceVersionAuthor,
             Constants.Variables.System.SourceVersionMessage,
             Constants.Variables.System.DefinitionName,
             Constants.Variables.System.JobDisplayName,

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -427,6 +427,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 public static readonly string SourceBranch = "build.sourcebranch";
                 public static readonly string SourceTfvcShelveset = "build.sourcetfvcshelveset";
                 public static readonly string SourceVersion = "build.sourceversion";
+                public static readonly string SourceVersionAuthor = "build.sourceversionauthor";
                 public static readonly string SourceVersionMessage = "build.sourceVersionMessage";
                 public static readonly string SourcesDirectory = "build.sourcesdirectory";
                 public static readonly string StagingDirectory = "build.stagingdirectory";
@@ -621,6 +622,7 @@ namespace Microsoft.VisualStudio.Services.Agent
                 Build.SourceBranch,
                 Build.SourceTfvcShelveset,
                 Build.SourceVersion,
+                Build.SourceVersionAuthor,
                 Build.SourceVersionMessage,
                 Build.SourcesDirectory,
                 Build.StagingDirectory,

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -241,6 +241,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             message.Variables[Constants.Variables.System.DefinitionName] = "##vso[setVariable]etc4";
             message.Variables[Constants.Variables.Release.ReleaseDefinitionName] = "##vso[setVariable]etc5";
             message.Variables[Constants.Variables.Release.ReleaseEnvironmentName] = "##vso[setVariable]etc6";
+            message.Variables[Constants.Variables.Build.SourceVersionAuthor] = "##vso[setVariable]etc7";
 
             var scrubbedMessage = WorkerUtilities.DeactivateVsoCommandsFromJobMessageVariables(message);
 
@@ -250,6 +251,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
             Assert.Equal("**vso[setVariable]etc4", scrubbedMessage.Variables[Constants.Variables.System.DefinitionName]);
             Assert.Equal("**vso[setVariable]etc5", scrubbedMessage.Variables[Constants.Variables.Release.ReleaseDefinitionName]);
             Assert.Equal("**vso[setVariable]etc6", scrubbedMessage.Variables[Constants.Variables.Release.ReleaseEnvironmentName]);
+            Assert.Equal("**vso[setVariable]etc7", scrubbedMessage.Variables[Constants.Variables.Build.SourceVersionAuthor]);
         }
 
         [Fact]


### PR DESCRIPTION
**Description:** Disable setting any vso-related commands using Build.SourceVersionAuthor variable

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) Y

**Additional Tests Performed:** N