### PR TITLE
WIF IdToken leak fix

### DIFF
--- a/src/Agent.Sdk/Util/MaskingUtil.cs
+++ b/src/Agent.Sdk/Util/MaskingUtil.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
         public static bool IsEndpointAuthorizationParametersSecret(string key)
         {
             var excludedAuthParams = new string[]{
-                EndpointAuthorizationParameters.IdToken,
                 EndpointAuthorizationParameters.Role,
                 EndpointAuthorizationParameters.Scope,
                 EndpointAuthorizationParameters.TenantId,

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Microsoft.VisualStudio.Services.WebApi;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using EndpointAuthorizationParameters = Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi.EndpointAuthorizationParameters;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 {
@@ -140,7 +141,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 
                 // Put a sentinel WIF ID token on the endpoint's authorization parameters.
                 const string idToken = "sentinel-wif-id-token";
-                jobMessage.Resources.Endpoints[0].Authorization.Parameters["IdToken"] = idToken;
+                jobMessage.Resources.Endpoints[0].Authorization.Parameters[EndpointAuthorizationParameters.IdToken] = idToken;
 
                 var arWorkerMessages = new WorkerMessage[]
                     {

--- a/src/Test/L0/Worker/WorkerL0.cs
+++ b/src/Test/L0/Worker/WorkerL0.cs
@@ -123,6 +123,63 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Worker")]
+        public async Task InitializeSecretMaskerMasksEndpointIdToken()
+        {
+            //Arrange
+            using (var hc = new TestHostContext(this))
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                var worker = new Microsoft.VisualStudio.Services.Agent.Worker.Worker();
+                hc.EnqueueInstance<IProcessChannel>(_processChannel.Object);
+                hc.EnqueueInstance<IJobRunner>(_jobRunner.Object);
+                hc.SetSingleton<IVstsAgentWebProxy>(_proxy.Object);
+                hc.SetSingleton<IAgentCertificateManager>(_cert.Object);
+                worker.Initialize(hc);
+
+                var jobMessage = CreateJobRequestMessage("job1");
+
+                // Put a sentinel WIF ID token on the endpoint's authorization parameters.
+                const string idToken = "sentinel-wif-id-token";
+                jobMessage.Resources.Endpoints[0].Authorization.Parameters["IdToken"] = idToken;
+
+                var arWorkerMessages = new WorkerMessage[]
+                    {
+                        new WorkerMessage
+                        {
+                            Body = JsonUtility.ToString(jobMessage),
+                            MessageType = MessageType.NewJobRequest
+                        }
+                    };
+                var workerMessages = new Queue<WorkerMessage>(arWorkerMessages);
+
+                _processChannel
+                    .Setup(x => x.ReceiveAsync(It.IsAny<CancellationToken>()))
+                    .Returns(async () =>
+                    {
+                        if (workerMessages.Count > 0)
+                        {
+                            return workerMessages.Dequeue();
+                        }
+
+                        await Task.Delay(-1, tokenSource.Token);
+                        return default(WorkerMessage);
+                    });
+                _jobRunner.Setup(x => x.RunAsync(It.IsAny<Pipelines.AgentJobRequestMessage>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult<TaskResult>(TaskResult.Succeeded));
+
+                //Act
+                await worker.RunAsync(pipeIn: "1", pipeOut: "2");
+
+                //Assert - the IdToken must actually be redacted after going through Worker.InitializeSecretMasker.
+                Assert.Equal("***", hc.SecretMasker.MaskSecrets(idToken));
+                Assert.Equal("token: ***", hc.SecretMasker.MaskSecrets($"token: {idToken}"));
+                tokenSource.Cancel();
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
         public async Task DispatchCancellation()
         {
             //Arrange


### PR DESCRIPTION
### Context
This PR fixes a security issue in endpoint authorization-parameter masking. `IdToken` was excluded from secret masking, which could allow a WIF ID token to appear in diagnostic logs.
[ICM 31000000655065](https://portal.microsofticm.com/imp/v5/incidents/details/31000000655065/summary)



---

### Description
Updated `MaskingUtil` to remove `EndpointAuthorizationParameters.IdToken` from the excluded authorization-parameter list.

This causes `IdToken` values to be registered as secrets and masked by the existing agent secret-masking flow.

---

### Risk Assessment (Low / Medium / High)
Low

Reason:

- Single-line secret-classification change.
- No authentication, endpoint authorization, token generation, or token-exchange logic changes.

---

### Unit Tests Added or Updated (Yes / No)
Yes

Added L0 unit test `InitializeSecretMaskerMasksEndpointIdToken` in `src/Test/L0/Worker/WorkerL0.cs` verifying an endpoint `IdToken` is actually masked (`***`) after flowing through `Worker.InitializeSecretMasker`.

---

### Additional Testing Performed
- PR validation pipeline completed successfully: `azure-pipelines-agent.ci`

---

### Change Behind Feature Flag (Yes / No)
No

This is a security masking fix and should apply to all agents.

---

### Tech Design / Approach
- Kept the change minimal by removing `IdToken` from the non-secret allowlist.
- Reused existing endpoint-secret masking logic in `Worker.cs`.
- Preserved behavior for all other authorization parameter classifications.

---

### Documentation Changes Required (Yes/No)
No

No user-facing documentation or API changes are required.

---

### Logging Added/Updated (Yes/No)
No

No logging was added.

---

### Telemetry Added/Updated (Yes/No)
No

No telemetry changes are required.

---

### Rollback Scenario and Process (Yes/No)
Yes

Rollback plan:

- Revert this commit to restore the previous parameter classification.
- Merge a rollback PR if unexpected masking behavior is observed.

---

### Dependency Impact Assessed and Regression Tested (Yes/No)
Yes

- Impact is isolated to endpoint authorization-value redaction.
- No external dependencies, API contracts, or authentication behavior are changed.
- Existing agent behavior continues to use the same secret-masking infrastructure.