### PR TITLE
Avoid stale connection when creating release PRs

### DIFF
--- a/.github/workflows/labelChecker.yml
+++ b/.github/workflows/labelChecker.yml
@@ -1,9 +1,7 @@
 # This workflow ensures that all PRs are correctly labeled
 
 name: LabelChecker
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+on: [pull_request]
 
 jobs:
   label:

--- a/.github/workflows/labelChecker.yml
+++ b/.github/workflows/labelChecker.yml
@@ -1,7 +1,9 @@
 # This workflow ensures that all PRs are correctly labeled
 
 name: LabelChecker
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   label:

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -23,7 +23,6 @@ const opt = require('node-getopt').create([
 const orgUrl = 'dev.azure.com/mseng';
 const httpsOrgUrl = `https://${orgUrl}`;
 const authHandler = azdev.getPersonalAccessTokenHandler(process.env.PAT);
-const connection = new azdev.WebApi(httpsOrgUrl, authHandler);
 
 /**
  * Fills InstallAgentPackage.xml and Publish.ps1 templates.
@@ -122,6 +121,7 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
     const pullRequest = { ...refs, title, description };
 
     console.log('Getting Git API');
+    const connection = new azdev.WebApi(httpsOrgUrl, authHandler, { keepAlive: true });
     const gitApi = await connection.getGitApi();
 
     console.log('Checking if an active pull request for the source and target branch already exists');

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -121,7 +121,7 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
     const pullRequest = { ...refs, title, description };
 
     console.log('Getting Git API');
-    const connection = new azdev.WebApi(httpsOrgUrl, authHandler, { keepAlive: true });
+    const connection = new azdev.WebApi(httpsOrgUrl, authHandler, { agent: new (require('https').Agent)({ keepAlive: true }) });
     const gitApi = await connection.getGitApi();
 
     console.log('Checking if an active pull request for the source and target branch already exists');

--- a/release/createAdoPrs.js
+++ b/release/createAdoPrs.js
@@ -121,7 +121,7 @@ async function openPR(repo, project, sourceBranch, targetBranch, commitMessage, 
     const pullRequest = { ...refs, title, description };
 
     console.log('Getting Git API');
-    const connection = new azdev.WebApi(httpsOrgUrl, authHandler, { agent: new (require('https').Agent)({ keepAlive: true }) });
+    const connection = new azdev.WebApi(httpsOrgUrl, authHandler, { keepAlive: true });
     const gitApi = await connection.getGitApi();
 
     console.log('Checking if an active pull request for the source and target branch already exists');


### PR DESCRIPTION
### **Context**

The VSTS Agent release pipeline's `CreatePRs` job fails while checking for an existing pull request in `AzureDevOps.ConfigChange`:

```text
Checking if an active pull request for the source and target branch already exists
##[error]write ECONNRESET
```

Related work item: [AB#2418185](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2418185)

The script previously created one Azure DevOps REST client before running synchronous Git operations. Cloning `AzureDevOps.ConfigChange` can take approximately 5-8 minutes, leaving the existing connection idle and potentially closed by the server or an intermediate gateway.

---

### **Description**

Create the Azure DevOps `WebApi` client inside `openPR()`, after the clone, commit, and push operations complete.

Enable the supported `keepAlive` request option so each `openPR()` invocation receives a private HTTPS connection pool. This prevents the ConfigChange PR lookup from reusing a connection that was idle during the long synchronous clone.

---

### **Risk Assessment** (Low / Medium / High)

**Low.** The change is limited to REST-client construction in the internal release PR script. Git operations, authentication, generated files, branch naming, dry-run behavior, and PR creation behavior remain unchanged.

---

### **Unit Tests Added or Updated** (Yes / No)

**No.** The PR changes only `release/createAdoPrs.js`; no test files were changed.

---

### **Additional Testing Performed**

- Reproduced the stale-connection behavior using `azure-devops-node-api@12.5.0`.
- Confirmed that the request after a simulated seven-minute synchronous block reused the old socket and failed.
- Confirmed that using a fresh client connection allowed the subsequent request to complete successfully with HTTP 200.
- Verified that `typed-rest-client@1.8.11` supports the `keepAlive` request option.
- Performed JavaScript syntax and diff validation.
- The full release pipeline dry-run was not executed.

---

### **Change Behind Feature Flag** (Yes / No)

**No.** This is an internal release-automation reliability fix with no agent runtime or customer-facing behavior change. A feature flag would add unnecessary complexity.

---

### **Tech Design / Approach**

- Move `WebApi` construction from module initialization into `openPR()`.
- Construct the client only after long-running synchronous Git operations finish.
- Pass `{ keepAlive: true }`, which `typed-rest-client@1.8.11` uses to create a private HTTPS agent.
- Allow the adjacent PR lookup and PR creation requests to reuse that fresh connection safely.

---

### **Documentation Changes Required** (Yes/No)

**No.** This change affects only internal release automation and does not change any public documentation or API.

---

### **Logging Added/Updated** (Yes/No)

**No.** Existing logging already identifies the Git API initialization and PR lookup stages.

---

### **Telemetry Added/Updated** (Yes/No)

**No.** No new telemetry is required for this isolated release-script correction.

---

### **Rollback Scenario and Process** (Yes/No)

**Yes.** Revert this PR to restore module-level `WebApi` construction. No data migration or persistent state changes are involved.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

**Yes.** No dependency manifests were changed, and `keepAlive` was verified against the existing `azure-devops-node-api@12.5.0` and `typed-rest-client@1.8.11` implementations. A local regression probe reproduced the stale-socket failure and confirmed that using a fresh client connection allowed the subsequent request to complete successfully. The full release pipeline dry-run was not executed.
