### PR TITLE
Updated ADO PR template to not use windows ARM64

### DIFF
--- a/src/Misc/UpdateAgentPackage.template.xml
+++ b/src/Misc/UpdateAgentPackage.template.xml
@@ -82,10 +82,5 @@
         <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
-    <ServicingStep name="Add ARM64 Windows agent package (without Node 6 and Node 10)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
-      <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="win-arm64" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://vstsagentpackage.azureedge.net/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-arm64-<AGENT_VERSION>.zip" />
-      </StepData>
-    </ServicingStep>
   </Steps>
 </ServicingStepGroup>


### PR DESCRIPTION

**Issue:** Updated ADO PR template to not use windows ARM64
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Description:** Updated ADO PR template to not use windows ARM64

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) N

**Additional Tests Performed:** <Add the list of tests Manual or Automated performed for your changes>