### PR TITLE
Agent ARM64 - Enabled Agent Windows ARM64 Build - AB#2143637

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -44,7 +44,7 @@ parameters:
   default: true
 - name: win_arm64
   type: boolean
-  default: false
+  default: true
 - name: linux_x64
   type: boolean
   default: true

--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -17,7 +17,7 @@ parameters:
 - name: win_arm64
   type: boolean
   displayName: Windows (ARM64)
-  default: false
+  default: true
 - name: linux_x64
   type: boolean
   displayName: Linux (x64)

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -5,6 +5,7 @@
 | -------------- | ------- | ------- |
 | Windows x64    | [vsts-agent-win-x64-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86    | [vsts-agent-win-x86-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| Windows ARM64 (beta)  | [vsts-agent-win-arm64-<AGENT_VERSION>.zip](https:///download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-win-arm64-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64      | [vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | macOS ARM64    | [vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64      | [vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
@@ -27,6 +28,13 @@ C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO
 ``` bash
 C:\> mkdir myagent && cd myagent
 C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\vsts-agent-win-x86-<AGENT_VERSION>.zip", "$PWD")
+```
+
+## Windows ARM64
+
+``` bash
+C:\> mkdir myagent && cd myagent
+C:\myagent> Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$HOME\Downloads\vsts-agent-win-arm64-<AGENT_VERSION>.zip", "$PWD")
 ```
 
 ## macOS x64
@@ -91,6 +99,7 @@ See [notes](docs/node6.md) on Node version support for more details.
 | ----------- | ------- | ------- |
 | Windows x64 | [pipelines-agent-win-x64-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x64-<AGENT_VERSION>.zip) | <HASH> |
 | Windows x86 | [pipelines-agent-win-x86-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip) | <HASH> |
+| Windows ARM64 (beta) | [pipelines-agent-win-arm64-<AGENT_VERSION>.zip](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip) | <HASH> |
 | macOS x64   | [pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-osx-x64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | macOS ARM64 | [pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-osx-arm64-<AGENT_VERSION>.tar.gz) | <HASH> |
 | Linux x64   | [pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz](https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-x64-<AGENT_VERSION>.tar.gz) | <HASH> |

--- a/src/Misc/UpdateAgentPackage.template.xml
+++ b/src/Misc/UpdateAgentPackage.template.xml
@@ -82,5 +82,10 @@
         <AddTaskPackageData packageType="pipelines-agent" platform="win-x86" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-x86-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-x86-<AGENT_VERSION>.zip" />
       </StepData>
     </ServicingStep>
+    <ServicingStep name="Add ARM64 Windows agent package (without Node 6 and Node 10)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
+      <StepData>
+        <AddTaskPackageData packageType="pipelines-agent" platform="win-arm64" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-win-arm64-<AGENT_VERSION>.zip" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-win-arm64-<AGENT_VERSION>.zip" />
+      </StepData>
+    </ServicingStep>
   </Steps>
 </ServicingStepGroup>


### PR DESCRIPTION
### **Context**
Agent for Windows ARM64 was implemented in Nov 2024 but further testing and rollout was due. This PR enables the Windows ARM64 build of Agent Binary.

---

### **Description**
1. Updated the Release Notes and Servicing Templates.
2. Updated the CI pipeline to generate the Windows ARM 64 Agent Build.

---

### **Risk Assessment** (Low / Medium / High)  
Low. Only generates the Windows ARM 64 build as a standalone binary without impacting any of the other variants.

---

### **Unit Tests Added or Updated** (Yes / No)  
NA

---

### **Additional Testing Performed**
1. Changes in this PR have been tested by building the Agent repo locally.
2. Self-hosted Windows ARM 64 Agent pool will be created where all the pipeline tasks will be tested.

### Related PR

1. [[Agent] Support for Windows ARM 64 - AB#2143637](https://github.com/microsoft/azure-pipelines-agent/pull/5021)