### PR TITLE
Moved vso-task-lib download to runtime

### DIFF
--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -107,6 +107,23 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
 
             if (!PlatformUtil.RunningOnWindows && !AgentKnobs.IgnoreVSTSTaskLib.GetValue(ExecutionContext).AsBoolean())
             {
+                Dictionary<string, string> telemetryData = new Dictionary<string, string>
+                {
+                    { "JobId", ExecutionContext.Variables.System_JobId.ToString()},
+                    { "PlanId", ExecutionContext.Variables.Get(Constants.Variables.System.PlanId)},
+                    { "AgentName", ExecutionContext.Variables.Get(Constants.Variables.Agent.Name)},
+                    { "MachineName", ExecutionContext.Variables.Get(Constants.Variables.Agent.MachineName)},
+                    { "AgentVersion", ExecutionContext.Variables.Get(Constants.Variables.Agent.Version)},
+                    { "IsSelfHosted", ExecutionContext.Variables.Get(Constants.Variables.Agent.IsSelfHosted)},
+                    { "IsAzureVM", ExecutionContext.Variables.Get(Constants.Variables.System.IsAzureVM)},
+                    { "IsDockerContainer", ExecutionContext.Variables.Get(Constants.Variables.System.IsDockerContainer)},
+                    { "VsoTaskLibUsed", "true" },
+                    { "Platform", PlatformUtil.HostOS.ToString() }
+                };
+                ExecutionContext.PublishTaskRunnerTelemetry(telemetryData);
+
+                await VsoTaskLibManager.DownloadVsoTaskLibAsync(ExecutionContext);
+                
                 // Ensure compat vso-task-lib exist at the root of _work folder
                 // This will make vsts-agent work against 2015 RTM/QU1 TFS, since tasks in those version doesn't package with task lib
                 // Put the 0.5.5 version vso-task-lib into the root of _work/node_modules folder, so tasks are able to find those lib.

--- a/src/Agent.Worker/VsoTaskLibManager.cs
+++ b/src/Agent.Worker/VsoTaskLibManager.cs
@@ -1,0 +1,127 @@
+using Microsoft.VisualStudio.Services.Agent.Util;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Agent.Sdk;
+using Agent.Sdk.Knob;
+
+namespace Microsoft.VisualStudio.Services.Agent.Worker
+{
+    public static class VsoTaskLibManager
+    {
+        /// <summary>
+        /// Downloads and installs vso-task-lib at runtime if not already present
+        /// </summary>
+        /// <param name="executionContext">The execution context</param>
+        /// <returns>Task representing the async operation</returns>
+        public static async Task DownloadVsoTaskLibAsync(IExecutionContext executionContext)
+        {
+            ArgUtil.NotNull(executionContext, nameof(executionContext));
+            string externalsPath = Path.Combine(executionContext.GetVariableValueOrDefault("Agent.HomeDirectory"), Constants.Path.ExternalsDirectory);
+            ArgUtil.NotNull(externalsPath, nameof(externalsPath));
+
+            string vsoTaskLibExternalsPath = Path.Combine(externalsPath, "vso-task-lib");
+            var retryOptions = new RetryOptions() { CurrentCount = 0, Limit = 3 };
+
+            if (!Directory.Exists(vsoTaskLibExternalsPath))
+            {
+                const string vsoTaskLibDownloadUrl = "https://vstsagenttools.blob.core.windows.net/tools/vso-task-lib/0.5.5/vso-task-lib.tar.gz";
+                string tempVsoTaskLibDirectory = Path.Combine(externalsPath, "vso-task-lib_download_temp");
+
+                await DownloadAsync(executionContext, vsoTaskLibDownloadUrl, tempVsoTaskLibDirectory, vsoTaskLibExternalsPath, retryOptions);
+            }
+            else
+            {
+                executionContext.Debug($"vso-task-lib download already exists at {vsoTaskLibExternalsPath}.");
+            }
+        }
+
+        public static async Task DownloadAsync(IExecutionContext executionContext, string blobUrl, string tempDirectory, string extractPath, IRetryOptions retryOptions)
+        {
+            Directory.CreateDirectory(tempDirectory);
+            Directory.CreateDirectory(extractPath);
+            string downloadPath = Path.ChangeExtension(Path.Combine(tempDirectory, "download"), ".tar.gz");
+            string toolName = new DirectoryInfo(extractPath).Name;
+
+            const int timeout = 180;
+            const int bufferSize = 4096;
+            const int retryDelay = 10000;
+
+            using var downloadCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+            using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(downloadCts.Token, executionContext.CancellationToken);
+            var cancellationToken = linkedTokenSource.Token;
+
+            for (; retryOptions.CurrentCount < retryOptions.Limit; retryOptions.CurrentCount++)
+            {
+                try
+                {
+                    executionContext.Debug($"Downloading {toolName} (attempt {retryOptions.CurrentCount + 1}/{retryOptions.Limit}).");
+                    using var httpClient = new HttpClient();
+                    using var stream = await httpClient.GetStreamAsync(blobUrl, cancellationToken);
+                    using var fs = new FileStream(downloadPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize, true);
+                    await stream.CopyToAsync(fs, cancellationToken);
+                    executionContext.Debug($"Finished downloading {toolName}.");
+                    await fs.FlushAsync(cancellationToken);
+                    ExtractTarGz(downloadPath, extractPath, executionContext, toolName);
+                    File.WriteAllText(Path.ChangeExtension(downloadPath, ".completed"), DateTime.UtcNow.ToString());
+                    executionContext.Debug($"{toolName} has been extracted and cleaned up");
+                    break;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    executionContext.Debug($"{toolName} download has been cancelled.");
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    if (retryOptions.CurrentCount + 1 == retryOptions.Limit)
+                    {
+                        IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
+                        executionContext.Error($"Retry limit for {toolName} download has been exceeded.");
+                        executionContext.Error(ex);
+                        return;
+                    }
+                    executionContext.Debug($"Failed to download {toolName}: {ex.Message}");
+                    executionContext.Debug($"Retry {toolName} download in 10 seconds.");
+                    await Task.Delay(retryDelay, cancellationToken);
+                }
+            }
+            IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
+            executionContext.Debug($"{toolName} download directory has been cleaned up.");
+        }
+
+        /// <summary>
+        /// Extracts a .tar.gz file to the specified directory using the tar command.
+        /// </summary>
+        private static void ExtractTarGz(string tarGzPath, string extractPath, IExecutionContext executionContext, string toolName)
+        {
+            Directory.CreateDirectory(extractPath);
+            executionContext.Debug($"Extracting {toolName} using tar...");
+            using (var process = new System.Diagnostics.Process
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "tar",
+                    Arguments = $"-xzf \"{tarGzPath}\" -C \"{extractPath}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            })
+            {
+                process.Start();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    var error = process.StandardError.ReadToEnd();
+                    executionContext.Error($"tar extraction failed: {error}");
+                    throw new Exception($"tar extraction failed: {error}");
+                }
+            }
+        }
+    }
+}

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -235,8 +235,6 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
 else
     # Download external tools for Linux and OSX.
 
-    acquireExternalTool "$CONTAINER_URL/vso-task-lib/0.5.5/vso-task-lib.tar.gz" vso-task-lib
-
     if [[ "$PACKAGERUNTIME" == "osx-arm64" ]]; then
         ARCH="darwin-x64"
         if [[ "$INCLUDE_NODE6" == "true" ]]; then


### PR DESCRIPTION
### **Context**
Agent code has few vulnerabilities due to vso-task-lib packaging few old minimist and shelljs packages
moving vso-task-lib loading to run time to avoid these CVEs for users not having custom task dependent on these  
📌 [AB#2301251](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2301251)

---

### **Description**
Agent code has few vulnerabilities due to vso-task-lib packaging few old minimist and shelljs pacakages
moving vso-task-lib loading to run time to avoid these CVEs for users not having custom task depdendent on these  
CVE-2022-0144
CVE-2022-3517
CVE-2017-18077

---

### **Risk Assessment** (Low)  
Moving the dependency to load from build time to run time, as this dependency is not required till NodeHandler is defined this is a safe place
---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
Manually triggered pipelines and validate the folder is available at desired location for tasks using NodeHandler

--- 

### **Change Behind Feature Flag** (Yes / No)
No (the original change to use these files is already behind FF, moving this as well in that FF condition

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
Na

---
### **Logging Added/Updated** (Yes/No)
Yes

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
Enable the feature flag

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes