### PR TITLE
[BUG FIX]: Add libicu78 to installdependencies.sh for Ubuntu 26.04 (Resolute) support

### DIFF
--- a/src/Misc/layoutbin/installdependencies.sh
+++ b/src/Misc/layoutbin/installdependencies.sh
@@ -98,8 +98,8 @@ then
                 fi
             fi
 
-            # libicu versions: libicu76 -> libicu74 -> libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-            apt install -y libicu76 || apt install -y libicu74 || apt install -y libicu70 || apt install -y libicu67 || apt install  -y libicu66 || apt install -y libicu63 || apt install -y libicu60  || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
+            # libicu versions: libicu78 -> libicu76 -> libicu74 -> libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+            apt install -y libicu78 || apt install -y libicu76 || apt install -y libicu74 || apt install -y libicu70 || apt install -y libicu67 || apt install  -y libicu66 || apt install -y libicu63 || apt install -y libicu60  || apt install -y libicu57 || apt install -y libicu55 || apt install -y libicu52
             if [ $? -ne 0 ]
             then
                 echo "'apt' failed with exit code '$?'"
@@ -132,8 +132,8 @@ then
                     fi
                 fi
 
-                # libicu versions: libicu76 -> libicu74 -> libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
-                apt-get install -y libicu76 || apt-get install -y libicu74 || apt-get install -y libicu70 || apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
+                # libicu versions: libicu78 -> libicu76 -> libicu74 -> libicu70 -> libicu67 -> libicu66 -> libicu63 -> libicu60 -> libicu57 -> libicu55 -> libicu52
+                apt-get install -y libicu78 || apt-get install -y libicu76 || apt-get install -y libicu74 || apt-get install -y libicu70 || apt-get install -y libicu67 || apt-get install -y libicu66 || apt-get install -y libicu63 || apt-get install -y libicu60 || apt-get install -y libicu57 || apt-get install -y libicu55 || apt-get install -y libicu52
                 if [ $? -ne 0 ]
                 then
                     echo "'apt-get' failed with exit code '$?'"


### PR DESCRIPTION
## Summary

On Ubuntu 26.04 (Resolute Raccoon), `installdependencies.sh` fails because it only tries `libicu` versions up to `libicu76`, while Ubuntu 26.04 ships `libicu78`. This causes agent self-updates to abort mid-way — `svc.sh install` is never called, `runsvc.sh` is not recreated, and the agent service fails to start after the next reboot.

This follows the same pattern as #4973 (libicu74 for Ubuntu 24.04) and #2955 (libicu66).

## Changes

Prepend `libicu78` to the ICU version chain in both the `apt` and `apt-get` paths of `installdependencies.sh`:

```diff
- # libicu versions: libicu76 -> libicu74 -> ...
+ # libicu versions: libicu78 -> libicu76 -> libicu74 -> ...
- apt install -y libicu76 || apt install -y libicu74 || ...
+ apt install -y libicu78 || apt install -y libicu76 || apt install -y libicu74 || ...
```

## Testing

Tested on Ubuntu 26.04 (Resolute Raccoon) with Azure DevOps agent v4.272.0:
- Patched `installdependencies.sh` exits 0 with `libicu78 is already the newest version`
- Agent self-update completes successfully and `runsvc.sh` is recreated

## Related

Closes #5569
