### PR TITLE
fix: add timeout to apt update to prevent indefinite hang on network issues

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -76,7 +76,8 @@ then
         command -v apt
         if [ $? -eq 0 ]
         then
-            apt update && apt install -y libkrb5-3 zlib1g debsums && (apt install -y liblttng-ust1 || apt install -y liblttng-ust0)
+            timeout 120 apt update || echo "WARNING: apt update failed or timed out, proceeding with cached package index"
+            apt install -y libkrb5-3 zlib1g debsums && (apt install -y liblttng-ust1 || apt install -y liblttng-ust0)
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -110,7 +111,8 @@ then
             command -v apt-get
             if [ $? -eq 0 ]
             then
-                apt-get update && apt-get install -y libkrb5-3 zlib1g debsums && (apt-get install -y liblttng-ust1 || apt-get install -y liblttng-ust0)
+                timeout 120 apt-get update || echo "WARNING: apt-get update failed or timed out, proceeding with cached package index"
+                apt-get install -y libkrb5-3 zlib1g debsums && (apt-get install -y liblttng-ust1 || apt-get install -y liblttng-ust0)
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
### **Context**
`installdependencies.sh` is executed by the Azure VM Extension on every VMSS reimage. It calls `apt update && apt install ...` with no timeout. When any apt source is unreachable, apt update hangs indefinitely in CLOSE_WAIT state, blocking apt install from running and preventing agent startup.

Observed in production:
  - 2026-05-05: connections hung to Canonical servers [archive.ubuntu.com](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQFYMUQt3d_F-gn4VhVipql9UvmgQxcHUsErlGgGoE-wIQ%3D%3D)
  - 2026-05-06: connections hung to packages.microsoft.com (IP 13.107.246.67, port 443)

In both cases, confirmed via `ss -tnp` showing CLOSE_WAIT connections held by /usr/lib/apt/methods/https subprocess with no timeout.

---

### **Description**

Add a 120-second timeout to apt update and apt-get update calls. Treat failure as non-fatal (print warning and continue) so apt install can still run against the locally cached package index on the VM.

---

### **Risk Assessment** (Low / Medium / High)  
Low. The change only affects behavior when apt update fails or times out — in the normal case (network available) behavior is unchanged. The locally cached package index is sufficient for  apt install to satisfy the required dependencies in most cases.

---

### **Unit Tests Added or Updated** (Yes / No)  
No. This is a shell script change with no existing unit test framework.

---

### **Additional Testing Performed**
Manually verified on Ubuntu 24.04 VMSS VMs:
  - Blocked all apt sources via iptables, confirmed timeout 120 apt update exits after timeout
  - Confirmed apt install libkrb5-3 zlib1g debsums completes successfully with exit code 0 using cached index after apt update timeout

--- 

### **Change Behind Feature Flag** (Yes / No)
No. Feature flags are not applicable to agent installation scripts.

---

### **Tech Design / Approach**
Replace apt update && apt install ... with two separate commands:
  1. timeout 120 apt update || echo "WARNING: ..." — non-fatal, continues on failure
  2. apt install ... — runs regardless of whether apt update succeeded

---

### **Documentation Changes Required** (Yes/No)
No.

---
### **Logging Added/Updated** (Yes/No)
Yes. A warning message is printed when apt update fails or times out, to aid diagnosis.

--- 

### **Telemetry Added/Updated** (Yes/No) 
No.

---

### **Rollback Scenario and Process** (Yes/No)
Low risk — revert the two changed lines to restore original && behavior. No state changes or migrations involved.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes. Change is limited to the apt/apt-get update step on Debian-based systems. All subsequent apt install calls are unchanged. No impact on Fedora, SUSE, Alpine, or Mariner code paths.
