### PR TITLE
Upgrading the version of the task CodeSignValidation in release pipeline

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -289,7 +289,7 @@ jobs:
   - ${{ if parameters.verifySigning }}:
 
     # Verify all binaries are signed (generate report)
-    - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodesignValidation@0
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-codesignvalidation.CodesignValidation@1
       displayName: 'Generate Codesign Report'
       inputs:
         path: ${{ variables.layoutRoot }}


### PR DESCRIPTION
### **Context**
The VSTS.Agent.Release pipeline is emitting a deprecation warning on every run for the Secure Development Tools (Guardian v1) extension, which will be phased out.

[AB#2428779](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2428779)


---

### **Description**
Bumping the major version of the task as suggested [here](https://aka.ms/gdn-v1-deprecation)


---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
NA

---

### **Additional Testing Performed**
NA

--- 

### **Change Behind Feature Flag** (Yes / No)
NA

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
NA
---
### **Logging Added/Updated** (Yes/No)
NA

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
- Revert to old version.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
