### PR TITLE
Agent CDN - Added Warning in Initialize Phase when new Agent CDN is not reachable - AB#2241315

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -786,7 +786,7 @@ namespace Agent.Sdk.Knob
             "Timeout for channel communication between agent listener and worker processes.",
             new EnvironmentKnobSource("PIPELINE_ARTIFACT_ASSOCIATE_TIMEOUT"),
             new BuiltInDefaultKnobSource("900")); // 15 * 60 - Setting the timeout to 15 minutes to account for slowness from azure storage and retries.
-        
+
         public static readonly Knob RollbackToDefaultTfExe = new Knob(
             nameof(RollbackToDefaultTfExe),
             "If true, the agent will install the default versions of TF, vstsom",
@@ -799,6 +799,8 @@ namespace Agent.Sdk.Knob
             nameof(AgentCDNConnectivityFailWarning),
             "Show warning message when the Agent CDN Endpoint (download.agent.dev.azure.com) is not reachable. ",
             new RuntimeKnobSource("AGENT_CDN_CONNECTIVITY_FAIL_WARNING"),
-            new EnvironmentKnobSource("AGENT_CDN_CONNECTIVITY_FAIL_WARNING"));
+            new EnvironmentKnobSource("AGENT_CDN_CONNECTIVITY_FAIL_WARNING"),
+            new PipelineFeatureSource("AgentCDNConnectivityFailWarning"),
+            new BuiltInDefaultKnobSource("false"));
     }
 }

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -794,5 +794,11 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("ROLLBACK_TO_DEFAULT_TF_EXE"),
             new PipelineFeatureSource("RollbackToDefaultTfExe"),
             new BuiltInDefaultKnobSource("false"));
+
+        public static readonly Knob AgentCDNConnectivityFailWarning = new Knob(
+            nameof(AgentCDNConnectivityFailWarning),
+            "Show warning message when the Agent CDN Endpoint (download.agent.dev.azure.com) is not reachable. ",
+            new RuntimeKnobSource("AGENT_CDN_CONNECTIVITY_FAIL_WARNING"),
+            new EnvironmentKnobSource("AGENT_CDN_CONNECTIVITY_FAIL_WARNING"));
     }
 }

--- a/src/Agent.Sdk/Util/PlatformUtil.cs
+++ b/src/Agent.Sdk/Util/PlatformUtil.cs
@@ -18,6 +18,8 @@ using Microsoft.Win32;
 using Newtonsoft.Json;
 using System.ServiceProcess;
 using Agent.Sdk.Util;
+using System.Net.Http;
+using System.Net;
 
 namespace Agent.Sdk
 {
@@ -438,6 +440,47 @@ namespace Agent.Sdk
             }
             return isAzureVM;
         }
+
+        // The URL of the agent package hosted on Azure CDN
+        private const string _agentPackageUri = "https://download.agent.dev.azure.com/agent/4.252.0/vsts-agent-win-x64-4.252.0.zip";
+
+#nullable enable
+        /// <summary>
+        /// Checks if the agent CDN endpoint is accessible by sending an HTTP HEAD request.
+        /// </summary>
+        /// <param name="webProxy">
+        /// Optional <see cref="IWebProxy"/> to route the request through a proxy. If null, the system default proxy settings are used.
+        /// </param>
+        /// <remarks>
+        /// - Returns <c>true</c> if the endpoint responds with a successful (2xx) status code.
+        /// - Returns <c>false</c> if the endpoint responds with a non-success status code (4xx, 5xx).
+        /// - Throws exceptions (e.g., timeout, DNS failure) if the request cannot be completed.
+        /// - Uses a 5-second timeout to avoid hanging.
+        /// - All HTTP resources are properly disposed after the request completes.
+        /// </remarks>
+        /// <returns><c>true</c> if the endpoint is reachable and returns success; otherwise, <c>false</c>.</returns>
+        public static async Task<bool> IsAgentCdnAccessibleAsync(IWebProxy? webProxy = null)
+        {
+            // Configure the HttpClientHandler with the proxy if provided
+            using HttpClientHandler handler = new()
+            {
+                Proxy = webProxy,
+                UseProxy = webProxy is not null
+            };
+            handler.CheckCertificateRevocationList = true; // Check for certificate revocation
+            using HttpClient httpClient = new(handler);
+
+            // Construct a HEAD request to avoid downloading the full file
+            using HttpRequestMessage request = new(HttpMethod.Head, _agentPackageUri);
+
+            // Apply a 5-second timeout to prevent hanging
+            using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+
+            // Send the request and return whether the response status indicates success
+            HttpResponseMessage response = await httpClient.SendAsync(request, cts.Token);
+            return response.IsSuccessStatusCode;
+        }
+#nullable disable
     }
 
 #pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -10,6 +10,7 @@
   "AddEnvironmentVMResourceTags": "Environment Virtual Machine resource tags? (Y/N)",
   "AgentAddedSuccessfully": "Successfully added the agent",
   "AgentAlreadyInsideContainer": "Container feature is not supported when agent is already running inside container. Please reference documentation (https://go.microsoft.com/fwlink/?linkid=875268)",
+  "AgentCdnAccessFailWarning": "Action Required: Azure Pipelines Agent cannot reach the new CDN URL. Allowlist 'download.agent.dev.azure.com' now to prevent pipeline failures. Details: https://devblogs.microsoft.com/devops/cdn-domain-url-change-for-agents-in-pipelines/",
   "AgentDoesNotSupportContainerFeatureRhel6": "Agent does not support the container feature on Red Hat Enterprise Linux 6 or CentOS 6.",
   "AgentDowngrade": "Downgrading agent to a lower version. This is usually due to a rollback of the currently published agent for a bug fix. To disable this behavior, set environment variable AZP_AGENT_DOWNGRADE_DISABLED=true before launching your agent.",
   "AgentExit": "Agent will exit shortly for update, should back online within 10 seconds.",


### PR DESCRIPTION
### **Issue**  
[[Se] Migrate Agent CDN URL from Edgio endpoint to a custom URL](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2241315/)

---

### **Context**  
The Azure DevOps Agent previously relied on Edgio CDN (`vstsagentpackage.azureedge.net`) for binary distribution. As Edgio is being retired and the `*.azureedge.net` domain is scheduled for decommissioning, we are migrating to a new Akamai-backed CDN endpoint: `download.agent.dev.azure.com`. This ensures continued availability and aligns with our domain strategy.

---

### **Description of Changes**  
This PR adds a connectivity check during the *Initialize Agent* phase to verify reachability of the new CDN endpoint (`download.agent.dev.azure.com`). A warning will be logged if the agent cannot connect.

---

### **Risk Assessment:** Low  
The change is guarded behind a feature flag to ensure safe rollout and minimal impact.

---

### **Unit Tests Added:** N/A

---

### **Manual Testing Performed**

#### ✅ **Warning when CDN is unreachable**
**Steps:**
1. Set up a self-hosted agent.
2. Simulate CDN unavailability by adding `127.0.0.1 download.agent.dev.azure.com` to the `hosts` file.
3. Run a pipeline on the agent.
4. Validate that a warning message appears in the pipeline logs.  
   ![Unreachable Warning](https://github.com/user-attachments/assets/a7163d59-0800-4c67-b870-f5c6a51eeee3)

---

#### ✅ **Routing via Proxy (when configured)**
**Steps:**
1. Set up a self-hosted agent behind a proxy (e.g., Fiddler).
2. Restrict all outbound traffic from `Agent.Listener` and `Agent.Worker` to allow only proxy-based routing:
```bash
netsh advfirewall firewall add rule name="Block Agent.Listener Outbound" dir=out action=block program="C:\agent\_layout\win-x64\bin\Agent.Listener.exe" enable=yes
netsh advfirewall firewall add rule name="Block Agent.Worker Outbound" dir=out action=block program="C:\agent\_layout\win-x64\bin\Agent.Worker.exe" enable=yes
````
3. Allow `Agent.Listener` and the `Agent.Worker` processes to only access the Local Proxy (127.0.0.1)
```bash
netsh advfirewall firewall add rule name="Allow Agent.Listener to Proxy" dir=out action=allow program="C:\agent\_layout\win-x64\bin\Agent.Listener.exe" remoteip=127.0.0.1 enable=yes
netsh advfirewall firewall add rule name="Allow Agent.Worker to Proxy" dir=out action=allow program="C:\agent\_layout\win-x64\bin\Agent.Worker.exe" remoteip=127.0.0.1 enable=yes
````
3. Run a pipeline and ensure traffic routes through the proxy:
   ![Proxy Routing](https://github.com/user-attachments/assets/5ae40617-262f-45e2-8880-bc3ff690631e)
4. Confirm no warning is shown in pipeline logs:
   ![No Warning via Proxy](https://github.com/user-attachments/assets/318f0bac-8e4e-4b6c-8938-8e059dc32949)