### PR TITLE
Populate task inputs, endpoints, and secure files after public variables in Node/PowerShell3 handlers

### DIFF
--- a/src/Agent.Worker/Handlers/NodeHandler.cs
+++ b/src/Agent.Worker/Handlers/NodeHandler.cs
@@ -181,10 +181,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             }
 
             // Update the env dictionary.
+            AddVariablesToEnvironment();
             AddInputsToEnvironment();
             AddEndpointsToEnvironment();
             AddSecureFilesToEnvironment();
-            AddVariablesToEnvironment();
             AddTaskVariablesToEnvironment();
             AddPrependPathToEnvironment();
 

--- a/src/Agent.Worker/Handlers/PowerShell3Handler.cs
+++ b/src/Agent.Worker/Handlers/PowerShell3Handler.cs
@@ -33,10 +33,10 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
             ArgUtil.Directory(TaskDirectory, nameof(TaskDirectory));
 
             // Update the env dictionary.
+            AddVariablesToEnvironment();
             AddInputsToEnvironment();
             AddEndpointsToEnvironment();
             AddSecureFilesToEnvironment();
-            AddVariablesToEnvironment();
             AddTaskVariablesToEnvironment();
             AddPrependPathToEnvironment();
             RemovePSModulePathFromEnvironment();


### PR DESCRIPTION
### **Context**
The Node and PowerShell3 task handlers build the task process environment by writing several groups of values into the same environment dictionary: agent-populated values derived from the task definition and protected resources — task inputs (`INPUT_*`), service connection endpoints (`ENDPOINT_URL_*` / `ENDPOINT_AUTH_*` / `ENDPOINT_DATA_*`), and secure files (`SECUREFILE_*`) — as well as public pipeline variables coming from the job/previous steps.

These values were written via a last-writer-wins setter, with the public pipeline variables written **last**. As a result, a public variable whose formatted name matched one of the agent-populated keys would overwrite the agent-provided value. The reserved `endpoint`/`input`/`securefile` prefixes are documented as system-reserved namespaces, so agent-populated values in those namespaces should take precedence over user-defined variables. This is a defense-in-depth hardening to align the runtime behavior with that contract.

---

### **Description**
Reorder the environment-dictionary population in `NodeHandler` and `PowerShell3Handler` so that `AddVariablesToEnvironment()` (public pipeline variables) runs **before** `AddInputsToEnvironment()`, `AddEndpointsToEnvironment()`, and `AddSecureFilesToEnvironment()`.

With this ordering, agent-populated task input, endpoint, and secure-file environment values are written after the public variables and therefore are not overwritten by a user-defined public variable of the same name. Variables whose names do not collide with the reserved namespaces are unaffected (ordering is irrelevant for distinct keys).

---

### **Risk Assessment** (Low / Medium / High)
**Low.** The change only affects the *order* in which values are written during the per-task environment build in two handlers. For non-colliding names there is no behavioral change. The only behavioral difference is that when a public variable name collides with an agent-populated `INPUT_*` / `ENDPOINT_*` / `SECUREFILE_*` key, the agent-populated value now wins — which matches the documented reserved-namespace contract. A pipeline that previously relied (intentionally or not) on a public variable overwriting one of these reserved keys would now observe the agent-populated value instead.

---

### **Unit Tests Added or Updated** (Yes / No)
**No.** This is a minimal ordering change. 

---

### **Additional Testing Performed**
Manual validation on a self-hosted Windows agent:
- A public variable matching a task input key (e.g. `INPUT_SCRIPT`) no longer overrides the agent-populated task input; the task runs with its intended input value.
- A public variable matching an endpoint URL key (`ENDPOINT_URL_<id>`) no longer overrides the endpoint URL populated from the service connection.
- Non-colliding public variables continue to flow through to the task environment unchanged.

---

### **Change Behind Feature Flag** (Yes / No)
**No.** The change is a small, self-contained ordering correction. Gating it behind a knob would retain the previous ordering as the default and add unnecessary complexity.

---

### **Tech Design / Approach**
- The environment dictionary is populated via a shared `AddEnvironmentVariable` helper that is last-writer-wins (`Environment[key] = value`).
- Both the Node and PowerShell3 handlers inject endpoints/inputs/secure files, so the ordering is corrected in both to keep behavior consistent across handlers.

---

### **Documentation Changes Required** (Yes/No)
**No.** 

---

### **Logging Added/Updated** (Yes/No)
**No.**

---

### **Telemetry Added/Updated** (Yes/No)
**No.**

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Revert this PR. The change is isolated to the ordering of method calls in `NodeHandler` and `PowerShell3Handler`; reverting restores the previous behavior with no data or schema impact.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes (Low impact).** Only the Node and PowerShell3 handler environment-build order changes. No public APIs, contracts, or third-party dependencies are affected. Task inputs, endpoints, and secure files continue to be populated; only their precedence relative to same-named public variables changes.
