### PR TITLE
Use repository .NET SDK for Component Governance scans

### DIFF
--- a/.azure-pipelines/build-job.yml
+++ b/.azure-pipelines/build-job.yml
@@ -301,3 +301,22 @@ jobs:
         CodesignValidation: true
         CodesignValidationBreakOn: WarningAbove
         ToolLogsNotFoundAction: Error
+
+  # Keep injected post-build tasks on the same SDK used to build the agent.
+  - pwsh: |
+      $dotnetRoot = Join-Path $env:BUILD_SOURCESDIRECTORY '_dotnetsdk'
+      $dotnetName = if ($IsWindows) { 'dotnet.exe' } else { 'dotnet' }
+      $dotnet = Join-Path $dotnetRoot $dotnetName
+
+      if (-not (Test-Path $dotnet)) {
+        throw "Repository .NET SDK was not found at $dotnet"
+      }
+
+      $sdkVersion = (& $dotnet --version).Trim()
+      if ($LASTEXITCODE -ne 0) {
+        throw "Failed to query the repository .NET SDK at $dotnet"
+      }
+
+      Write-Host "Exposing repository .NET SDK $sdkVersion to subsequent tasks"
+      Write-Host "##vso[task.prependpath]$dotnetRoot"
+    displayName: Expose repository .NET SDK


### PR DESCRIPTION
### **Context**

Component Governance scans in [release run 20260720.1](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31794958) reported `DOTNET-Security-SC-10.0` for SDK `10.0.101`, even though the agent was built and packaged with repository-managed SDK `10.0.110`. The Ubuntu build image includes `10.0.101`, and the post-build detector resolved that global SDK because `dev.sh` only updates `PATH` within its own process.
[AB#2409614](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2409614)
[AB#2409615](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2409615)
---

### **Description**

Add a final shared build-job step that validates the repository `_dotnetsdk`, logs its version, and publishes its directory through `##vso[task.prependpath]`. Injected post-build tasks such as Component Governance now use the same SDK as the build in both CI and release pipelines.

---

### **Risk Assessment** (Low / Medium / High)

Low. The change only affects `PATH` for tasks that run after all declared build steps. It fails explicitly if a successful build did not produce the expected repository SDK.

---

### **Unit Tests Added or Updated** (Yes / No)

No. This is Azure Pipelines task configuration.

---

### **Additional Testing Performed**

Executed the cross-platform PowerShell step locally against the restored `_dotnetsdk`; it resolved SDK `10.0.110` and emitted the expected `task.prependpath` command. `git diff --check` passes.

---

### **Change Behind Feature Flag** (Yes / No)

No. A feature flag would not address the scanner environment mismatch and would leave affected jobs reporting the image SDK.

---

### **Tech Design / Approach**

Use Azure Pipelines' job-scoped `task.prependpath` logging command rather than process-local `PATH` changes. Placing the step in the shared `build-job.yml` template covers standard and alternate platform jobs used by both `.vsts.ci.yml` and `.vsts.release.yml`.

---

### **Documentation Changes Required** (Yes/No)

No. This does not change an agent feature or public workflow.

---

### **Logging Added/Updated** (Yes/No)

Yes. The step reports which repository SDK is exposed without logging secrets.

---

### **Telemetry Added/Updated** (Yes/No)

No. No runtime behavior is changed.

---

### **Rollback Scenario and Process** (Yes/No)

Yes. Revert this commit to restore the previous post-build task environment.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

Yes. No dependencies or build outputs change; only the SDK selected by subsequent tasks in the same job changes.