### PR TITLE
Enhance GitSourceProvider for partial clone support

### DIFF
--- a/src/Agent.Plugins/GitSourceProvider.cs
+++ b/src/Agent.Plugins/GitSourceProvider.cs
@@ -730,6 +730,25 @@ namespace Agent.Plugins.Repository
                 {
                     throw new InvalidOperationException($"Unable to use git.exe add remote 'origin', 'git remote add' failed with exit code: {exitCode_addremote}");
                 }
+
+                // `git init` + `git remote add` + `git fetch --filter=...` does NOT write the partial-clone
+                // bookkeeping configs that `git clone --filter=...` would write automatically. Without these,
+                // subsequent fetches re-walk reachability without knowing the repo is a partial clone, the
+                // fetched pack is not marked as a promisor pack, and on-demand blob fetches during checkout
+                // don't engage the promisor lazy-fetch path. Write them explicitly when a fetch filter is in use.
+                if (!string.IsNullOrEmpty(fetchFilter))
+                {
+                    int exitCode_promisor = await gitCommandManager.GitConfig(executionContext, targetPath, "remote.origin.promisor", "true");
+                    if (exitCode_promisor != 0)
+                    {
+                        executionContext.Warning($"Failed to set remote.origin.promisor=true (exit {exitCode_promisor}); subsequent fetches may be slower.");
+                    }
+                    int exitCode_filter = await gitCommandManager.GitConfig(executionContext, targetPath, "remote.origin.partialclonefilter", fetchFilter);
+                    if (exitCode_filter != 0)
+                    {
+                        executionContext.Warning($"Failed to set remote.origin.partialclonefilter={fetchFilter} (exit {exitCode_filter}); subsequent fetches may be slower.");
+                    }
+                }
             }
 
             if (AgentKnobs.UseSparseCheckoutInCheckoutTask.GetValue(executionContext).AsBoolean())


### PR DESCRIPTION
### **Context**
When the built-in `checkout` task is invoked with `fetchFilter` (e.g. `blob:none`, `tree:0`), the agent creates the local repository with `git init` followed by `git remote add origin <url>`, then issues `git fetch --filter=<filter>`. Unlike `git clone --filter=<filter>`, this init-then-fetch path does not populate the partial-clone bookkeeping configs that Git's native clone path writes automatically:

- `remote.origin.promisor = true`
- `remote.origin.partialclonefilter = <filter>`

As a result, the resulting clone is functional on the first fetch but is not properly marked as a partial clone for subsequent operations. This degrades performance on follow-up syncs because:

1. The pack written by the filtered fetch is not marked as a promisor pack (the `.promisor` marker file alongside the `.pack`/`.idx` is absent), so connectivity walks during subsequent fetches, repacks, and auto-maintenance treat missing blobs as potentially needed rather than intentionally absent.
2. Client-side fetch negotiation is not filter-aware across subsequent fetches; `partialclonefilter` is what makes follow-up fetches inherit the filter consistently with the initial fetch.
3. Lazy on-demand blob fetches during `git checkout` do not engage the promisor fetch path correctly without `promisor=true`, leading to either errors on missing objects or unbatched single-object fetches depending on Git version.

References:
- Git partial clone documentation: https://git-scm.com/docs/partial-clone
- `remote.<name>.promisor` config: https://git-scm.com/docs/git-config#Documentation/git-config.txt-remoteltnamegtpromisor

---
### **Description**
After `git remote add origin` in `GitSourceProvider.GetSourceAsync`, when `fetchFilter` is non-empty, the agent now writes the two partial-clone configs explicitly:

```
git config remote.origin.promisor true
git config remote.origin.partialclonefilter <fetchFilter>
```

This makes the locally initialized repository equivalent to what `git clone --filter=<fetchFilter>` would have produced, restoring full partial-clone semantics for all subsequent fetches and checkouts on the same working directory.

The change is scoped to the fresh-init path (where the `.git` folder does not yet exist). 

---
### **Risk Assessment** (Low / Medium / High)
**Low.**
- `git config` is idempotent; rerunning is safe.
- The configs being written are exactly what `git clone --filter` writes natively, so behavior converges with a long-established Git code path.