### PR TITLE
Reduce noise when using Node 20 for container startup

### DIFF
--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -694,10 +694,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                             }
                             else if (logLine.Contains(labelContainerStartupUsingNode20))
                             {
-                                string warningMsg = useNode24ToStartContainer 
-                                    ? "Cannot run Node 24 in container. Falling back to Node 20 for container startup."
-                                    : "Using Node 20 for container startup.";
-                                executionContext.Warning(warningMsg);
+                                if (useNode24ToStartContainer)
+                                {
+                                    executionContext.Warning("Cannot run Node 24 in container. Falling back to Node 20 for container startup.");
+                                }
+                                else
+                                {
+                                    executionContext.Debug("Using Node 20 for container startup.");
+                                }
                                 containerStartupCompleted = true;
                                 container.ResultNodePath = node20ContainerPath;
                                 break;

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -688,6 +688,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         {
                             if (logLine.Contains(labelContainerStartupUsingNode24))
                             {
+                                executionContext.Debug("Using Node 24 for container startup.");
                                 containerStartupCompleted = true;
                                 container.ResultNodePath = node24ContainerPath;
                                 break;

--- a/src/Agent.Worker/ContainerOperationProviderEnhanced.cs
+++ b/src/Agent.Worker/ContainerOperationProviderEnhanced.cs
@@ -802,10 +802,14 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                                 }
                                 else if (logLine.Contains(labelContainerStartupUsingNode20))
                                 {
-                                    string warningMsg = useNode24ToStartContainer 
-                                        ? "Cannot run Node 24 in container. Falling back to Node 20 for container startup."
-                                        : "Using Node 20 for container startup.";
-                                    executionContext.Warning(warningMsg);
+                                    if (useNode24ToStartContainer)
+                                    {
+                                        executionContext.Warning("Cannot run Node 24 in container. Falling back to Node 20 for container startup.");
+                                    }
+                                    else
+                                    {
+                                        executionContext.Debug("Using Node 20 for container startup.");
+                                    }
                                     containerStartupCompleted = true;
                                     container.ResultNodePath = node20ContainerPath;
                                     break;


### PR DESCRIPTION
### **Context**

This PR fixes noisy container startup logging introduced with the Node24 / Node20 fallback flow in #5419.

When Node 20 is the expected startup path, the agent currently logs a warning (`Using Node 20 for container startup.`) even though no fallback occurred.

Related issue: #5464

---

### **Description**
This change updates logging in `ContainerOperationProvider.cs` and `ContainerOperationProviderEnhanced.cs`:

- `Node 24` success logs at `Debug`
- `Node 20` success logs at `Debug` when it is the expected path
- fallback from `Node 24` to `Node 20` remains a `Warning`

This keeps warnings for real degraded behavior and removes noise from normal startup.

---

### **Risk Assessment** (Low / Medium / High)
Low

No changes except for logging.

---

### **Unit Tests Added or Updated** (Yes / No)
No

---

### **Additional Testing Performed**
None

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
Apply the same log-level adjustment in both implementations so behavior stays consistent.

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Logging Added/Updated** (Yes/No)
Yes

Adjusted log levels so expected startup paths use `Debug` and real fallbacks keep `Warning`.

---

### **Telemetry Added/Updated** (Yes/No)
No

---

### **Rollback Scenario and Process** (Yes/No)
No

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
No