### PR TITLE
TFVC auth issues fix on Win11 | Add TF version 17

### DIFF
--- a/src/Agent.Plugins/TFCliManager.cs
+++ b/src/Agent.Plugins/TFCliManager.cs
@@ -38,9 +38,26 @@ namespace Agent.Plugins.Repository
 
         public static readonly int RetriesOnFailure = 3;
 
-        private string TfPath => AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean()
-            ? Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf-legacy")
-            : Path.Combine(ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", "tf");
+        private string TfPath
+        {
+            get
+            {
+                string agentHomeDirectory = ExecutionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value;
+                
+                if (AgentKnobs.UseLatestTfExe.GetValue(ExecutionContext).AsBoolean())
+                {
+                    return Path.Combine(agentHomeDirectory, "externals", "tf-latest");
+                }
+                else if (AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean())
+                {
+                    return Path.Combine(agentHomeDirectory, "externals", "tf-legacy");
+                }
+                else
+                {
+                    return Path.Combine(agentHomeDirectory, "externals", "tf");
+                }
+            }
+        }
 
         public string FilePath => Path.Combine(TfPath, "tf.exe");
 

--- a/src/Agent.Plugins/TfsVCSourceProvider.cs
+++ b/src/Agent.Plugins/TfsVCSourceProvider.cs
@@ -101,7 +101,19 @@ namespace Agent.Plugins.Repository
             if (PlatformUtil.RunningOnWindows)
             {
                 // Set TFVC_BUILDAGENT_POLICYPATH
-                string tfDirectoryName = AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean() ? "tf-legacy" : "tf";
+                string tfDirectoryName;
+                if (AgentKnobs.UseLatestTfExe.GetValue(executionContext).AsBoolean())
+                {
+                    tfDirectoryName = "tf-latest";
+                }
+                else if (AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean())
+                {
+                    tfDirectoryName = "tf-legacy";
+                }
+                else
+                {
+                    tfDirectoryName = "tf";
+                }
                 string policyDllPath = Path.Combine(executionContext.Variables.GetValueOrDefault("Agent.HomeDirectory")?.Value, "externals", tfDirectoryName, "Microsoft.TeamFoundation.VersionControl.Controls.dll");
                 ArgUtil.File(policyDllPath, nameof(policyDllPath));
                 const string policyPathEnvKey = "TFVC_BUILDAGENT_POLICYPATH";

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -823,6 +823,14 @@ namespace Agent.Sdk.Knob
             new PipelineFeatureSource("InstallLegacyTfExe"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob UseLatestTfExe = new Knob(
+            nameof(UseLatestTfExe),
+            "If true, the agent will use the latest versions of TF, vstsom and vstshost instead of legacy versions",
+            new RuntimeKnobSource("AGENT_USE_LATEST_TF_EXE"),
+            new EnvironmentKnobSource("AGENT_USE_LATEST_TF_EXE"),
+            new PipelineFeatureSource("UseLatestTfExe"),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob UseSparseCheckoutInCheckoutTask = new Knob(
             nameof(UseSparseCheckoutInCheckoutTask),
             "If true, agent will use sparse checkout in checkout task.",

--- a/src/Agent.Worker/Build/TFCommandManager.cs
+++ b/src/Agent.Worker/Build/TFCommandManager.cs
@@ -35,9 +35,24 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
 
         protected override string Switch => "/";
 
-        private string TfPath => AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean()
-            ? HostContext.GetDirectory(WellKnownDirectory.TfLegacy)
-            : HostContext.GetDirectory(WellKnownDirectory.Tf);
+        private string TfPath
+        {
+            get
+            {
+                if (AgentKnobs.UseLatestTfExe.GetValue(ExecutionContext).AsBoolean())
+                {
+                    return HostContext.GetDirectory(WellKnownDirectory.TfLatest);
+                }
+                else if (AgentKnobs.InstallLegacyTfExe.GetValue(ExecutionContext).AsBoolean())
+                {
+                    return HostContext.GetDirectory(WellKnownDirectory.TfLegacy);
+                }
+                else
+                {
+                    return HostContext.GetDirectory(WellKnownDirectory.Tf);
+                }
+            }
+        }
 
         public override string FilePath => Path.Combine(TfPath, "tf.exe");
 

--- a/src/Agent.Worker/Build/TfsVCSourceProvider.cs
+++ b/src/Agent.Worker/Build/TfsVCSourceProvider.cs
@@ -89,9 +89,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Build
             if (PlatformUtil.RunningOnWindows)
             {
                 // Set TFVC_BUILDAGENT_POLICYPATH
-                string vstsomPath = AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean()
-                    ? HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy)
-                    : HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+                string vstsomPath;
+                if (AgentKnobs.UseLatestTfExe.GetValue(executionContext).AsBoolean())
+                {
+                    vstsomPath = HostContext.GetDirectory(WellKnownDirectory.ServerOMLatest);
+                }
+                else if (AgentKnobs.InstallLegacyTfExe.GetValue(executionContext).AsBoolean())
+                {
+                    vstsomPath = HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy);
+                }
+                else
+                {
+                    vstsomPath = HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+                }
 
                 string policyDllPath = Path.Combine(vstsomPath, "Microsoft.TeamFoundation.VersionControl.Controls.dll");
                 ArgUtil.File(policyDllPath, nameof(policyDllPath));

--- a/src/Agent.Worker/JobRunner.cs
+++ b/src/Agent.Worker/JobRunner.cs
@@ -195,9 +195,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     Trace.Info($"Agent metadata populated [AgentId:{settings.AgentId}, AgentName:{settings.AgentName}, OS:{VarUtil.OS}, Architecture:{VarUtil.OSArchitecture}, SelfHosted:{!settings.IsMSHosted}, CloudId:{settings.AgentCloudId}, MachineName:{Environment.MachineName}]");
                     if (PlatformUtil.RunningOnWindows)
                     {
-                        string serverOMDirectoryVariable = AgentKnobs.InstallLegacyTfExe.GetValue(jobContext).AsBoolean()
-                            ? HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy)
-                            : HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+                        string serverOMDirectoryVariable;
+                        if (AgentKnobs.UseLatestTfExe.GetValue(jobContext).AsBoolean())
+                        {
+                            serverOMDirectoryVariable = HostContext.GetDirectory(WellKnownDirectory.ServerOMLatest);
+                        }
+                        else if (AgentKnobs.InstallLegacyTfExe.GetValue(jobContext).AsBoolean())
+                        {
+                            serverOMDirectoryVariable = HostContext.GetDirectory(WellKnownDirectory.ServerOMLegacy);
+                        }
+                        else
+                        {
+                            serverOMDirectoryVariable = HostContext.GetDirectory(WellKnownDirectory.ServerOM);
+                        }
 
                         jobContext.SetVariable(Constants.Variables.Agent.ServerOMDirectory, serverOMDirectoryVariable, isFilePath: true);
                     }

--- a/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/Constants.cs
@@ -23,7 +23,9 @@ namespace Microsoft.VisualStudio.Services.Agent
         Update,
         Work,
         TfLegacy,
+        TfLatest,
         ServerOMLegacy,
+        ServerOMLatest,
         LegacyPSHostLegacy
     }
 
@@ -320,10 +322,12 @@ namespace Microsoft.VisualStudio.Services.Agent
             public static readonly string LegacyPSHostLegacyDirectory = "vstshost-legacy";
             public static readonly string ServerOMDirectory = "vstsom";
             public static readonly string ServerOMLegacyDirectory = "vstsom-legacy";
+            public static readonly string ServerOMLatestDirectory = "vstsom-latest";
             public static readonly string TempDirectory = "_temp";
             public static readonly string TeeDirectory = "tee";
             public static readonly string TfDirectory = "tf";
             public static readonly string TfLegacyDirectory = "tf-legacy";
+            public static readonly string TfLatestDirectory = "tf-latest";
             public static readonly string ToolDirectory = "_tool";
             public static readonly string TaskJsonFile = "task.json";
             public static readonly string TasksDirectory = "_tasks";

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -257,6 +257,12 @@ namespace Microsoft.VisualStudio.Services.Agent
                         Constants.Path.ServerOMLegacyDirectory);
                     break;
 
+                case WellKnownDirectory.ServerOMLatest:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.ServerOMLatestDirectory);
+                    break;
+
                 case WellKnownDirectory.Tf:
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Externals),
@@ -267,6 +273,12 @@ namespace Microsoft.VisualStudio.Services.Agent
                     path = Path.Combine(
                         GetDirectory(WellKnownDirectory.Externals),
                         Constants.Path.TfLegacyDirectory);
+                    break;
+
+                case WellKnownDirectory.TfLatest:
+                    path = Path.Combine(
+                        GetDirectory(WellKnownDirectory.Externals),
+                        Constants.Path.TfLatestDirectory);
                     break;
 
                 case WellKnownDirectory.Tee:

--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -174,6 +174,7 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
         acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy
         acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost
         acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom
+        acquireExternalTool "$CONTAINER_URL/vstsom/dev17.11vs_c0748e6e/vstsom.zip" vstsom-latest
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git
@@ -181,6 +182,7 @@ if [[ "$PACKAGERUNTIME" == "win-x"* ]]; then
     acquireExternalTool "$CONTAINER_URL/pdbstr/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
+    acquireExternalTool "$CONTAINER_URL/vstsom/dev17.11vs_c0748e6e/vstsom.zip" tf-latest
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v4.6.4/nuget.exe" nuget
 
@@ -206,6 +208,7 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
         # acquireExternalTool "$CONTAINER_URL/azcopy/1/azcopy.zip" azcopy # Unavailable for Win ARM 64 - https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf#download-the-azcopy-portable-binary
         acquireExternalTool "$CONTAINER_URL/vstshost/m122_887c6659_binding_redirect_patched/vstshost.zip" vstshost  # Custom package. Will the same work for Win ARM 64?
         acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" vstsom  # Custom package. Will the same work for Win ARM 64?
+        acquireExternalTool "$CONTAINER_URL/vstsom/dev17.11vs_c0748e6e/vstsom.zip" vstsom-latest
     fi
 
     acquireExternalTool "$CONTAINER_URL/mingit/${MINGIT_VERSION}/MinGit-${MINGIT_VERSION}-${BIT}-bit.zip" git # Unavailable for Win ARM 64 - https://github.com/git-for-windows/git/releases
@@ -213,6 +216,7 @@ elif [[ "$PACKAGERUNTIME" == "win-arm64" || "$PACKAGERUNTIME" == "win-arm32" ]];
     acquireExternalTool "$CONTAINER_URL/pdbstr/win-arm${BIT}/1/pdbstr.zip" pdbstr
     acquireExternalTool "$CONTAINER_URL/symstore/win-arm${BIT}/1/symstore.zip" symstore
     acquireExternalTool "$CONTAINER_URL/vstsom/m153_47c0856d_adhoc/vstsom.zip" tf
+    acquireExternalTool "$CONTAINER_URL/vstsom/dev17.11vs_c0748e6e/vstsom.zip" tf-latest
     acquireExternalTool "$CONTAINER_URL/vswhere/2_8_4/vswhere.zip" vswhere
     acquireExternalTool "https://dist.nuget.org/win-x86-commandline/v4.6.4/nuget.exe" nuget
 


### PR DESCRIPTION
### **Context**
Self-hosted agents are encountering authentication errors during TFVC checkout using TF version 16 on Win11.
ICM - https://portal.microsofticm.com/imp/v5/incidents/details/664461375/summary

---

### **Description**
The existing version of TF fails to authenticate with the server when the self-hosted agent is running behind a proxy.
As a workaround, we can use TF version 17 from https://vstsagenttools.blob.core.windows.net/tools/vstsom/dev17.11vs_c0748e6e/vstsom.zip.
We’ve onboarded the new vstsom.zip file during build time alongside the existing version, and either can be used with an Agent knob.
---

### **Risk Assessment** (Low / Medium / High)  
Medium
The regular flow is unaffected, and the latest TF version has been added behind an agent knob. 

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
The exact repro is not reproducible, but the customer confirmed that this version of the agent binaries is working for them when shared.

--- 

### **Change Behind Feature Flag** (Yes / No)
No.
Behind an agent Knob

---

### **Tech Design / Approach**
- Design has been written and reviewed. - TBD
- Any architectural decisions, trade-offs, and alternatives are captured. - No

---

### **Documentation Changes Required** (Yes/No)
_Indicate whether related documentation needs to be updated._
- User guides, API specs, system diagrams, or runbooks are updated. 

---
### **Logging Added/Updated** (Yes/No)
- Appropriate log statements are added with meaningful messages. 
- Logging does not expose sensitive data. 
- Log levels are used correctly (e.g., info, warn, error). 

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes/No)
- Rollback plan is documented. 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.
