### PR TITLE
Remove .NET 8 from PR CI builds

### DIFF
--- a/.vsts.ci.yml
+++ b/.vsts.ci.yml
@@ -61,7 +61,7 @@ extends:
     publishArtifacts: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
     buildAlternatePackage: false
     testProxyAgent: ${{ parameters.testProxyAgent }}
-    targetFramework: 'all'
+    targetFramework: 'net10.0'
     win_x64: ${{ parameters.win_x64 }}
     win_x86: ${{ parameters.win_x86 }}
     win_arm64: ${{ parameters.win_arm64 }}


### PR DESCRIPTION
### **Context**
PR CI currently passes `all` to the shared pipeline template, expanding builds across both .NET 8 and .NET 10. PR validation should run only on .NET 10.

---

### **Description**
Configure `.vsts.ci.yml` to pass `net10.0` as the target framework, removing .NET 8 jobs from PR/CI while leaving the shared pipeline and release behavior unchanged.

---

### **Risk Assessment** (Low / Medium / High)
Low. The change is limited to the PR/CI entry point and uses an existing supported framework value.

---

### **Unit Tests Added or Updated** (Yes / No)
No. This is a pipeline configuration-only change.

---

### **Additional Testing Performed**
Validated the YAML diff and confirmed `net10.0` follows the existing non-`all` pipeline path.

---

### **Change Behind Feature Flag** (Yes / No)
No. Feature flags do not apply to CI pipeline configuration.

---

### **Tech Design / Approach**
Use the existing `targetFramework` string parameter to select `net10.0` directly instead of modifying the shared `all` matrix, preserving release pipeline behavior.

---

### **Documentation Changes Required** (Yes/No)
No.

---

### **Logging Added/Updated** (Yes/No)
No.

---

### **Telemetry Added/Updated** (Yes/No)
No.

---

### **Rollback Scenario and Process** (Yes/No)
Yes. Revert `targetFramework` in `.vsts.ci.yml` to `all`.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes. No dependencies or production code are changed.