### PR TITLE
Fix container crash in VsoTaskLibManager and flip IgnoreVSTSTaskLib default

### DIFF
--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -719,7 +719,7 @@ namespace Agent.Sdk.Knob
             "Ignores the VSTSTaskLib folder when copying tasks.",
             new RuntimeKnobSource("AZP_AGENT_IGNORE_VSTSTASKLIB"),
             new EnvironmentKnobSource("AZP_AGENT_IGNORE_VSTSTASKLIB"),
-            new BuiltInDefaultKnobSource("false"));
+            new BuiltInDefaultKnobSource("true"));
 
         public static readonly Knob FailJobWhenAgentDies = new Knob(
             nameof(FailJobWhenAgentDies),

--- a/src/Agent.Sdk/Util/IOUtil.cs
+++ b/src/Agent.Sdk/Util/IOUtil.cs
@@ -569,6 +569,30 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             }
         }
 
+        /// <summary>
+        /// Attempts to create a directory. Returns true if created or already exists, false on failure.
+        /// Does NOT throw — callers decide how to handle failure.
+        /// </summary>
+        public static bool TryCreateDirectory(string path)
+        {
+            try
+            {
+                if (!Directory.Exists(path))
+                {
+                    Directory.CreateDirectory(path);
+                }
+                return true;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
         public static string GetDirectoryName(string path, PlatformUtil.OS platform)
         {
             if (string.IsNullOrWhiteSpace(path))

--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -171,9 +171,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                 // Ensure compat vso-task-lib exist at the root of _work folder
                 // This will make vsts-agent work against 2015 RTM/QU1 TFS, since tasks in those version doesn't package with task lib
                 // Put the 0.5.5 version vso-task-lib into the root of _work/node_modules folder, so tasks are able to find those lib.
-                if (!File.Exists(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib", "package.json")))
+                string vsoTaskLibFromExternal = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "vso-task-lib");
+                if (Directory.Exists(vsoTaskLibFromExternal) &&
+                    !File.Exists(Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib", "package.json")))
                 {
-                    string vsoTaskLibFromExternal = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Externals), "vso-task-lib");
                     string compatVsoTaskLibInWork = Path.Combine(HostContext.GetDirectory(WellKnownDirectory.Work), "node_modules", "vso-task-lib");
                     IOUtil.CopyDirectory(vsoTaskLibFromExternal, compatVsoTaskLibInWork, ExecutionContext.CancellationToken);
                 }

--- a/src/Agent.Worker/VsoTaskLibManager.cs
+++ b/src/Agent.Worker/VsoTaskLibManager.cs
@@ -41,8 +41,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
 
         public static async Task DownloadAsync(IExecutionContext executionContext, string blobUrl, string tempDirectory, string extractPath, IRetryOptions retryOptions)
         {
-            Directory.CreateDirectory(tempDirectory);
-            Directory.CreateDirectory(extractPath);
+            if (!IOUtil.TryCreateDirectory(tempDirectory))
+            {
+                executionContext.Warning($"Cannot create directory '{tempDirectory}': permission denied. " +
+                    "This may occur in container environments. Skipping vso-task-lib download.");
+                return;
+            }
+            if (!IOUtil.TryCreateDirectory(extractPath))
+            {
+                executionContext.Warning($"Cannot create directory '{extractPath}': permission denied. " +
+                    "This may occur in container environments. Skipping vso-task-lib download.");
+                IOUtil.DeleteDirectory(tempDirectory, CancellationToken.None);
+                return;
+            }
             string downloadPath = Path.ChangeExtension(Path.Combine(tempDirectory, "download"), ".tar.gz");
             string toolName = new DirectoryInfo(extractPath).Name;
 
@@ -99,7 +110,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
         /// </summary>
         private static void ExtractTarGz(string tarGzPath, string extractPath, IExecutionContext executionContext, string toolName)
         {
-            Directory.CreateDirectory(extractPath);
+            if (!IOUtil.TryCreateDirectory(extractPath))
+            {
+                executionContext.Warning($"Cannot create directory '{extractPath}' for extraction: permission denied.");
+                return;
+            }
             executionContext.Debug($"Extracting {toolName} using tar...");
             using (var process = new System.Diagnostics.Process
             {

--- a/src/Test/L0/Util/IOUtilL0.cs
+++ b/src/Test/L0/Util/IOUtilL0.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -1332,6 +1333,46 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
                     requireExitCodeZero: true,
                     cancellationToken: CancellationToken.None);
             }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void TryCreateDirectory_CreatesNewDirectory()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Assert.True(IOUtil.TryCreateDirectory(tempPath));
+                Assert.True(Directory.Exists(tempPath));
+            }
+            finally
+            {
+                if (Directory.Exists(tempPath))
+                {
+                    Directory.Delete(tempPath, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void TryCreateDirectory_ReturnsTrueForExistingDirectory()
+        {
+            Assert.True(IOUtil.TryCreateDirectory(Path.GetTempPath()));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void TryCreateDirectory_ReturnsFalseOnInvalidPath()
+        {
+            // Use a path under a known read-only/special location that triggers IOException
+            var invalidPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? @"C:\Windows\System32\config\systemprofile\impossible_test_" + Guid.NewGuid().ToString()
+                : "/proc/impossible_dir";
+            Assert.False(IOUtil.TryCreateDirectory(invalidPath));
         }
     }
 }

--- a/src/Test/L0/Util/IOUtilL0.cs
+++ b/src/Test/L0/Util/IOUtilL0.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.Services.Agent.Util;
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -1368,11 +1367,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
         [Trait("Category", "Common")]
         public void TryCreateDirectory_ReturnsFalseOnInvalidPath()
         {
-            // Use a path under a known read-only/special location that triggers IOException
-            var invalidPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? @"C:\Windows\System32\config\systemprofile\impossible_test_" + Guid.NewGuid().ToString()
-                : "/proc/impossible_dir";
-            Assert.False(IOUtil.TryCreateDirectory(invalidPath));
+            // Creating a directory at a path where a file already exists triggers IOException
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                Assert.False(IOUtil.TryCreateDirectory(tempFile));
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
         }
     }
 }


### PR DESCRIPTION
### **Context**
This PR addresses two active IcM 712597353 retro repair items that caused agent crashes in read-only container environments:

- **[AB#2345018](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2345018)** — Directory creation in `VsoTaskLibManager` throws `UnauthorizedAccessException` when container user (UID 1001) lacks write permissions to `/__a/externals`
- **[AB#2345020](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2345020)** — `IgnoreVSTSTaskLib` knob defaults to `false`, causing the crash-prone VsoTaskLib code path to run unnecessarily on every non-Windows job

**Incident Summary:** Agent v4.260.0 introduced a code path where `DownloadSecureFile@1` triggered VsoTaskLibManager, which attempted `Directory.CreateDirectory("/__a/externals/vso-task-lib_download_temp")` in containers that had switched from root to non-root user. This caused `UnauthorizedAccessException` and pipeline failures.

**IcM:** https://portal.microsofticm.com/imp/v5/incidents/details/712597353/summary  
**Retro:** https://portal.microsofticm.com/imp/v5/retrospectives/Internal/1321720

---

### **Description**
1. **Added `IOUtil.TryCreateDirectory` helper** — wraps `Directory.CreateDirectory` with catch for `UnauthorizedAccessException`/`IOException`, returns bool instead of throwing.

2. **Fixed VsoTaskLibManager** — 3 bare `Directory.CreateDirectory` calls replaced with `TryCreateDirectory`. On failure, logs a warning and skips the download gracefully instead of crashing the agent.

3. **Added guard in NodeHandler** — `Directory.Exists` check before `IOUtil.CopyDirectory` to prevent crash when download was skipped (source directory doesn't exist).

4. **Flipped `IgnoreVSTSTaskLib` default to `true`** — the vso-task-lib 0.5.5 is a legacy compatibility shim for TFS 2015 RTM. No modern tasks require it. This was already the production hotfix applied during incident mitigation with zero regressions.

5. **Added 3 L0 unit tests** for `TryCreateDirectory`.

---

### **Risk Assessment** (**Low**)
- **Knob flip (`true`):** Already validated in production during incident mitigation across all hosted pools. No regressions reported. Self-hosted customers can override via `AZP_AGENT_IGNORE_VSTSTASKLIB=false`.
- **VsoTaskLibManager graceful skip:** Only triggers when knob is explicitly set to `false` AND directories are unwritable — an edge case that previously crashed. The success path is unchanged.
- **NodeHandler guard:** Pure defensive check — `Directory.Exists` before copy. No behavior change when directory exists.
- **No changes to core task execution, job dispatch, or agent lifecycle.**

---

### **Unit Tests Added or Updated** (Yes)
Added 3 new L0 tests in `src/Test/L0/Util/IOUtilL0.cs`:
- `TryCreateDirectory_CreatesNewDirectory` — verifies directory creation works
- `TryCreateDirectory_ReturnsTrueForExistingDirectory` — verifies idempotency
- `TryCreateDirectory_ReturnsFalseOnInvalidPath` — verifies failure returns false without throwing

---

### **Additional Testing Performed**
_List manual or automated tests performed beyond unit tests (e.g., integration, scenario, regression)._

--- 

### **Change Behind Feature Flag** (Yes)
The `IgnoreVSTSTaskLib` knob itself acts as the feature flag:
- Default `true` (VsoTaskLib path skipped)
- Set `AZP_AGENT_IGNORE_VSTSTASKLIB=false` = opt back into legacy behavior
- The VsoTaskLibManager graceful-skip fix is **not** behind a separate flag because the old behavior (crash) is never desirable.
- 
---

### **Tech Design / Approach**
- `TryCreateDirectory` placed in `IOUtil` (Agent.Sdk) — available to all layers, consistent with existing patterns (`DeleteDirectory`, `CopyDirectory`)
- Helper catches only `UnauthorizedAccessException` and `IOException` — does not swallow unexpected errors (e.g., `ArgumentException` for null path still throws)
- Helper does NOT log — callers decide messaging. Keeps it a pure utility function.
- Knob default flipped rather than removing the code — preserves backward compatibility for any edge cases

**Alternatives considered:**
- Bulk-updating all ~60 `Directory.CreateDirectory` calls in the codebase → rejected (high risk, not required by repair items, most calls run in contexts with proper permissions)
- Removing VsoTaskLibManager entirely → rejected (breaking change for anyone who might still depend on it via the knob)

---

### **Documentation Changes Required** (Yes/No)
NA

---
### **Logging Added/Updated** (Yes)
- **Warning-level logs** added in VsoTaskLibManager when directory creation fails:
  - `"Cannot create directory '{path}': permission denied. This may occur in container environments. Skipping vso-task-lib download."`

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes/No)
- Rollback plan is documented. 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.
