### PR TITLE
add windows 2019 to the script checking for jobs with retired images

### DIFF
--- a/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
+++ b/tools/FindPipelinesUsingRetiredImages/QueryJobHistoryForRetiredImages.ps1
@@ -17,7 +17,7 @@ $vstsAuthHeader = @{"Authorization"="Basic $base64authinfo"}
 $allHeaders = $vstsAuthHeader + @{"Content-Type"="application/json"; "Accept"="application/json"}
 
 # List of deprecated images
-[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu18', 'ubuntu-18.04', 'Ubuntu20', 'ubuntu-20.04', 'ubuntu 20.04', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017'
+[string[]] $deprecatedImages = 'macOS-10.15', 'macOS 10.15', 'MacOS 1015', 'MacOS-1015', 'Ubuntu18', 'ubuntu-18.04', 'Ubuntu20', 'ubuntu-20.04', 'ubuntu 20.04', 'VS2017', 'vs2017 win2016', 'vs2017-win2016', 'windows-2016-vs2017', 'windows-2019'
 
 try
 {


### PR DESCRIPTION

**Issue:** Add Windows 2019 to the list of deprecated images
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Description:**  We are adding Window 2019 image to the list of deprecated images in the script.

**Risk Assesment(Low/Medium/High)**: low
**Added unit tests:** (Y/N) N

**Additional Tests Performed:** <Add the list of tests Manual or Automated performed for your changes>