### PR TITLE
Agent CDN - Added Warning in Initialize Phase when new Agent CDN is not reachable - AB#2241315

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -765,7 +765,7 @@ namespace Agent.Sdk.Knob
             new RuntimeKnobSource("ADD_FORCE_CREDENTIALS_TO_GIT_CHECKOUT"),
             new PipelineFeatureSource(nameof(AddForceCredentialsToGitCheckout)),
             new BuiltInDefaultKnobSource("false"));
-      
+
         public static readonly Knob InstallLegacyTfExe = new Knob(
             nameof(InstallLegacyTfExe),
             "If true, the agent will install the legacy versions of TF, vstsom and vstshost",
@@ -786,5 +786,11 @@ namespace Agent.Sdk.Knob
             "Timeout for channel communication between agent listener and worker processes.",
             new EnvironmentKnobSource("PIPELINE_ARTIFACT_ASSOCIATE_TIMEOUT"),
             new BuiltInDefaultKnobSource("900")); // 15 * 60 - Setting the timeout to 15 minutes to account for slowness from azure storage and retries.
+
+        public static readonly Knob AgentCDNConnectivityFailWarning = new Knob(
+            nameof(AgentCDNConnectivityFailWarning),
+            "Show warning message when the Agent CDN Endpoint (download.agent.dev.azure.com) is not reachable. ",
+            new PipelineFeatureSource("AGENT_CDN_CONNECTIVITY_FAIL_WARNING"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -10,6 +10,7 @@
   "AddEnvironmentVMResourceTags": "Environment Virtual Machine resource tags? (Y/N)",
   "AgentAddedSuccessfully": "Successfully added the agent",
   "AgentAlreadyInsideContainer": "Container feature is not supported when agent is already running inside container. Please reference documentation (https://go.microsoft.com/fwlink/?linkid=875268)",
+  "AgentCdnAccessFailWarning": "The Azure Pipelines Agent CDN endpoint is changing to download.agent.dev.azure.com. Please ensure this new endpoint is allowlisted as soon as possible to avoid disruptions or pipeline failures. See https://devblogs.microsoft.com/devops/cdn-domain-url-change-for-agents-in-pipelines/",
   "AgentDoesNotSupportContainerFeatureRhel6": "Agent does not support the container feature on Red Hat Enterprise Linux 6 or CentOS 6.",
   "AgentDowngrade": "Downgrading agent to a lower version. This is usually due to a rollback of the currently published agent for a bug fix. To disable this behavior, set environment variable AZP_AGENT_DOWNGRADE_DISABLED=true before launching your agent.",
   "AgentExit": "Agent will exit shortly for update, should back online within 10 seconds.",


### PR DESCRIPTION
**Issue:** [[Se] Migrate Agent CDN URL from Edgio endpoint to a custom URL](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2241315/)

**Context:** Azure DevOps Agent previously used Edgio CDN with the endpoint `vstsagentpackage.azureedge.net`. As part of Edgio's retirement, the `*.azureedge.net` domain is being decommissioned. To ensure continued availability, we have migrated to an Akamai-backed CDN and are setting up a new endpoint `download.agent.dev.azure.com`.

**Description:** This PR introduces a check in the Initialize Agent Phase to verify the connectivity to the new CDN Endpoint.

**Risk Assessment(**Low**/Medium/High)**: Changes are contained using a Feature Flag.

**Added unit tests:** (Y/N) NA

**Additional Tests Performed:** Testing in progress