### PR TITLE
Fail fast in Node10/Node6 strategy path when node binary is absent

### DIFF
--- a/src/Agent.Worker/NodeVersionStrategies/Node10Strategy.cs
+++ b/src/Agent.Worker/NodeVersionStrategies/Node10Strategy.cs
@@ -9,11 +9,23 @@ using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker;
+using Microsoft.VisualStudio.Services.Agent.Worker.Handlers;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
 {
     public sealed class Node10Strategy : INodeVersionStrategy
     {
+        private readonly INodeHandlerHelper _nodeHandlerHelper;
+
+        public Node10Strategy() : this(new NodeHandlerHelper())
+        {
+        }
+
+        public Node10Strategy(INodeHandlerHelper nodeHandlerHelper)
+        {
+            _nodeHandlerHelper = nodeHandlerHelper ?? throw new ArgumentNullException(nameof(nodeHandlerHelper));
+        }
+
         public NodeRunnerInfo CanHandle(TaskContext context, IExecutionContext executionContext, GlibcCompatibilityInfo glibcInfo)
         {
             bool eolPolicyEnabled = AgentKnobs.EnableEOLNodeVersionPolicy.GetValue(executionContext).AsBoolean();
@@ -28,6 +40,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
             if (eolPolicyEnabled)
             {
                 throw new NotSupportedException(StringUtil.Loc("NodeEOLPolicyBlocked", "Node10"));
+            }
+
+            // Only use Node10 if the binary actually exists on disk
+            // (e.g., vsts-agent package includes it; pipelines-agent does not).
+            // When absent, return null so the orchestrator falls through to its
+            // clean terminal error instead of returning a non-existent node path
+            // that fails later at process launch.
+            var hostContext = executionContext.GetHostContext();
+            string node10Folder = NodeVersionHelper.GetFolderName(NodeVersion.Node10);
+            if (!_nodeHandlerHelper.IsNodeFolderExist(node10Folder, hostContext))
+            {
+                executionContext.Debug("[Node10Strategy] Node10 binary not found on disk, skipping to allow fallback to next strategy");
+                return null;
             }
 
             if (context.HandlerData is Node10HandlerData)

--- a/src/Agent.Worker/NodeVersionStrategies/Node20Strategy.cs
+++ b/src/Agent.Worker/NodeVersionStrategies/Node20Strategy.cs
@@ -8,18 +8,43 @@ using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker;
 using Microsoft.VisualStudio.Services.Agent.Worker.Container;
+using Microsoft.VisualStudio.Services.Agent.Worker.Handlers;
 using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
 {
     public sealed class Node20Strategy : INodeVersionStrategy
     {
+        private readonly INodeHandlerHelper _nodeHandlerHelper;
+
+        public Node20Strategy() : this(new NodeHandlerHelper())
+        {
+        }
+
+        public Node20Strategy(INodeHandlerHelper nodeHandlerHelper)
+        {
+            _nodeHandlerHelper = nodeHandlerHelper ?? throw new ArgumentNullException(nameof(nodeHandlerHelper));
+        }
+
         public NodeRunnerInfo CanHandle(TaskContext context, IExecutionContext executionContext, GlibcCompatibilityInfo glibcInfo)
         {
             bool useNode20Globally = AgentKnobs.UseNode20_1.GetValue(executionContext).AsBoolean();
             bool eolPolicyEnabled = AgentKnobs.EnableEOLNodeVersionPolicy.GetValue(executionContext).AsBoolean();
 
             string taskName = executionContext.Variables.Get(Constants.Variables.Task.DisplayName) ?? "Unknown Task";
+
+            // Only use Node20 if the binary actually exists on disk. When absent, return null
+            // so the orchestrator falls through to the next strategy (and ultimately its clean
+            // terminal error) instead of returning a non-existent node path that would fail
+            // later at process launch. This guard is placed before the knob-driven returns so
+            // that even a global override / EOL upgrade cannot select a missing Node20.
+            var hostContext = executionContext.GetHostContext();
+            string node20Folder = NodeVersionHelper.GetFolderName(NodeVersion.Node20);
+            if (!_nodeHandlerHelper.IsNodeFolderExist(node20Folder, hostContext))
+            {
+                executionContext.Debug("[Node20Strategy] Node20 binary not found on disk, skipping to allow fallback to next strategy");
+                return null;
+            }
 
             if (glibcInfo.Node20HasGlibcError)
             {

--- a/src/Agent.Worker/NodeVersionStrategies/Node6Strategy.cs
+++ b/src/Agent.Worker/NodeVersionStrategies/Node6Strategy.cs
@@ -8,11 +8,23 @@ using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Microsoft.VisualStudio.Services.Agent;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker;
+using Microsoft.VisualStudio.Services.Agent.Worker.Handlers;
 
 namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
 {
     public sealed class Node6Strategy : INodeVersionStrategy
     {
+        private readonly INodeHandlerHelper _nodeHandlerHelper;
+
+        public Node6Strategy() : this(new NodeHandlerHelper())
+        {
+        }
+
+        public Node6Strategy(INodeHandlerHelper nodeHandlerHelper)
+        {
+            _nodeHandlerHelper = nodeHandlerHelper ?? throw new ArgumentNullException(nameof(nodeHandlerHelper));
+        }
+
         public NodeRunnerInfo CanHandle(TaskContext context, IExecutionContext executionContext, GlibcCompatibilityInfo glibcInfo)
         {
             bool eolPolicyEnabled = AgentKnobs.EnableEOLNodeVersionPolicy.GetValue(executionContext).AsBoolean();
@@ -27,6 +39,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
 
             if (hasNode6Handler)
             {
+                // Only use Node6 if the binary actually exists on disk
+                // (e.g., vsts-agent package includes it; pipelines-agent does not).
+                // When absent, return null so the orchestrator falls through to its
+                // clean terminal error instead of returning a non-existent node path
+                // that fails later at process launch.
+                var hostContext = executionContext.GetHostContext();
+                string node6Folder = NodeVersionHelper.GetFolderName(NodeVersion.Node6);
+                if (!_nodeHandlerHelper.IsNodeFolderExist(node6Folder, hostContext))
+                {
+                    executionContext.Debug("[Node6Strategy] Node6 binary not found on disk, skipping to allow fallback to next strategy");
+                    return null;
+                }
+
                 return new NodeRunnerInfo
                 {
                     NodePath = null,

--- a/src/Agent.Worker/NodeVersionStrategies/NodeVersionOrchestrator.cs
+++ b/src/Agent.Worker/NodeVersionStrategies/NodeVersionOrchestrator.cs
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
             _strategies.Add(new Node24Strategy(nodeHandlerHelper));
             _strategies.Add(new Node20Strategy());
             _strategies.Add(new Node16Strategy());
-            _strategies.Add(new Node10Strategy());
-            _strategies.Add(new Node6Strategy());
+            _strategies.Add(new Node10Strategy(nodeHandlerHelper));
+            _strategies.Add(new Node6Strategy(nodeHandlerHelper));
         }
 
         /// <summary>

--- a/src/Agent.Worker/NodeVersionStrategies/NodeVersionOrchestrator.cs
+++ b/src/Agent.Worker/NodeVersionStrategies/NodeVersionOrchestrator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies
             // The orchestrator will try each strategy in order until one can handle the request
             _strategies.Add(new CustomNodeStrategy());
             _strategies.Add(new Node24Strategy(nodeHandlerHelper));
-            _strategies.Add(new Node20Strategy());
+            _strategies.Add(new Node20Strategy(nodeHandlerHelper));
             _strategies.Add(new Node16Strategy());
             _strategies.Add(new Node10Strategy(nodeHandlerHelper));
             _strategies.Add(new Node6Strategy(nodeHandlerHelper));

--- a/src/Test/L0/NodeStrategyFallbackL0.cs
+++ b/src/Test/L0/NodeStrategyFallbackL0.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.VisualStudio.Services.Agent.Util;
+using Microsoft.VisualStudio.Services.Agent.Worker;
+using Microsoft.VisualStudio.Services.Agent.Worker.Handlers;
+using Microsoft.VisualStudio.Services.Agent.Worker.NodeVersionStrategies;
+using Moq;
+using Xunit;
+using Agent.Sdk;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests
+{
+    /// <summary>
+    /// Tests that the Node10 and Node6 strategies fail fast (return null so the
+    /// orchestrator surfaces its clean terminal error) when the corresponding
+    /// node binary is not present on disk — e.g. on the pipelines-agent package,
+    /// which does not ship node6/node10. This mirrors the on-disk guard already
+    /// present in Node24Strategy/Node16Strategy and avoids returning a
+    /// non-existent node path that would otherwise fail later at process launch.
+    /// </summary>
+    [Collection("Unified NodeHandler Tests")]
+    public sealed class NodeStrategyFallbackL0
+    {
+        private void ClearEolKnob()
+        {
+            // Ensure the EOL-policy knob is not accidentally enabled by the host environment.
+            Environment.SetEnvironmentVariable("AGENT_RESTRICT_EOL_NODE_VERSIONS", null);
+        }
+
+        private Mock<IExecutionContext> CreateExecutionContext(TestHostContext tc)
+        {
+            var executionContext = new Mock<IExecutionContext>();
+            var variables = new Dictionary<string, VariableValue>
+            {
+                // Force node-selection knobs to deterministic values via RuntimeKnobSource, which
+                // reads from the execution context variables and takes precedence over the process
+                // environment variable. This avoids cross-test env-var races (other test collections
+                // run in parallel and may set these globals).
+                { "AGENT_RESTRICT_EOL_NODE_VERSIONS", "false" },
+                { "AGENT_USE_NODE20_1", "false" },
+                { "AGENT_USE_NODE24", "false" },
+                { "AGENT_USE_NODE24_WITH_HANDLER_DATA", "false" }
+            };
+            List<string> warnings;
+
+            executionContext
+                .Setup(x => x.Variables)
+                .Returns(new Variables(tc, copy: variables, warnings: out warnings));
+
+            executionContext
+                .Setup(x => x.GetScopedEnvironment())
+                .Returns(new SystemEnvironment());
+
+            executionContext
+                .Setup(x => x.GetVariableValueOrDefault(It.IsAny<string>()))
+                .Returns((string variableName) =>
+                {
+                    if (variables.TryGetValue(variableName, out VariableValue value))
+                    {
+                        return value.Value;
+                    }
+                    return null;
+                });
+
+            executionContext
+                .Setup(x => x.GetHostContext())
+                .Returns(tc);
+
+            return executionContext;
+        }
+
+        private Mock<INodeHandlerHelper> CreateNodeHandlerHelper(bool nodeFolderExists)
+        {
+            var helper = new Mock<INodeHandlerHelper>();
+
+            helper
+                .Setup(x => x.IsNodeFolderExist(It.IsAny<string>(), It.IsAny<IHostContext>()))
+                .Returns(nodeFolderExists);
+
+            helper
+                .Setup(x => x.GetNodeFolderPath(It.IsAny<string>(), It.IsAny<IHostContext>()))
+                .Returns((string nodeFolderName, IHostContext hostContext) => Path.Combine(
+                    hostContext.GetDirectory(WellKnownDirectory.Externals),
+                    nodeFolderName,
+                    "bin",
+                    $"node{IOUtil.ExeExtension}"));
+
+            // node24 executable check: report not executable so Node24Strategy skips in orchestrator tests.
+            helper
+                .Setup(x => x.IsNodeExecutable(It.IsAny<string>(), It.IsAny<IHostContext>(), It.IsAny<IExecutionContext>()))
+                .Returns(false);
+
+            return helper;
+        }
+
+        private Mock<IGlibcCompatibilityInfoProvider> CreateGlibcProvider()
+        {
+            var glibcMock = new Mock<IGlibcCompatibilityInfoProvider>();
+            glibcMock.Setup(x => x.Initialize(It.IsAny<IHostContext>()));
+            glibcMock
+                .Setup(x => x.GetGlibcCompatibilityAsync(It.IsAny<TaskContext>(), It.IsAny<IExecutionContext>()))
+                .ReturnsAsync(GlibcCompatibilityInfo.Compatible);
+            glibcMock
+                .Setup(x => x.CheckGlibcCompatibilityAsync(It.IsAny<IExecutionContext>()))
+                .ReturnsAsync(GlibcCompatibilityInfo.Compatible);
+            return glibcMock;
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Node10Strategy_ReturnsNull_WhenNode10BinaryAbsent()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: false);
+                var strategy = new Node10Strategy(helper.Object);
+                var context = new TaskContext { HandlerData = new Node10HandlerData() };
+
+                var result = strategy.CanHandle(context, executionContext.Object, GlibcCompatibilityInfo.Compatible);
+
+                Assert.Null(result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Node10Strategy_ReturnsNode10_WhenNode10BinaryPresent()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: true);
+                var strategy = new Node10Strategy(helper.Object);
+                var context = new TaskContext { HandlerData = new Node10HandlerData() };
+
+                var result = strategy.CanHandle(context, executionContext.Object, GlibcCompatibilityInfo.Compatible);
+
+                Assert.NotNull(result);
+                Assert.Equal(NodeVersion.Node10, result.NodeVersion);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Node6Strategy_ReturnsNull_WhenNode6BinaryAbsent()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: false);
+                var strategy = new Node6Strategy(helper.Object);
+                var context = new TaskContext { HandlerData = new NodeHandlerData() };
+
+                var result = strategy.CanHandle(context, executionContext.Object, GlibcCompatibilityInfo.Compatible);
+
+                Assert.Null(result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Node6Strategy_ReturnsNode6_WhenNode6BinaryPresent()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: true);
+                var strategy = new Node6Strategy(helper.Object);
+                var context = new TaskContext { HandlerData = new NodeHandlerData() };
+
+                var result = strategy.CanHandle(context, executionContext.Object, GlibcCompatibilityInfo.Compatible);
+
+                Assert.NotNull(result);
+                Assert.Equal(NodeVersion.Node6, result.NodeVersion);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task Orchestrator_HostSelection_FailsFast_WhenNode10TaskAndNoNodeAvailable()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                thc.SetSingleton<IGlibcCompatibilityInfoProvider>(CreateGlibcProvider().Object);
+
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: false);
+                var orchestrator = new NodeVersionOrchestrator(executionContext.Object, thc, helper.Object);
+                var context = new TaskContext { HandlerData = new Node10HandlerData() };
+
+                // With node10/node16/node6 absent and node24 not executable, no strategy
+                // can handle the Node10 task, so the orchestrator throws its clean terminal error.
+                await Assert.ThrowsAsync<NotSupportedException>(
+                    () => orchestrator.SelectNodeVersionForHostAsync(context));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public async Task Orchestrator_HostSelection_FailsFast_WhenNode6TaskAndNoNodeAvailable()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                thc.SetSingleton<IGlibcCompatibilityInfoProvider>(CreateGlibcProvider().Object);
+
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: false);
+                var orchestrator = new NodeVersionOrchestrator(executionContext.Object, thc, helper.Object);
+                var context = new TaskContext { HandlerData = new NodeHandlerData() };
+
+                await Assert.ThrowsAsync<NotSupportedException>(
+                    () => orchestrator.SelectNodeVersionForHostAsync(context));
+            }
+        }
+    }
+}

--- a/src/Test/L0/NodeStrategyFallbackL0.cs
+++ b/src/Test/L0/NodeStrategyFallbackL0.cs
@@ -193,6 +193,45 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public void Node20Strategy_ReturnsNull_WhenNode20BinaryAbsent()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: false);
+                var strategy = new Node20Strategy(helper.Object);
+                var context = new TaskContext { HandlerData = new Node20_1HandlerData() };
+
+                var result = strategy.CanHandle(context, executionContext.Object, GlibcCompatibilityInfo.Compatible);
+
+                Assert.Null(result);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void Node20Strategy_ReturnsNode20_WhenNode20BinaryPresent()
+        {
+            ClearEolKnob();
+            using (TestHostContext thc = new TestHostContext(this))
+            {
+                var executionContext = CreateExecutionContext(thc);
+                var helper = CreateNodeHandlerHelper(nodeFolderExists: true);
+                var strategy = new Node20Strategy(helper.Object);
+                var context = new TaskContext { HandlerData = new Node20_1HandlerData() };
+
+                var result = strategy.CanHandle(context, executionContext.Object, GlibcCompatibilityInfo.Compatible);
+
+                Assert.NotNull(result);
+                Assert.Equal(NodeVersion.Node20, result.NodeVersion);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public async Task Orchestrator_HostSelection_FailsFast_WhenNode10TaskAndNoNodeAvailable()
         {
             ClearEolKnob();


### PR DESCRIPTION
### **Context**
The agent has two node-selection paths: the newer **strategy** path (`NodeVersionStrategies`) and the **legacy** path (`NodeHandler.GetNodeLocationLegacy`). They behaved **inconsistently** when a requested EOL node binary was **absent on disk** (e.g. the `pipelines-agent` package, which does not ship node6 / node10, and can be built without node20):

- **Legacy path:** fails fast with a clear `MissingNodePath` error.
- **Strategy path:** returned a `NodeRunnerInfo` pointing at a **non-existent** node path, which then failed *later* at process launch with an opaque `file not found`-style error.

This PR makes the strategy path fail fast the same way, closing the gap for Node10, Node6, and Node20.

Related: standalone follow-up to the node-selection work; independent of PR #5555 (Remove node16 from pipelines-agent).

---

### **Description**
Mirror the on-disk existence guard already used by `Node24Strategy` so the strategy path fails fast (returns `null`) when the requested node binary folder is absent, letting `NodeVersionOrchestrator` surface its clean terminal `NotSupportedException` instead of a downstream launch failure.

- **`Node10Strategy` / `Node6Strategy`:** inject `INodeHandlerHelper` and **return `null`** when `IsNodeFolderExist(...)` is false, so the orchestrator exhausts the chain and throws `NodeVersionNotAvailable` (`NotSupportedException`).
- **`Node20Strategy`:** same injection + guard, placed at the top of `CanHandle` so even a global `AGENT_USE_NODE20_1` override / EOL upgrade cannot select a missing Node20. The container path (`CanHandleInContainer`) is intentionally unchanged (node is injected into the container).
- **`NodeVersionOrchestrator`:** wires the shared `INodeHandlerHelper` into `Node20Strategy`, `Node10Strategy`, and `Node6Strategy` (parameterless ctors preserved for compatibility).

**No behavior change** when the binary is present (e.g. vsts-agent package) or when EOL policy is enabled (Node24/Node20 still upgrade EOL tasks).

---

### **Risk Assessment** (Low / Medium / High)
Low - Behaind a NodeStrategy FF that is yet to be enabled 
Touches host node selection — a path used by every Node task — but the change is narrow: strategies only return `null` (fall through) when the binary is genuinely missing, which previously produced a broken node path anyway. When binaries are present the selection is unchanged, and the parameterless constructors are preserved. Covered by new L0 unit tests.

---

### **Unit Tests Added or Updated** (Yes / No)
Yes. New `NodeStrategyFallbackL0` L0 suite:
- `Node10Strategy` / `Node6Strategy` / `Node20Strategy` return `null` when their binary is absent, and select the expected version when present.
- The orchestrator throws `NotSupportedException` (fail fast) for a Node10 or Node6 task when no compatible node is available.

Node-selection knobs are seeded via the execution context (RuntimeKnobSource precedence) so the tests are deterministic regardless of environment-variable state set by other parallel test collections.

---

### **Additional Testing Performed**
Targeted L0 runs on the built Test project (net8.0, osx-arm64): the node-related suite (`NodeStrategy` / `NodeVersion` / `NodeHandler` filters) passes **154 / 0 failed**, including the new Node10/Node6/Node20 guard tests and the orchestrator fail-fast tests. No integration/E2E changes required — the change only affects which strategy claims a task when a binary is missing.

---

### **Change Behind Feature Flag** (Yes / No)
No. This corrects an error-handling inconsistency (opaque late failure → clean fail-fast) for an already-invalid state (requested node binary absent); it does not introduce new user-facing behavior that warrants a flag. Existing knobs (`AGENT_USE_NODE20_1`, `AGENT_RESTRICT_EOL_NODE_VERSIONS`, etc.) still govern selection.

---

### **Tech Design / Approach**
- Reuses the established `INodeHandlerHelper.IsNodeFolderExist(...)` guard pattern from `Node24Strategy`, applied consistently to `Node10`/`Node6`/`Node20`.
- Strategies return `null` (fall through) rather than throwing, so the single terminal error stays centralized in `NodeVersionOrchestrator` (`NotSupportedException` / `NodeVersionNotAvailable`).
- Guard placed before knob-driven returns in `Node20Strategy` so overrides/EOL upgrades cannot select a missing binary; container selection left untouched.

---

### **Documentation Changes Required** (Yes/No)
No.

---

### **Logging Added/Updated** (Yes/No)
Yes. Debug-level trace added when a strategy skips due to a missing binary (e.g. `[Node20Strategy] Node20 binary not found on disk, skipping to allow fallback to next strategy`). No sensitive data logged.

---

### **Telemetry Added/Updated** (Yes/No)
No.

---

### **Rollback Scenario and Process** (Yes/No)
Yes. Revert the branch/commits to restore the prior strategy behavior. Because the strategies key off binary presence and preserve parameterless constructors, reverting is self-contained with no data/state migration.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes. Only the `NodeVersionStrategies` and their orchestrator wiring are affected. `NodeVersionOrchestrator` already constructed `Node24Strategy` with `INodeHandlerHelper`; the same instance is now shared with Node20/Node10/Node6. Existing orchestrator tests (Node10/Node6 fail-fast) and the broader node L0 suite pass without regressions.
