### PR TITLE
CG  - Update cmdLine task

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -301,7 +301,7 @@ if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then
     # cmdline task
     acquireExternalTool "$CONTAINER_URL/l1Tasks/d9bafed4-0b18-4f58-968d-86655b4d2ce9.zip" "Tasks" false dont_uncompress
     # cmdline node10 task
-    acquireExternalTool "$CONTAINER_URL/l1Tasks/f9bafed4-0b18-4f58-968d-86655b4d2ce9.zip" "Tasks" false dont_uncompress
+    acquireExternalTool "$CONTAINER_URL/l1Tasks/b9bafed4-0b18-4f58-968d-86655b4d2ce9.zip" "Tasks" false dont_uncompress
 
     # with the current setup of this package there are backslashes so it fails to extract on non-windows at runtime
     # we may need to fix this in the Agent

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -148,9 +148,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             {
                 Reference = new TaskStepDefinitionReference
                 {
-                    Id = Guid.Parse("f9bafed4-0b18-4f58-968d-86655b4d2ce9"),
+                    Id = Guid.Parse("b9bafed4-0b18-4f58-968d-86655b4d2ce9"),
                     Name = "CmdLine",
-                    Version = "2.201.1"
+                    Version = "2.250.1"
                 },
                 Name = "CmdLine",
                 DisplayName = "CmdLine",


### PR DESCRIPTION
### **Context**
Update cmdLine task to resolve form-data CG alert

---

### **Description**
CmdLine task 2.201.1 used a vulnerable version of form-data. Updating it to latest version 2.250.1 that does not use any vulnerable version of form-data
Associated WI: [#AB2303390](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2303390/?view=edit)
[L1tests](https://mseng.visualstudio.com/AzureDevOps/_git/CIPlat.Externals/pullrequest/868009)

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
Updated L1testBase with new task zip file

--- 

### **Change Behind Feature Flag** (Yes / No)
_Can this change be behine feature flag, if not why?_

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Rollback Scenario and Process** (Yes/No)
Please revert PR to revert changes.
