### PR TITLE
Enabling the warning when agent runs in PowerShell core using CheckPsModulesLocations knob

### DIFF
--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -359,14 +359,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
 
                 var featureFlagProvider = HostContext.GetService<IFeatureFlagProvider>();
                 var checkPsModulesFeatureFlag = await featureFlagProvider.GetFeatureFlagAsync(HostContext, "DistributedTask.Agent.CheckPsModulesLocations", Trace);
-                if (checkPsModulesFeatureFlag?.EffectiveState == "On")
-                {
-                    Trace.Info("checkPsModulesFeatureFlag is enabled");
-                }
-                else
-                {
-                    Trace.Info("checkPsModulesFeatureFlag is disabled");
-                }
+
                 if (PlatformUtil.RunningOnWindows && checkPsModulesFeatureFlag?.EffectiveState == "On")
                 {
                     string psModulePath = Environment.GetEnvironmentVariable("PSModulePath");

--- a/src/Agent.Listener/Agent.cs
+++ b/src/Agent.Listener/Agent.cs
@@ -19,7 +19,7 @@ using Microsoft.TeamFoundation.TestClient.PublishTestResults.Telemetry;
 using Microsoft.VisualStudio.Services.Agent.Listener.Telemetry;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Agent.Sdk.Knob;
+using Agent.Listener.Configuration;
 
 namespace Microsoft.VisualStudio.Services.Agent.Listener
 {
@@ -357,7 +357,17 @@ namespace Microsoft.VisualStudio.Services.Agent.Listener
             {
                 Trace.Info(nameof(RunAsync));
 
-                if (PlatformUtil.RunningOnWindows && AgentKnobs.CheckPsModulesLocations.GetValue(HostContext).AsBoolean())
+                var featureFlagProvider = HostContext.GetService<IFeatureFlagProvider>();
+                var checkPsModulesFeatureFlag = await featureFlagProvider.GetFeatureFlagAsync(HostContext, "DistributedTask.Agent.CheckPsModulesLocations", Trace);
+                if (checkPsModulesFeatureFlag?.EffectiveState == "On")
+                {
+                    Trace.Info("checkPsModulesFeatureFlag is enabled");
+                }
+                else
+                {
+                    Trace.Info("checkPsModulesFeatureFlag is disabled");
+                }
+                if (PlatformUtil.RunningOnWindows && checkPsModulesFeatureFlag?.EffectiveState == "On")
                 {
                     string psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
                     bool containsPwshLocations = PsModulePathUtil.ContainsPowershellCoreLocations(psModulePath);

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -770,6 +770,7 @@ namespace Agent.Sdk.Knob
         public static readonly Knob CheckPsModulesLocations = new Knob(
             nameof(CheckPsModulesLocations),
             "Checks if the PSModulePath environment variable contains locations specific to PowerShell Core.",
+            new RuntimeKnobSource("DistributedTask.Agent.CheckPsModulesLocations"),
             new EnvironmentKnobSource("AZP_AGENT_CHECK_PSMODULES_LOCATIONS"),
             new BuiltInDefaultKnobSource("false"));
 

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -303,9 +303,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         [SupportedOSPlatform("windows")]
         protected bool PsModulePathContainsPowershellCoreLocations()
         {
-            bool checkLocationsKnob = AgentKnobs.CheckPsModulesLocations.GetValue(HostContext).AsBoolean();
+            bool checkLocationsKnob = AgentKnobs.CheckPsModulesLocations.GetValue(ExecutionContext).AsBoolean();
 
             bool isPwshCore = Inputs.TryGetValue("pwsh", out string pwsh) && StringUtil.ConvertToBoolean(pwsh);
+            Trace.Info($"PsModulePathContainsPowershellCoreLocations- Windows: {PlatformUtil.RunningOnWindows}, knob: {checkLocationsKnob}, pwshCore: {isPwshCore}");
 
             if (!PlatformUtil.RunningOnWindows || !checkLocationsKnob || isPwshCore)
             {

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -306,7 +306,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             bool checkLocationsKnob = AgentKnobs.CheckPsModulesLocations.GetValue(ExecutionContext).AsBoolean();
 
             bool isPwshCore = Inputs.TryGetValue("pwsh", out string pwsh) && StringUtil.ConvertToBoolean(pwsh);
-            Trace.Info($"PsModulePathContainsPowershellCoreLocations- Windows: {PlatformUtil.RunningOnWindows}, knob: {checkLocationsKnob}, pwshCore: {isPwshCore}");
 
             if (!PlatformUtil.RunningOnWindows || !checkLocationsKnob || isPwshCore)
             {


### PR DESCRIPTION
### **Context**
  When the self-hosted agent is run in the PowerShell core a warning is shown on terminal that PowerShell based tasks will give an error. A similar error is shown on the pipeline when PowerShell based tasks are present.

---

### **Description**
When agent is hosted from PowerShell core the warning (that PowerShell tasks won't run on pipeline) is not shown until environment variable "AZP_AGENT_CHECK_PSMODULES_LOCATIONS" is set true manually. But now it will be shown. This done by setting FF ON for "DistributedTask.Agent.CheckPsModulesLocations", from the server side. And adding runtime knob for "CheckPsModulesLocations" so that an error is shown on pipeline also.

---

### **Risk Assessment** (Low)  
Low risk - adds warning functionality, doesn't change task execution behaviour.

---

### **Unit Tests Added or Updated** (No)  
No

---

### **Additional Testing Performed**
Manual testing done on some PowerShell based tasks to check whether warning is shown or not. 

--- 

### **Change Behind Feature Flag** (Yes)
Runtime knob is added for CheckPsModulesLocations so that an error is shown on pipeline why pipeline is failing.

---

### **Tech Design / Approach**
ExecutionContext provides runtime variable access needed for knob evaluation, unlike HostContext.

---

### **Documentation Changes Required** (No)
Internal warning system, no user docs needed.

---
### **Logging Added/Updated** (No)
No

--- 

### **Telemetry Added/Updated** (No) 
Uses existing logging infrastructure.

---

### **Rollback Scenario and Process** (Yes)
Disable feature flag to turn off warning system.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

PowerShell core:
<img width="1288" height="144" alt="image" src="https://github.com/user-attachments/assets/570dfbb9-9442-47e9-b2a8-09e3d53edcbc" />

Pipeline: 
<img width="1277" height="391" alt="image" src="https://github.com/user-attachments/assets/e5117edc-b857-41f0-ac73-3af47c7be940" />
