### PR TITLE
**DRAFT**: Send secret masking telemetry if opted in to it.

### DIFF
--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Security.Utilities.Core" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Security.Utilities.Core" Version="[1.17.0-g4bafbeaa94]" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Management" Version="4.7.0" />

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -681,6 +681,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AZP_ENABLE_NEW_MASKER_AND_REGEXES"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob SendSecretMaskerTelemetry = new Knob(
+            nameof(SendSecretMaskerTelemetry),
+            "If true, the agent will send telemetry about secret masking",
+            new RuntimeKnobSource("AZP_SEND_SECRET_MASKER_TELEMETRY"),
+            new EnvironmentKnobSource("AZP_SEND_SECRET_MASKER_TELEMETRY"),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob AddDockerInitOption = new Knob(
             nameof(AddDockerInitOption),
             "If true, the agent will create docker container with the --init option.",

--- a/src/Agent.Sdk/SecretMasking/ILoggedSecretMasker.cs
+++ b/src/Agent.Sdk/SecretMasking/ILoggedSecretMasker.cs
@@ -2,14 +2,20 @@
 // Licensed under the MIT License.
 
 using System;
-
+using System.Collections.Generic;
 using Microsoft.TeamFoundation.DistributedTask.Logging;
 
 namespace Agent.Sdk.SecretMasking
 {
     /// <summary>
-    /// Extended ISecretMasker interface that adds support for logging the origin of
-    /// regexes, encoders and literal secret values.
+    /// An action that publishes the given data corresonding to the given
+    /// feature to a telemetry channel. 
+    /// </summary>
+    public delegate void PublishSecretMaskerTelemetryAction(string feature, Dictionary<string, string> data);
+
+    /// <summary>
+    /// Extended ISecretMasker interface that adds support for telemetry and
+    /// logging the origin of regexes, encoders and literal secret values.
     /// </summary>
     public interface ILoggedSecretMasker : ISecretMasker, IDisposable
     {
@@ -19,5 +25,8 @@ namespace Agent.Sdk.SecretMasking
         void AddValue(String value, string origin);
         void AddValueEncoder(ValueEncoder encoder, string origin);
         void SetTrace(ITraceWriter trace);
+
+        bool TelemetryEnabled { get; set; }
+        void PublishTelemetry(PublishSecretMaskerTelemetryAction publishAction);
     }
 }

--- a/src/Agent.Sdk/SecretMasking/LoggedSecretMasker.cs
+++ b/src/Agent.Sdk/SecretMasking/LoggedSecretMasker.cs
@@ -163,5 +163,25 @@ namespace Agent.Sdk.SecretMasking
                 _secretMasker = null;
             }
         }
+
+        public bool TelemetryEnabled
+        {
+            get => _secretMasker is OssSecretMasker ossMasker && ossMasker.TelemetryEnabled;
+            set
+            {
+                if (_secretMasker is OssSecretMasker ossMasker)
+                {
+                    ossMasker.TelemetryEnabled = value;
+                }
+            }
+        }
+
+        public void PublishTelemetry(PublishSecretMaskerTelemetryAction publishAction)
+        {
+            if (_secretMasker is OssSecretMasker ossMasker)
+            {
+                ossMasker.PublishTelemetry(publishAction);
+            }
+        }
     }
 }

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -4,5 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
+    <add key="local" value="D:\Src\security-utilities\bld\nupkg\AnyCPU_Release" />
   </packageSources>
 </configuration>

--- a/src/Test/L0/SecretMaskerTests/LoggedSecretMaskerL0.cs
+++ b/src/Test/L0/SecretMaskerTests/LoggedSecretMaskerL0.cs
@@ -2,16 +2,167 @@
 // Licensed under the MIT License.
 
 using Agent.Sdk.SecretMasking;
-using Microsoft.TeamFoundation.DistributedTask.Logging;
+using Microsoft.Security.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
+using ISecretMasker = Microsoft.TeamFoundation.DistributedTask.Logging.ISecretMasker;
+using VsoSecretMasker = Microsoft.TeamFoundation.DistributedTask.Logging.SecretMasker;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests
 {
     public class OssLoggedSecretMaskerL0 : LoggedSecretMaskerL0
     {
+        private readonly ITestOutputHelper _output;
+
+        public OssLoggedSecretMaskerL0(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         protected override ISecretMasker CreateSecretMasker()
         {
             return new OssSecretMasker();
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void OssLoggedSecretMasker_TelemetryEnabled_ThrowsOnAttemptToDisable()
+        {
+            using var lsm = new LoggedSecretMasker(CreateSecretMasker());
+            Assert.False(lsm.TelemetryEnabled);
+
+            lsm.TelemetryEnabled = true;
+            Assert.True(lsm.TelemetryEnabled);
+
+            Assert.Throws<InvalidOperationException>(() => lsm.TelemetryEnabled = false);
+        }
+
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(OssSecretMasker.MaxTelemetryDetections - 1)]
+        [InlineData(OssSecretMasker.MaxTelemetryDetections)]
+        [InlineData(OssSecretMasker.MaxTelemetryDetections + 1)]
+        [InlineData(2 * OssSecretMasker.MaxTelemetryDetections - 1)]
+        [InlineData(2 * OssSecretMasker.MaxTelemetryDetections)]
+        [InlineData(2 * OssSecretMasker.MaxTelemetryDetections + 1)]
+        public void OssLoggedSecretMasker_TelemetryEnabled_SendsTelemetry(int uniqueCorrelatingIds)
+        {
+            var pattern = new RegexPattern(id: "TEST001/001",
+                                           name: "TestPattern",
+                                           label: "a test",
+                                           DetectionMetadata.HighEntropy,
+                                           pattern: "TEST[0-9]+");
+
+            using var ossMasker = new OssSecretMasker(new[] { pattern });
+            using var lsm = new LoggedSecretMasker(ossMasker) { TelemetryEnabled = true };
+
+            int charsScanned = 0;
+            int stringsScanned = 0;
+            int totalDetections = 0;
+            var correlatingIds = new string[uniqueCorrelatingIds];
+
+            for (int i = 0; i < uniqueCorrelatingIds; i++)
+            {
+                string inputWithSecret = $"Hello TEST{i} World!";
+                lsm.MaskSecrets(inputWithSecret);
+                lsm.MaskSecrets(inputWithSecret + "x");
+
+                string inputWithoutSecret = "Nothing to see here";
+                lsm.MaskSecrets(inputWithoutSecret);
+
+                correlatingIds[i] = RegexPattern.GenerateCrossCompanyCorrelatingId($"TEST{i}");
+                stringsScanned += 3;
+                charsScanned += 2 * inputWithSecret.Length + 1 + inputWithoutSecret.Length;
+                totalDetections += 2;
+            }
+
+            var correlatingIdsToObserve = new HashSet<string>(correlatingIds);
+
+            var telemetry = new List<(string Feature, Dictionary<string, string> Data)>();
+            lsm.PublishTelemetry((feature, data) =>
+            {
+                _output.WriteLine($"Telemetry Event Received: {feature}");
+                _output.WriteLine($"Properties: ({data.Count}):");
+
+                foreach (var (key, value) in data)
+                {
+                    _output.WriteLine($"    {key}: {value}");
+                }
+
+                _output.WriteLine("");
+
+                telemetry.Add((feature, data));
+            });
+
+            int remainder = uniqueCorrelatingIds % OssSecretMasker.MaxDetectionsPerTelemetryEvent;
+            int expectedDetectionEvents = (uniqueCorrelatingIds / OssSecretMasker.MaxDetectionsPerTelemetryEvent) + (remainder == 0 ? 0 : 1);
+
+            bool maxEventsExceeded = expectedDetectionEvents > OssSecretMasker.MaxTelemetryDetectionEvents;
+            if (maxEventsExceeded)
+            {
+                expectedDetectionEvents = OssSecretMasker.MaxTelemetryDetectionEvents;
+            }
+
+            int expectedEvents = expectedDetectionEvents + 1;
+
+            Assert.Equal(expectedEvents, telemetry.Count);
+
+            Dictionary<string, string> mergedDetectionData = new Dictionary<string, string>();
+
+            for (int i = 0; i < expectedDetectionEvents; i++)
+            {
+                var detectionTelemetry = telemetry[i];
+                var detectionData = detectionTelemetry.Data;
+
+                Assert.Equal(detectionTelemetry.Feature, "SecretMaskerDetections");
+
+                if (maxEventsExceeded || remainder == 0 || i < expectedDetectionEvents - 1)
+                {
+                    Assert.Equal(OssSecretMasker.MaxDetectionsPerTelemetryEvent, detectionData.Count);
+                }
+                else
+                {
+                    Assert.Equal(remainder, detectionData.Count);
+                }
+
+                foreach (var (key, value) in detectionData)
+                {
+                    Assert.True(correlatingIdsToObserve.Remove(key));
+                    Assert.Equal("TEST001/001.TestPattern", value);
+                }
+            }
+
+            if (maxEventsExceeded)
+            {
+                Assert.Equal(uniqueCorrelatingIds - OssSecretMasker.MaxTelemetryDetections, correlatingIdsToObserve.Count);
+            }
+            else
+            {
+                Assert.Equal(0, correlatingIdsToObserve.Count);
+            }
+
+            var overallTelemetry = telemetry[telemetry.Count - 1];
+            var overallData = overallTelemetry.Data;
+            Assert.Equal(overallTelemetry.Feature, "SecretMasker");
+            Assert.Equal(SecretMasker.Version.ToString(), overallData["Version"]);
+            Assert.Equal(charsScanned.ToString(CultureInfo.InvariantCulture), overallData["CharsScanned"]);
+            Assert.Equal(stringsScanned.ToString(CultureInfo.InvariantCulture), overallData["StringsScanned"]);
+            Assert.Equal(uniqueCorrelatingIds.ToString(CultureInfo.InvariantCulture), overallData["UniqueCorrelatingIds"]);
+            Assert.True(0.0 <= double.Parse(overallData["ElapsedMaskingTimeInMilliseconds"], CultureInfo.InvariantCulture));
+
+            if (maxEventsExceeded)
+            {
+                Assert.Equal("true", overallData["DetectionDataIsIncomplete"]);
+            }
         }
     }
 
@@ -19,13 +170,33 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
     {
         protected override ISecretMasker CreateSecretMasker()
         {
-            return new SecretMasker();
+            return new VsoSecretMasker();
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void VsoLoggedSecretMasker_TelemetryEnabled_Ignored()
+        {
+            using var lsm = new LoggedSecretMasker(CreateSecretMasker());
+            lsm.TelemetryEnabled = true;
+            Assert.False(lsm.TelemetryEnabled, "Setting TelemetryEnabled to true should be ignored since since VSO masker does not support telemetry.");
         }
     }
 
     public abstract class LoggedSecretMaskerL0
     {
         protected abstract ISecretMasker CreateSecretMasker();
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "SecretMasker")]
+        public void LoggedSecretMasker_TelemetryDisabled_DoesNotPublish()
+        {
+            using var lsm = new LoggedSecretMasker(CreateSecretMasker());
+            Assert.False(lsm.TelemetryEnabled);
+            lsm.PublishTelemetry((_, _) => Assert.True(false, "This should not be called."));
+        }
 
         [Fact]
         [Trait("Level", "L0")]


### PR DESCRIPTION
**Issue:** We would like to have telemetry on secret masking.

**Description:** 
If using the new OSS secret masker and an additional opt-in knob is turned on, then send telemetry about secrets that were masked.

An overall 'SecretMasker' event is sent with statistics such as total detections and elapsed time. Additional 'SecretMaskerDetections' events are sent mapping C3ID to pattern monikers. These are batched to keep event sizes capped and the total number of events are also capped.

**Risk Assessment (Low/Medium/High)**: Low. Behind opt-in flag.

**Added unit tests (Y/N):** Y

**Additional Tests Performed:** None yet, but will test end-to-end before taking out of draft.