### PR TITLE
feat: ensure env.sh does not fail with unboud var

### DIFF
--- a/src/Misc/layoutroot/env.sh
+++ b/src/Misc/layoutroot/env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +u
 
 varCheckList=(
     'LANG'


### PR DESCRIPTION
If -u is set where this env script is sourced from, it can error out with `./env.sh: line 34: !checkVar: unbound variable`

### **Context**
Ado setup breaks when called from a parent with -u set
---

### **Description**
Set +u so the env.sh script does not error with it`s own onboad var
---

### **Risk Assessment** (Low / Medium / High)  
Low. Unboand var check was not set in the script in the first place and impact is very limited
---

### **Unit Tests Added or Updated** (Yes / No)  
NO

---

### **Additional Testing Performed**
verified with manual flag setting and running agent
