### PR TITLE
Agent Release - Replaced Download .NET Vanity URL with Actual URL

### DIFF
--- a/src/dev.sh
+++ b/src/dev.sh
@@ -79,7 +79,7 @@ restore_dotnet_install_script() {
     DOTNET_INSTALL_SCRIPT_PATH="./Misc/${DOTNET_INSTALL_SCRIPT_NAME}"
 
     if [[ ! -e "${DOTNET_INSTALL_SCRIPT_PATH}" ]]; then
-        curl -sSL "https://builds.dotnet.microsoft.com/v1/${DOTNET_INSTALL_SCRIPT_NAME}" -o "${DOTNET_INSTALL_SCRIPT_PATH}"
+        curl -sSL "https://builds.dotnet.microsoft.com/dotnet/scripts/v1/${DOTNET_INSTALL_SCRIPT_NAME}" -o "${DOTNET_INSTALL_SCRIPT_PATH}"
     fi
 }
 

--- a/src/dev.sh
+++ b/src/dev.sh
@@ -79,7 +79,7 @@ restore_dotnet_install_script() {
     DOTNET_INSTALL_SCRIPT_PATH="./Misc/${DOTNET_INSTALL_SCRIPT_NAME}"
 
     if [[ ! -e "${DOTNET_INSTALL_SCRIPT_PATH}" ]]; then
-        curl -sSL "https://dot.net/v1/${DOTNET_INSTALL_SCRIPT_NAME}" -o "${DOTNET_INSTALL_SCRIPT_PATH}"
+        curl -sSL "https://builds.dotnet.microsoft.com/v1/${DOTNET_INSTALL_SCRIPT_NAME}" -o "${DOTNET_INSTALL_SCRIPT_PATH}"
     fi
 }
 


### PR DESCRIPTION
### **Context**
Updated dot net download URL in pipelines. dot.net is redirecting to https://builds.dotnet.microsoft.com/ only so this is directly replacing the URL with the actual URL

---

### **Description**
Updated dot net download URL in pipelines

---

### **Risk Assessment** (Low / Medium / High)  
Low [This change is only updating the release pipeline]

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
Validate this URL manually
