### PR TITLE
Removing .net6 option and input box for Derived from version

### DIFF
--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -29,7 +29,6 @@ parameters:
   type: string
   default: net8.0
   values:
-  - net6.0
   - net8.0
 - name: derivedFrom
   type: string

--- a/.vsts.release.yml
+++ b/.vsts.release.yml
@@ -30,10 +30,14 @@ parameters:
   default: net8.0
   values:
   - net8.0
+  
 - name: derivedFrom
   type: string
   displayName: Derived From Version
   default: 'lastMinorRelease'
+  values:
+  - 'lastMinorRelease'
+  
 - name: skipTests
   type: boolean
   default: false


### PR DESCRIPTION
### **Context**
Removing .net6 option and input box for Derived from version
---

### **Description**
Removing .net6 option int the Target Framework.
Removing input box for Derived from version because it should not change (from lastMinorRelease) and making it default value.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
Manual testing was performed

--- 

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Documentation Changes Required** (Yes/No)
Yes. Should inform .net6 is removed.

---
### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Yes. Rollback plan is documented. 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.


**New Pipeline:**

<img width="715" height="1423" alt="Screenshot 2025-07-11 170030" src="https://github.com/user-attachments/assets/ec92c8b2-22cc-48b2-a670-f9f9cbee64af" />


