### PR TITLE
Adding check for Null character in env variable

### DIFF
--- a/src/Agent.Sdk/ProcessInvoker.cs
+++ b/src/Agent.Sdk/ProcessInvoker.cs
@@ -283,6 +283,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             {
                 foreach (KeyValuePair<string, string> kvp in environment)
                 {
+                    ArgUtil.ThrowIfContainsNull(kvp.Key, kvp.Value);
                     _proc.StartInfo.Environment[kvp.Key] = kvp.Value;
                 }
             }

--- a/src/Agent.Sdk/Util/ArgUtil/ArgUtil.cs
+++ b/src/Agent.Sdk/Util/ArgUtil/ArgUtil.cs
@@ -37,6 +37,19 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             ArgUtil.ArgUtilInstance.NotNullOrEmpty(value, name);
         }
 
+        public static void ThrowIfContainsNull(string name, string value)
+        {
+            // A NUL (U+0000) is the entry separator in the Windows native environment block and the
+            // C-string terminator in POSIX envp. It is never valid in an environment variable name or
+            // value on any OS; allowing it lets one approved variable split into two native variables
+            // (environment variable injection).
+            if ((name != null && name.IndexOf('\0') >= 0) ||
+                (value != null && value.IndexOf('\0') >= 0))
+            {
+                throw new ArgumentException(StringUtil.Loc("EnvironmentVariableContainsNullCharacter", name ?? string.Empty));
+            }
+        }
+
         public static void ListNotNullOrEmpty<T>([ValidatedNotNull] IEnumerable<T> value, string name)
         {
             ArgUtil.ArgUtilInstance.ListNotNullOrEmpty(value, name);

--- a/src/Agent.Sdk/Util/ArgUtil/ArgUtil.cs
+++ b/src/Agent.Sdk/Util/ArgUtil/ArgUtil.cs
@@ -43,10 +43,12 @@ namespace Microsoft.VisualStudio.Services.Agent.Util
             // C-string terminator in POSIX envp. It is never valid in an environment variable name or
             // value on any OS; allowing it lets one approved variable split into two native variables
             // (environment variable injection).
-            if ((name != null && name.IndexOf('\0') >= 0) ||
-                (value != null && value.IndexOf('\0') >= 0))
+            string field = (name != null && name.IndexOf('\0') >= 0) ? "name"
+                         : (value != null && value.IndexOf('\0') >= 0) ? "value"
+                         : null;
+            if (field != null)
             {
-                throw new ArgumentException(StringUtil.Loc("EnvironmentVariableContainsNullCharacter", name ?? string.Empty));
+                throw new ArgumentException(StringUtil.Loc("EnvironmentVariableContainsNullCharacter", name ?? string.Empty, field));
             }
         }
 

--- a/src/Agent.Worker/Handlers/Handler.cs
+++ b/src/Agent.Worker/Handlers/Handler.cs
@@ -234,6 +234,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         protected void AddEnvironmentVariable(string key, string value)
         {
             ArgUtil.NotNullOrEmpty(key, nameof(key));
+            ArgUtil.ThrowIfContainsNull(key, value);
             Trace.Verbose($"Setting env '{key}' to '{value}'.");
 
             Environment[key] = value ?? string.Empty;

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -296,7 +296,7 @@
   "EnterValidValueFor0": "Enter a valid value for {0}.",
   "EnvironmentName": "Environment Name",
   "EnvironmentNotFound": "Environment not found: '{0}'",
-  "EnvironmentVariableContainsNullCharacter": "The environment variable '{0}' contains a NUL character (U+0000), which is not allowed.",
+  "EnvironmentVariableContainsNullCharacter": "The {1} of environment variable '{0}' contains a NUL (U+0000) character, which is not permitted in environment variables because it corrupts the process environment block and can cause unexpected behavior, so the operation was blocked.",
   "EnvironmentVariableExceedsMaximumLength": "Environment variable '{0}' exceeds the maximum supported length. Environment variable length: {1} , Maximum supported length: {2}",
   "EnvironmentVMResourceTags": "Comma separated list of tags (e.g web, db)",
   "ErrorDuringBuildGC": "Unable to discover garbage based on '{0}'. Try it next time.",

--- a/src/Misc/layoutbin/en-US/strings.json
+++ b/src/Misc/layoutbin/en-US/strings.json
@@ -296,6 +296,7 @@
   "EnterValidValueFor0": "Enter a valid value for {0}.",
   "EnvironmentName": "Environment Name",
   "EnvironmentNotFound": "Environment not found: '{0}'",
+  "EnvironmentVariableContainsNullCharacter": "The environment variable '{0}' contains a NUL character (U+0000), which is not allowed.",
   "EnvironmentVariableExceedsMaximumLength": "Environment variable '{0}' exceeds the maximum supported length. Environment variable length: {1} , Maximum supported length: {2}",
   "EnvironmentVMResourceTags": "Comma separated list of tags (e.g web, db)",
   "ErrorDuringBuildGC": "Unable to discover garbage based on '{0}'. Try it next time.",

--- a/src/Test/L0/ProcessInvokerL0.cs
+++ b/src/Test/L0/ProcessInvokerL0.cs
@@ -40,6 +40,39 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public async Task RejectsEnvironmentVariableContainingNullCharacter()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                Tracing trace = hc.GetTrace();
+                using (var processInvoker = new ProcessInvokerWrapper())
+                {
+                    processInvoker.Initialize(hc);
+
+                    // A NUL in an environment value would split into two native env vars
+                    // (environment variable injection). It must be rejected before the
+                    // process is started.
+                    var environment = new Dictionary<string, string>
+                    {
+                        { "SAFE_QUEUE_LABEL", "safe-label\0NODE_OPTIONS=--max-old-space-size=2048" }
+                    };
+
+                    await Assert.ThrowsAsync<ArgumentException>(async () =>
+                    {
+                        await processInvoker.ExecuteAsync(
+                            "",
+                            TestUtil.IsWindows() ? "cmd.exe" : "bash",
+                            "",
+                            environment,
+                            CancellationToken.None);
+                    });
+                }
+            }
+        }
+
         //Run a process that normally takes 20sec to finish and cancel it.
         [Fact]
         [Trait("Level", "L0")]

--- a/src/Test/L0/Util/ArgUtilL0.cs
+++ b/src/Test/L0/Util/ArgUtilL0.cs
@@ -146,5 +146,61 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Util
                 });
             }
         }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void ThrowIfContainsNull_AllowsCleanNameAndValue()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                Tracing trace = hc.GetTrace();
+
+                // Act/Assert - none of these contain a NUL, so nothing is thrown.
+                ArgUtil.ThrowIfContainsNull("SAFE_QUEUE_LABEL", "safe-label");
+                ArgUtil.ThrowIfContainsNull("NAME", null);
+                ArgUtil.ThrowIfContainsNull(null, "value");
+                // Newlines are legal in environment variable values and must not be rejected.
+                ArgUtil.ThrowIfContainsNull("MULTILINE", "line1\r\nline2");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void ThrowIfContainsNull_ThrowsWhenValueContainsNull()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                Tracing trace = hc.GetTrace();
+
+                // A NUL in the value would split into two native environment variables.
+                string value = "safe-label\0NODE_OPTIONS=--max-old-space-size=2048";
+
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    ArgUtil.ThrowIfContainsNull("SAFE_QUEUE_LABEL", value);
+                });
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void ThrowIfContainsNull_ThrowsWhenNameContainsNull()
+        {
+            using (TestHostContext hc = new TestHostContext(this))
+            {
+                Tracing trace = hc.GetTrace();
+
+                // A NUL in the name is also rejected.
+                string name = "SAFE\0INJECTED";
+
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    ArgUtil.ThrowIfContainsNull(name, "value");
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
### **Context**
This addresses an MSRC‑class NUL‑byte environment‑variable injection in the agent. A queue‑time variable whose value or name contains a raw NUL ( \0 ) is copied verbatim into a child process's environment. On Windows the native environment block is NUL‑separated, so the embedded  '\0' acts as an entry separator and splits one approved variable into two, smuggling in an attacker‑controlled variable → RCE. 

_Note: '\0'  is never valid in an environment variable on any OS._

---

### **Description**
Reject  '\0'  in an environment variable name or value at the trust boundary. Adds a shared helper  ArgUtil.ThrowIfContainsNull(name, value)  and calls it at two enforcement points:

• **Handler.AddEnvironmentVariable** - validates pipeline variables; runs before the value is traced, so tampered values aren't logged).
• **ProcessInvoker** - environment copy loop (guards every process launch, catching step‑level env:  and all non‑handler callers that bypass  Handler .


---

### **Risk Assessment** (Low / Medium / High)  
Low. The guard is a narrow conditional that only throws on a NUL, which is never valid in an env var.

---

### **Unit Tests Added or Updated** (Yes / No)  
_Indicate whether unit tests were added or modified to reflect the changes._

---

### **Additional Testing Performed**
- Manual repro using REST API
- Unit tests run

--- 

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
Design has been written and reviewed. 


---

### **Documentation Changes Required** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes/No)
- Rollback plan is documented. 

---
