### PR TITLE
Avoid stale connection when creating release PRs

### DIFF
--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -23,7 +23,6 @@ const opt = require('node-getopt').create([
 const orgUrl = 'dev.azure.com/mseng';
 const httpsOrgUrl = `https://${orgUrl}`;
 const authHandler = azdev.getPersonalAccessTokenHandler(process.env.PAT);
-const connection = new azdev.WebApi(httpsOrgUrl, authHandler);
 
 /**
  * Fills InstallAgentPackage.xml and Publish.ps1 templates.
@@ -122,6 +121,7 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
     const pullRequest = { ...refs, title, description };
 
     console.log('Getting Git API');
+    const connection = new azdev.WebApi(httpsOrgUrl, authHandler, { keepAlive: true });
     const gitApi = await connection.getGitApi();
 
     console.log('Checking if an active pull request for the source and target branch already exists');


### PR DESCRIPTION
## Issue

Fixes investigation for [Azure DevOps work item 2418185](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2418185): **VSTS Agent release pipeline's CreatePRs job is failing**.

## Problem

The `CreatePRs` stage consistently fails while checking for an existing PR in `AzureDevOps.ConfigChange`:

```text
Checking if an active pull request for the source and target branch already exists
##[error]write ECONNRESET
```

The ConfigChange clone, file copy, commit, and push all complete successfully. The failure occurs on the first Azure DevOps REST request after those Git operations.

## Likely cause

`createAdoPrs.js` previously created one `WebApi` client at module startup. The script then used synchronous Git commands through `execSync`. Cloning `AzureDevOps.ConfigChange` takes approximately 5-8 minutes, during which the Node.js event loop is blocked and the earlier REST connection remains idle.

If Azure DevOps or an intermediate gateway closes that idle socket, Node cannot process the close event while blocked. The following PR lookup can then reuse the stale socket and fail immediately with `ECONNRESET`.

## Local reproduction

A read-only local probe used the same `azure-devops-node-api@12.5.0` client and performed:

1. A successful PR lookup in `AzureDevOps`.
2. A synchronous seven-minute event-loop block to simulate the ConfigChange clone.
3. A PR lookup in `AzureDevOps.ConfigChange`.

The second request reused the original socket and failed in 2 ms:

```json
{"event":"request-socket","requestId":5,"socketId":1,"reusedSocket":true}
{"event":"request-error","requestId":5,"reusedSocket":true,"code":"ECONNABORTED","message":"write ECONNABORTED","elapsedMs":2}
```

After destroying the old socket pool, the same request used a new socket and succeeded with HTTP 200:

```json
{"event":"request-socket","requestId":6,"socketId":2,"reusedSocket":false}
{"event":"response","requestId":6,"reusedSocket":false,"statusCode":200,"elapsedMs":751}
{"event":"fresh-socket-retry-succeeded"}
```

`ECONNABORTED` locally and `ECONNRESET` in the Linux pipeline are platform/network-path variants of the same stale TCP connection behavior.

## Fix

Create the Azure DevOps `WebApi` client inside `openPR()` after clone, commit, and push complete. Enabling `keepAlive` gives this newly created client a private HTTPS connection pool rather than using the shared global pool.

Each repository PR flow now follows:

```text
clone -> copy -> commit -> push -> create fresh WebApi client -> check/create PR
```

The PR lookup can no longer reuse a connection that was idle during the long synchronous ConfigChange clone. The new connection may safely be reused between the adjacent PR lookup and PR creation calls.

## Blast radius

The change is limited to REST client construction in `release/createAdoPrs.js`. Git operations, authentication, generated files, branch naming, dry-run behavior, and PR behavior remain unchanged.
