### PR TITLE
Fix DockerCreate -v argument for paths ending with a backslash

### DIFF
--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -173,25 +173,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             }
             foreach (var volume in container?.MountVolumes)
             {
-                // replace `"` with `\"` and add `"{0}"` to all path.
-                String volumeArg;
-                String targetVolume = container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, volume.TargetVolumePath).Replace("\"", "\\\"");
-
-                if (String.IsNullOrEmpty(volume.SourceVolumePath))
-                {
-                    // Anonymous docker volume
-                    volumeArg = $"-v \"{targetVolume}\"";
-                }
-                else
-                {
-                    // Named Docker volume / host bind mount
-                    volumeArg = $"-v \"{volume.SourceVolumePath.Replace("\"", "\\\"")}\":\"{targetVolume}\"";
-                }
-                if (volume.ReadOnly)
-                {
-                    volumeArg += ":ro";
-                }
-                dockerOptions.Add(volumeArg);
+                string targetVolume = container.TranslateContainerPathForImageOS(PlatformUtil.HostOS, volume.TargetVolumePath);
+                dockerOptions.Add(FormatMountVolumeArg(volume.SourceVolumePath, targetVolume, volume.ReadOnly));
             }
             // IMAGE
             dockerOptions.Add($"{container.ContainerImage}");
@@ -395,6 +378,51 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
         private Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, CancellationToken cancellationToken = default(CancellationToken))
         {
             return ExecuteDockerCommandAsync(context, command, options, null, cancellationToken);
+        }
+
+        // Builds the "-v ..." docker argument for a single mount volume. The returned string is
+        // intended to be embedded in a Windows command line, so any trailing backslash on a
+        // path is doubled to avoid escaping the closing quote when docker.exe (or any other
+        // process started by Windows) parses argv per the C runtime rules. Without this,
+        // a drive-root source such as "F:\" produces -v "F:\":"target" which the CRT parses
+        // as a single argument that swallows everything up to the next unquoted space.
+        //
+        // Real examples taken from the InitializeContainers step:
+        //   sourceVolumePath = "D:\a\_work",        target = "C:\__w"        -> -v "D:\a\_work":"C:\__w"
+        //   sourceVolumePath = "D:\a\_work\_tasks", target = "C:\__w\_tasks" -> -v "D:\a\_work\_tasks":"C:\__w\_tasks"
+        //   sourceVolumePath = "F:\",               target = "C:\__w"        -> -v "F:\\":"C:\__w"
+        //   sourceVolumePath = "F:\_tasks",         target = "F:\_tasks"     -> -v "F:\_tasks":"F:\_tasks"
+        internal static string FormatMountVolumeArg(string sourceVolumePath, string targetVolumePath, bool readOnly)
+        {
+            string volumeArg = String.IsNullOrEmpty(sourceVolumePath)
+                ? $"-v {QuotePathForCommandLine(targetVolumePath)}"
+                : $"-v {QuotePathForCommandLine(sourceVolumePath)}:{QuotePathForCommandLine(targetVolumePath)}";
+
+            if (readOnly)
+            {
+                volumeArg += ":ro";
+            }
+            return volumeArg;
+        }
+
+        private static string QuotePathForCommandLine(string path)
+        {
+            // Escape embedded double quotes.
+            string escaped = (path ?? string.Empty).Replace("\"", "\\\"");
+
+            // Count trailing backslashes; double them so a path like "F:\" becomes "F:\\"
+            // and is parsed by the Windows C runtime as F:\ followed by the closing quote
+            // instead of treating the closing quote as escaped.
+            int trailing = 0;
+            for (int i = escaped.Length - 1; i >= 0 && escaped[i] == '\\'; i--)
+            {
+                trailing++;
+            }
+            if (trailing > 0)
+            {
+                escaped += new string('\\', trailing);
+            }
+            return "\"" + escaped + "\"";
         }
 
         private async Task<int> ExecuteDockerCommandAsync(IExecutionContext context, string command, string options, IList<string> standardIns = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Agent.Worker/Container/DockerCommandManager.cs
+++ b/src/Agent.Worker/Container/DockerCommandManager.cs
@@ -380,14 +380,16 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             return ExecuteDockerCommandAsync(context, command, options, null, cancellationToken);
         }
 
-        // Builds the "-v ..." docker argument for a single mount volume. The returned string is
-        // intended to be embedded in a Windows command line, so any trailing backslash on a
-        // path is doubled to avoid escaping the closing quote when docker.exe (or any other
-        // process started by Windows) parses argv per the C runtime rules. Without this,
-        // a drive-root source such as "F:\" produces -v "F:\":"target" which the CRT parses
-        // as a single argument that swallows everything up to the next unquoted space.
+        // Builds the "-v ..." docker argument for a single mount volume. On Windows, any
+        // trailing backslash on a path is doubled to avoid escaping the closing quote when
+        // docker.exe parses argv per the C runtime rules. Without this, a drive-root source
+        // such as "F:\" produces -v "F:\":"target" which the CRT parses as a single argument
+        // that swallows everything up to the next unquoted space.
         //
-        // Real examples taken from the InitializeContainers step:
+        // On Linux/macOS, '\' is a literal path character (not a separator) and is not
+        // special to shell/argv quoting, so no doubling is applied.
+        //
+        // Real examples taken from the InitializeContainers step on Windows:
         //   sourceVolumePath = "D:\a\_work",        target = "C:\__w"        -> -v "D:\a\_work":"C:\__w"
         //   sourceVolumePath = "D:\a\_work\_tasks", target = "C:\__w\_tasks" -> -v "D:\a\_work\_tasks":"C:\__w\_tasks"
         //   sourceVolumePath = "F:\",               target = "C:\__w"        -> -v "F:\\":"C:\__w"
@@ -410,17 +412,21 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Container
             // Escape embedded double quotes.
             string escaped = (path ?? string.Empty).Replace("\"", "\\\"");
 
-            // Count trailing backslashes; double them so a path like "F:\" becomes "F:\\"
-            // and is parsed by the Windows C runtime as F:\ followed by the closing quote
-            // instead of treating the closing quote as escaped.
-            int trailing = 0;
-            for (int i = escaped.Length - 1; i >= 0 && escaped[i] == '\\'; i--)
+            // Trailing-backslash doubling is a Windows-only concern: the Windows C runtime
+            // parses argv such that a `\` before a `"` escapes the quote. On Linux/macOS,
+            // '\' is not a path separator and not special to argv quoting, so doubling it
+            // would corrupt legitimate paths/filenames that contain a literal backslash.
+            if (PlatformUtil.RunningOnWindows)
             {
-                trailing++;
-            }
-            if (trailing > 0)
-            {
-                escaped += new string('\\', trailing);
+                int trailing = 0;
+                for (int i = escaped.Length - 1; i >= 0 && escaped[i] == '\\'; i--)
+                {
+                    trailing++;
+                }
+                if (trailing > 0)
+                {
+                    escaped += new string('\\', trailing);
+                }
             }
             return "\"" + escaped + "\"";
         }

--- a/src/Test/L0/Container/DockerCommandManagerL0.cs
+++ b/src/Test/L0/Container/DockerCommandManagerL0.cs
@@ -471,5 +471,108 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
                     It.IsAny<CancellationToken>()), Times.Exactly(3));
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_BindMount_BuildsExpectedArg()
+        {
+            Assert.Equal(
+                "-v \"C:\\src\":\"C:\\__w\"",
+                DockerCommandManager.FormatMountVolumeArg("C:\\src", "C:\\__w", readOnly: false));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_BindMount_ReadOnly_AppendsRoSuffix()
+        {
+            Assert.Equal(
+                "-v \"C:\\src\":\"C:\\__w\":ro",
+                DockerCommandManager.FormatMountVolumeArg("C:\\src", "C:\\__w", readOnly: true));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_AnonymousVolume_NoSource()
+        {
+            Assert.Equal(
+                "-v \"/var/data\"",
+                DockerCommandManager.FormatMountVolumeArg(null, "/var/data", readOnly: false));
+
+            Assert.Equal(
+                "-v \"/var/data\"",
+                DockerCommandManager.FormatMountVolumeArg(string.Empty, "/var/data", readOnly: false));
+        }
+
+        // Regression: a Windows drive-root source like "F:\" used to produce -v "F:\":"C:\__w",
+        // which the Windows C runtime parses as a single argument (the trailing backslash
+        // escapes the closing quote), causing docker to fail with "too many colons". Trailing
+        // backslashes must be doubled so the closing quote is preserved.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_BindMount_DriveRootSource_DoublesTrailingBackslash()
+        {
+            Assert.Equal(
+                "-v \"F:\\\\\":\"C:\\__w\"",
+                DockerCommandManager.FormatMountVolumeArg("F:\\", "C:\\__w", readOnly: false));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_BindMount_DriveRootTarget_DoublesTrailingBackslash()
+        {
+            Assert.Equal(
+                "-v \"C:\\src\":\"D:\\\\\"",
+                DockerCommandManager.FormatMountVolumeArg("C:\\src", "D:\\", readOnly: false));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_BindMount_MultipleTrailingBackslashes_AreAllDoubled()
+        {
+            Assert.Equal(
+                "-v \"F:\\\\\\\\\":\"C:\\__w\"",
+                DockerCommandManager.FormatMountVolumeArg("F:\\\\", "C:\\__w", readOnly: false));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_AnonymousVolume_TrailingBackslashTarget_IsDoubled()
+        {
+            Assert.Equal(
+                "-v \"C:\\data\\\\\"",
+                DockerCommandManager.FormatMountVolumeArg(null, "C:\\data\\", readOnly: false));
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void FormatMountVolumeArg_BindMount_PathWithEmbeddedQuote_IsEscaped()
+        {
+            Assert.Equal(
+                "-v \"C:\\weird\\\"name\":\"/mnt/x\"",
+                DockerCommandManager.FormatMountVolumeArg("C:\\weird\"name", "/mnt/x", readOnly: false));
+        }
+
+        // Regression: exact mount specs observed in the InitializeContainers step logs.
+        // All four must produce arguments that docker.exe parses as a single valid -v spec
+        // (the F:\ case used to fail with "invalid spec ... too many colons").
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [InlineData("D:\\a\\_work", "C:\\__w", "-v \"D:\\a\\_work\":\"C:\\__w\"")]
+        [InlineData("D:\\a\\_work\\_tasks", "C:\\__w\\_tasks", "-v \"D:\\a\\_work\\_tasks\":\"C:\\__w\\_tasks\"")]
+        [InlineData("F:\\", "C:\\__w", "-v \"F:\\\\\":\"C:\\__w\"")]
+        [InlineData("F:\\_tasks", "F:\\_tasks", "-v \"F:\\_tasks\":\"F:\\_tasks\"")]
+        public void FormatMountVolumeArg_InitializeContainersLogScenarios(string source, string target, string expected)
+        {
+            Assert.Equal(expected, DockerCommandManager.FormatMountVolumeArg(source, target, readOnly: false));
+        }
     }
 }

--- a/src/Test/L0/Container/DockerCommandManagerL0.cs
+++ b/src/Test/L0/Container/DockerCommandManagerL0.cs
@@ -510,9 +510,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
         // which the Windows C runtime parses as a single argument (the trailing backslash
         // escapes the closing quote), causing docker to fail with "too many colons". Trailing
         // backslashes must be doubled so the closing quote is preserved.
+        // Windows-only: on Linux/macOS '\' is a literal path character and is not doubled.
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
         public void FormatMountVolumeArg_BindMount_DriveRootSource_DoublesTrailingBackslash()
         {
             Assert.Equal(
@@ -523,6 +526,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
         public void FormatMountVolumeArg_BindMount_DriveRootTarget_DoublesTrailingBackslash()
         {
             Assert.Equal(
@@ -533,6 +538,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
         public void FormatMountVolumeArg_BindMount_MultipleTrailingBackslashes_AreAllDoubled()
         {
             Assert.Equal(
@@ -543,11 +550,32 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
         public void FormatMountVolumeArg_AnonymousVolume_TrailingBackslashTarget_IsDoubled()
         {
             Assert.Equal(
                 "-v \"C:\\data\\\\\"",
                 DockerCommandManager.FormatMountVolumeArg(null, "C:\\data\\", readOnly: false));
+        }
+
+        // Non-Windows counterpart: on Linux/macOS, a trailing backslash is a literal path
+        // character (not a separator) and must be left untouched by the quoting helper.
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "windows")]
+        public void FormatMountVolumeArg_BindMount_TrailingBackslash_NotDoubledOnNonWindows()
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                // SkipOn=windows in CI; guard here so local Windows runs don't fail.
+                return;
+            }
+
+            Assert.Equal(
+                "-v \"/mnt/weird\\\":\"/container\\\"",
+                DockerCommandManager.FormatMountVolumeArg("/mnt/weird\\", "/container\\", readOnly: false));
         }
 
         [Fact]
@@ -560,12 +588,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
                 DockerCommandManager.FormatMountVolumeArg("C:\\weird\"name", "/mnt/x", readOnly: false));
         }
 
-        // Regression: exact mount specs observed in the InitializeContainers step logs.
-        // All four must produce arguments that docker.exe parses as a single valid -v spec
-        // (the F:\ case used to fail with "invalid spec ... too many colons").
+        // Regression: exact mount specs observed in the InitializeContainers step logs on a
+        // Windows agent. All four must produce arguments that docker.exe parses as a single
+        // valid -v spec (the F:\ case used to fail with "invalid spec ... too many colons").
+        // Windows-only because the expected output reflects the trailing-backslash doubling.
         [Theory]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        [Trait("SkipOn", "darwin")]
+        [Trait("SkipOn", "linux")]
         [InlineData("D:\\a\\_work", "C:\\__w", "-v \"D:\\a\\_work\":\"C:\\__w\"")]
         [InlineData("D:\\a\\_work\\_tasks", "C:\\__w\\_tasks", "-v \"D:\\a\\_work\\_tasks\":\"C:\\__w\\_tasks\"")]
         [InlineData("F:\\", "C:\\__w", "-v \"F:\\\\\":\"C:\\__w\"")]


### PR DESCRIPTION
### **Context**
When running an Azure Pipelines job inside a Windows container, the `Initialize containers` step calls `docker create` with a `-v` argument built per `MountVolume`. If any mount path ends with a backslash (most commonly a drive-root such as `F:\`), the produced argument is malformed when parsed by the Windows C runtime, and `docker create` aborts with `invalid spec ... too many colons` (exit code 125) before the container is ever started.

Observed failing line from the `Initialize containers` step:

```
docker create ... -v "F:\":"C:\__w" -v "F:\_tasks":"F:\_tasks" ...
docker: invalid spec: F:":C:\__w -v F:\_tasks:F:\_tasks ... too many colons.
```

Root cause: in MS CRT argv parsing, a backslash immediately preceding `"` is treated as an escape (`\"` → literal `"`), so the closing quote for `"F:\"` is consumed as a literal character. Every subsequent quote merely toggles quoted/unquoted mode, and the entire tail of the command line is absorbed into a single `-v` argument until the next unquoted space — which is exactly what the docker error shows.

---

### **Description**
- Extract the `-v` mount formatting in `DockerCommandManager.DockerCreate` into a testable helper `FormatMountVolumeArg(sourceVolumePath, targetVolumePath, readOnly)`.
- Add `QuotePathForCommandLine` that escapes embedded `"` and **doubles any trailing backslashes** before wrapping the path in quotes. Under MS CRT parsing rules, `"F:\\"` decodes back to `F:\` with the closing quote intact, so docker receives a single, well-formed mount spec.
- Behavior for paths without a trailing backslash (`D:\a\_work`, `F:\_tasks`, `C:\ToolCache`, etc.) is unchanged.
- Doc comment on `FormatMountVolumeArg` includes the actual mount specs taken from the failing `InitializeContainers` logs (`D:\a\_work`, `D:\a\_work\_tasks`, `F:\`, `F:\_tasks`) so the expected output is documented next to the code.

After the fix, the failing line above serializes to:

```
docker create ... -v "F:\\":"C:\__w" -v "F:\_tasks":"F:\_tasks" ...
```

which docker.exe parses correctly as `-v F:\:C:\__w` and `-v F:\_tasks:F:\_tasks`.

---

### **Risk Assessment** (Low / Medium / High)
**Low.**

- Change is localized to a single helper used only by `DockerCommandManager.DockerCreate`; no callers outside the worker.
- For every path that does *not* end in `\` (the overwhelming majority — workspace, tasks, tools, externals directories produced via `Path.GetFullPath` / `HostContext.GetDirectory`), the emitted `-v` string is byte-for-byte identical to today's output, so existing pipelines are unaffected.
- For paths that *do* end in `\`, the previous output was already broken on Windows (`docker create` failed); the new output is the documented escaping per MS CRT rules and produces a valid mount spec.
- Affects only the host-side command-line serialization; container runtime, mount semantics, and volume contents are unchanged.
- Backed by L0 unit tests covering the regression cases from the production logs as well as anonymous, read-only, embedded-quote, and multi-trailing-backslash variants.

---

### **Unit Tests Added or Updated** (Yes / No)
**Yes.** New L0 tests in `src/Test/L0/Container/DockerCommandManagerL0.cs`:

- `FormatMountVolumeArg_BindMount_BuildsExpectedArg`
- `FormatMountVolumeArg_BindMount_ReadOnly_AppendsRoSuffix`
- `FormatMountVolumeArg_AnonymousVolume_NoSource`
- `FormatMountVolumeArg_BindMount_DriveRootSource_DoublesTrailingBackslash`
- `FormatMountVolumeArg_BindMount_DriveRootTarget_DoublesTrailingBackslash`
- `FormatMountVolumeArg_BindMount_MultipleTrailingBackslashes_AreAllDoubled`
- `FormatMountVolumeArg_AnonymousVolume_TrailingBackslashTarget_IsDoubled`
- `FormatMountVolumeArg_BindMount_PathWithEmbeddedQuote_IsEscaped`
- `FormatMountVolumeArg_InitializeContainersLogScenarios` (`[Theory]` with the four real `D:\a\_work`, `D:\a\_work\_tasks`, `F:\`, `F:\_tasks` cases from the failing log)

All 14 `DockerCommandManagerL0` tests (6 pre-existing + 8 new + 1 theory with 4 inline cases) pass on `net8.0` / `win-x64`.

---
