### PR TITLE
Changing the default value of mapDockerSocket to false for linux

### DIFF
--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -36,7 +36,7 @@ namespace Agent.Sdk
             }
         }
 
-        public ContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true)
+        public ContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true, bool mapDockerSocketDefault = false)
         {
             ArgUtil.NotNull(container, nameof(container));
 
@@ -53,7 +53,7 @@ namespace Agent.Sdk
             _environmentVariables = container.Environment != null ? new Dictionary<string, string>(container.Environment) : new Dictionary<string, string>();
             this.ContainerCommand = container.Properties.Get<string>("command", defaultValue: "");
             this.IsJobContainer = isJobContainer;
-            this.MapDockerSocket = container.Properties.Get<bool>("mapDockerSocket", false);
+            this.MapDockerSocket = container.Properties.Get<bool>("mapDockerSocket", mapDockerSocketDefault);
             this._imageOS = PlatformUtil.HostOS;
             _pathMappings = new Dictionary<string, string>(PlatformUtil.RunningOnWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
             this._readOnlyVolumes = container.ReadOnlyMounts != null ? new List<string>(container.ReadOnlyMounts) : new List<string>();

--- a/src/Agent.Sdk/ContainerInfo.cs
+++ b/src/Agent.Sdk/ContainerInfo.cs
@@ -53,8 +53,7 @@ namespace Agent.Sdk
             _environmentVariables = container.Environment != null ? new Dictionary<string, string>(container.Environment) : new Dictionary<string, string>();
             this.ContainerCommand = container.Properties.Get<string>("command", defaultValue: "");
             this.IsJobContainer = isJobContainer;
-            // Windows has never automatically enabled Docker.Sock, but Linux does. So we need to set the default here based on OS.
-            this.MapDockerSocket = container.Properties.Get<bool>("mapDockerSocket", !PlatformUtil.RunningOnWindows);
+            this.MapDockerSocket = container.Properties.Get<bool>("mapDockerSocket", false);
             this._imageOS = PlatformUtil.HostOS;
             _pathMappings = new Dictionary<string, string>(PlatformUtil.RunningOnWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
             this._readOnlyVolumes = container.ReadOnlyMounts != null ? new List<string>(container.ReadOnlyMounts) : new List<string>();

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -20,6 +20,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("VSTS_SETUP_DOCKERGROUP"),
             new BuiltInDefaultKnobSource("true"));
 
+        public static readonly Knob DefaultMapDockerSocketToFalse = new Knob(
+            nameof(DefaultMapDockerSocketToFalse),
+            "If true, containers without an explicit mapDockerSocket setting do not map the Docker socket by default.",
+            new PipelineFeatureSource("DefaultMapDockerSocketToFalse"),
+            new EnvironmentKnobSource("AZP_AGENT_DEFAULT_MAP_DOCKER_SOCKET_TO_FALSE"),
+            new BuiltInDefaultKnobSource("true"));
+
         public static readonly Knob AllowMountTasksReadonlyOnWindows = new Knob(
             nameof(AllowMountTasksReadonlyOnWindows),
             "If true, allows the user to mount 'tasks' volume read-only on Windows OS",

--- a/src/Agent.Worker/ContainerOperationProvider.cs
+++ b/src/Agent.Worker/ContainerOperationProvider.cs
@@ -979,7 +979,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     // Allow the new sudo group run any sudo command without providing password.
                     await DockerExec(executionContext, container.ContainerId, $"su -c \"echo '%{sudoGroupName} ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers\"");
 
-                    if (AgentKnobs.SetupDockerGroup.GetValue(executionContext).AsBoolean())
+                    if (container.MapDockerSocket && AgentKnobs.SetupDockerGroup.GetValue(executionContext).AsBoolean())
                     {
                         executionContext.Output(StringUtil.Loc("AllowContainerUserRunDocker", containerUserName));
                         // Get docker.sock group id on Host

--- a/src/Agent.Worker/ContainerOperationProviderEnhanced.cs
+++ b/src/Agent.Worker/ContainerOperationProviderEnhanced.cs
@@ -1142,7 +1142,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                         // Allow the new sudo group run any sudo command without providing password.
                         await DockerExec(executionContext, container.ContainerId, $"su -c \"echo '%{sudoGroupName} ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers\"");
 
-                        if (AgentKnobs.SetupDockerGroup.GetValue(executionContext).AsBoolean())
+                        if (container.MapDockerSocket && AgentKnobs.SetupDockerGroup.GetValue(executionContext).AsBoolean())
                         {
                             executionContext.Debug($"Docker group setup enabled via agent knob");
                             executionContext.Output(StringUtil.Loc("AllowContainerUserRunDocker", containerUserName));

--- a/src/Agent.Worker/ExecutionContext.cs
+++ b/src/Agent.Worker/ExecutionContext.cs
@@ -620,6 +620,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             Containers = new List<ContainerInfo>();
             _defaultStepTarget = null;
             _currentStepTarget = null;
+            var mapDockerSocketDefault = !AgentKnobs.DefaultMapDockerSocketToFalse.GetValue(this).AsBoolean() && !PlatformUtil.RunningOnWindows;
             if (!string.IsNullOrEmpty(imageName) &&
                 string.IsNullOrEmpty(message.JobContainer))
             {
@@ -628,13 +629,15 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                     Alias = "vsts_container_preview"
                 };
                 dockerContainer.Properties.Set("image", imageName);
-                var defaultJobContainer = HostContext.CreateContainerInfo(dockerContainer);
+                var defaultJobContainer = HostContext.CreateContainerInfo(dockerContainer, mapDockerSocketDefault: mapDockerSocketDefault);
                 _defaultStepTarget = defaultJobContainer;
                 Containers.Add(defaultJobContainer);
             }
             else if (!string.IsNullOrEmpty(message.JobContainer))
             {
-                var defaultJobContainer = HostContext.CreateContainerInfo(message.Resources.Containers.Single(x => string.Equals(x.Alias, message.JobContainer, StringComparison.OrdinalIgnoreCase)));
+                var defaultJobContainer = HostContext.CreateContainerInfo(
+                    message.Resources.Containers.Single(x => string.Equals(x.Alias, message.JobContainer, StringComparison.OrdinalIgnoreCase)),
+                    mapDockerSocketDefault: mapDockerSocketDefault);
                 _defaultStepTarget = defaultJobContainer;
                 Containers.Add(defaultJobContainer);
             }
@@ -647,7 +650,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
             foreach (var container in message.Resources.Containers.Where(x =>
                 !string.Equals(x.Alias, message.JobContainer, StringComparison.OrdinalIgnoreCase) && !sidecarContainers.Contains(x.Alias)))
             {
-                Containers.Add(HostContext.CreateContainerInfo(container));
+                Containers.Add(HostContext.CreateContainerInfo(container, mapDockerSocketDefault: mapDockerSocketDefault));
             }
 
             // Docker (Sidecar Containers)
@@ -657,7 +660,7 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker
                 var networkAlias = sidecar.Key;
                 var containerResourceAlias = sidecar.Value;
                 var containerResource = message.Resources.Containers.Single(c => string.Equals(c.Alias, containerResourceAlias, StringComparison.OrdinalIgnoreCase));
-                ContainerInfo containerInfo = HostContext.CreateContainerInfo(containerResource, isJobContainer: false);
+                ContainerInfo containerInfo = HostContext.CreateContainerInfo(containerResource, isJobContainer: false, mapDockerSocketDefault: mapDockerSocketDefault);
                 containerInfo.ContainerNetworkAlias = networkAlias;
                 SidecarContainers.Add(containerInfo);
             }

--- a/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
+++ b/src/Microsoft.VisualStudio.Services.Agent/HostContext.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.Services.Agent
         void ShutdownAgent(ShutdownReason reason);
         void WritePerfCounter(string counter);
         void EnableHttpTrace();
-        ContainerInfo CreateContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true);
+        ContainerInfo CreateContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true, bool mapDockerSocketDefault = false);
         // Added for flush logs support
         CancellationToken WorkerShutdownForTimeout { get; }
         void ShutdownWorkerForTimeout();
@@ -576,9 +576,9 @@ namespace Microsoft.VisualStudio.Services.Agent
             _workerShutdownForTimeout.Cancel();
         }
 
-        public ContainerInfo CreateContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true)
+        public ContainerInfo CreateContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true, bool mapDockerSocketDefault = false)
         {
-            ContainerInfo containerInfo = new ContainerInfo(container, isJobContainer);
+            ContainerInfo containerInfo = new ContainerInfo(container, isJobContainer, mapDockerSocketDefault);
             Dictionary<string, string> pathMappings = new Dictionary<string, string>();
             if (PlatformUtil.RunningOnWindows)
             {

--- a/src/Test/L0/Container/ContainerInfoL0.cs
+++ b/src/Test/L0/Container/ContainerInfoL0.cs
@@ -95,6 +95,97 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker.Container
             }
         }
 
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void OmittedMapDockerSocketDefaultsToFalseWithoutSocketMount()
+        {
+            var dockerContainer = new Pipelines.ContainerResource()
+            {
+                Alias = "container",
+                Image = "foo"
+            };
+
+            using (TestHostContext hc = CreateTestContext())
+            {
+                ContainerInfo info = hc.CreateContainerInfo(dockerContainer);
+
+                Assert.False(info.MapDockerSocket);
+                Assert.DoesNotContain(info.MountVolumes, volume =>
+                    volume.SourceVolumePath == "/var/run/docker.sock" &&
+                    volume.TargetVolumePath == "/var/run/docker.sock");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void ExplicitMapDockerSocketTrueMountsSocketForJobContainer()
+        {
+            var dockerContainer = new Pipelines.ContainerResource()
+            {
+                Alias = "container",
+                Image = "foo"
+            };
+            dockerContainer.Properties.Set<bool>("mapDockerSocket", true);
+
+            using (TestHostContext hc = CreateTestContext())
+            {
+                ContainerInfo info = hc.CreateContainerInfo(dockerContainer);
+
+                Assert.True(info.MapDockerSocket);
+                Assert.Contains(info.MountVolumes, volume =>
+                    volume.SourceVolumePath == "/var/run/docker.sock" &&
+                    volume.TargetVolumePath == "/var/run/docker.sock");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void ExplicitMapDockerSocketFalseOverridesDefaultWithoutSocketMount()
+        {
+            var dockerContainer = new Pipelines.ContainerResource()
+            {
+                Alias = "container",
+                Image = "foo"
+            };
+            dockerContainer.Properties.Set<bool>("mapDockerSocket", false);
+
+            using (TestHostContext hc = CreateTestContext())
+            {
+                ContainerInfo info = hc.CreateContainerInfo(dockerContainer, mapDockerSocketDefault: true);
+
+                Assert.False(info.MapDockerSocket);
+                Assert.DoesNotContain(info.MountVolumes, volume =>
+                    volume.SourceVolumePath == "/var/run/docker.sock" &&
+                    volume.TargetVolumePath == "/var/run/docker.sock");
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        public void ServiceContainerDoesNotMountDockerSocket()
+        {
+            var dockerContainer = new Pipelines.ContainerResource()
+            {
+                Alias = "service",
+                Image = "foo"
+            };
+            dockerContainer.Properties.Set<bool>("mapDockerSocket", true);
+
+            using (TestHostContext hc = CreateTestContext())
+            {
+                ContainerInfo info = hc.CreateContainerInfo(dockerContainer, isJobContainer: false);
+
+                Assert.True(info.MapDockerSocket);
+                Assert.DoesNotContain(info.MountVolumes, volume =>
+                    volume.SourceVolumePath == "/var/run/docker.sock" &&
+                    volume.TargetVolumePath == "/var/run/docker.sock");
+            }
+        }
+
 
         [Fact]
         [Trait("Level", "L0")]

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -477,9 +477,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             return _traceManager[name];
         }
 
-        public ContainerInfo CreateContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true)
+        public ContainerInfo CreateContainerInfo(Pipelines.ContainerResource container, Boolean isJobContainer = true, bool mapDockerSocketDefault = false)
         {
-            ContainerInfo containerInfo = new ContainerInfo(container, isJobContainer);
+            ContainerInfo containerInfo = new ContainerInfo(container, isJobContainer, mapDockerSocketDefault);
             if (TestUtil.IsWindows())
             {
                 // Tool cache folder may come from ENV, so we need a unique folder to avoid collision

--- a/src/Test/L0/TestHostContext.cs
+++ b/src/Test/L0/TestHostContext.cs
@@ -494,10 +494,11 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
                 containerInfo.PathMappings[this.GetDirectory(WellKnownDirectory.Tools)] = "/__t";
                 containerInfo.PathMappings[this.GetDirectory(WellKnownDirectory.Work)] = "/__w";
                 containerInfo.PathMappings[this.GetDirectory(WellKnownDirectory.Root)] = "/__a";
-                if (containerInfo.IsJobContainer)
-                {
-                    containerInfo.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
-                }
+            }
+
+            if (containerInfo.IsJobContainer && containerInfo.MapDockerSocket)
+            {
+                containerInfo.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
             }
             return containerInfo;
         }

--- a/src/Test/L0/Worker/ContainerOperationProviderEnhancedL0.cs
+++ b/src/Test/L0/Worker/ContainerOperationProviderEnhancedL0.cs
@@ -7,7 +7,9 @@ using Microsoft.VisualStudio.Services.Agent.Worker.Container;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using Moq;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -313,6 +315,94 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 await provider.StartContainersAsync(executionContext.Object, new List<ContainerInfo> { container });
 
                 Assert.Equal("sleep infinity", container.ContainerCommand);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "windows")]
+        public async Task StartContainer_WhenDockerSocketIsOmittedOrFalse_DoesNotProbeSocket(bool explicitlyDisableSocket)
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                return;
+            }
+
+            using (var hc = new TestHostContext(this))
+            {
+                System.IO.Directory.CreateDirectory(hc.GetDirectory(WellKnownDirectory.Work));
+
+                var dockerManager = CreateDockerManagerMock(NodePathFromLabel);
+                var executionContext = CreateExecutionContextMock(hc);
+                var dockerContainer = new Pipelines.ContainerResource() { Alias = "test", Image = "node:16" };
+                if (explicitlyDisableSocket)
+                {
+                    dockerContainer.Properties.Set<bool>("mapDockerSocket", false);
+                }
+                var container = new ContainerInfo(dockerContainer);
+                var processInvoker = SetupProcessInvokerMockForVerification(hc);
+
+                hc.SetSingleton<IDockerCommandManager>(dockerManager.Object);
+
+                var provider = new ContainerOperationProviderEnhanced();
+                provider.Initialize(hc);
+
+                await provider.StartContainersAsync(executionContext.Object, new List<ContainerInfo> { container });
+
+                processInvoker.Verify(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    "stat",
+                    It.Is<string>(arguments => arguments.Contains("/var/run/docker.sock")),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<System.Text.Encoding>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "windows")]
+        public async Task StartContainer_WhenDockerSocketIsMapped_ProbesSocketForDockerGroupSetup()
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                return;
+            }
+
+            using (var hc = new TestHostContext(this))
+            {
+                System.IO.Directory.CreateDirectory(hc.GetDirectory(WellKnownDirectory.Work));
+
+                var dockerManager = CreateDockerManagerMock(NodePathFromLabel);
+                var executionContext = CreateExecutionContextMock(hc);
+                executionContext.Setup(x => x.GetVariableValueOrDefault("VSTS_SETUP_DOCKERGROUP")).Returns("true");
+                var dockerContainer = new Pipelines.ContainerResource() { Alias = "test", Image = "node:16" };
+                dockerContainer.Properties.Set<bool>("mapDockerSocket", true);
+                var container = new ContainerInfo(dockerContainer);
+                var processInvoker = SetupProcessInvokerMockForVerification(hc);
+
+                hc.SetSingleton<IDockerCommandManager>(dockerManager.Object);
+
+                var provider = new ContainerOperationProviderEnhanced();
+                provider.Initialize(hc);
+
+                await provider.StartContainersAsync(executionContext.Object, new List<ContainerInfo> { container });
+
+                processInvoker.Verify(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    "stat",
+                    It.Is<string>(arguments => arguments.Contains("/var/run/docker.sock")),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<System.Text.Encoding>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Once);
             }
         }
     }

--- a/src/Test/L0/Worker/ContainerOperationProviderL0.cs
+++ b/src/Test/L0/Worker/ContainerOperationProviderL0.cs
@@ -7,7 +7,9 @@ using Microsoft.VisualStudio.Services.Agent.Worker.Container;
 using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;
 using Pipelines = Microsoft.TeamFoundation.DistributedTask.Pipelines;
+using Moq;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -177,6 +179,94 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 Assert.Contains(NodeFromAgentExternal, container.ResultNodePath);
                 Assert.EndsWith("/bin/node", container.ResultNodePath);
                 Assert.Contains(NodeFromAgentExternal, container.ContainerCommand);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "windows")]
+        public async Task StartContainer_WhenDockerSocketIsOmittedOrFalse_DoesNotProbeSocket(bool explicitlyDisableSocket)
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                return;
+            }
+
+            using (var hc = new TestHostContext(this))
+            {
+                System.IO.Directory.CreateDirectory(hc.GetDirectory(WellKnownDirectory.Work));
+
+                var dockerManager = CreateDockerManagerMock(NodePathFromLabel);
+                var executionContext = CreateExecutionContextMock(hc);
+                var dockerContainer = new Pipelines.ContainerResource() { Alias = "test", Image = "node:16" };
+                if (explicitlyDisableSocket)
+                {
+                    dockerContainer.Properties.Set<bool>("mapDockerSocket", false);
+                }
+                var container = new ContainerInfo(dockerContainer);
+                var processInvoker = SetupProcessInvokerMockForVerification(hc);
+
+                hc.SetSingleton<IDockerCommandManager>(dockerManager.Object);
+
+                var provider = new ContainerOperationProvider();
+                provider.Initialize(hc);
+
+                await provider.StartContainersAsync(executionContext.Object, new List<ContainerInfo> { container });
+
+                processInvoker.Verify(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    "stat",
+                    It.Is<string>(arguments => arguments.Contains("/var/run/docker.sock")),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<System.Text.Encoding>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Never);
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Worker")]
+        [Trait("SkipOn", "windows")]
+        public async Task StartContainer_WhenDockerSocketIsMapped_ProbesSocketForDockerGroupSetup()
+        {
+            if (PlatformUtil.RunningOnWindows)
+            {
+                return;
+            }
+
+            using (var hc = new TestHostContext(this))
+            {
+                System.IO.Directory.CreateDirectory(hc.GetDirectory(WellKnownDirectory.Work));
+
+                var dockerManager = CreateDockerManagerMock(NodePathFromLabel);
+                var executionContext = CreateExecutionContextMock(hc);
+                executionContext.Setup(x => x.GetVariableValueOrDefault("VSTS_SETUP_DOCKERGROUP")).Returns("true");
+                var dockerContainer = new Pipelines.ContainerResource() { Alias = "test", Image = "node:16" };
+                dockerContainer.Properties.Set<bool>("mapDockerSocket", true);
+                var container = new ContainerInfo(dockerContainer);
+                var processInvoker = SetupProcessInvokerMockForVerification(hc);
+
+                hc.SetSingleton<IDockerCommandManager>(dockerManager.Object);
+
+                var provider = new ContainerOperationProvider();
+                provider.Initialize(hc);
+
+                await provider.StartContainersAsync(executionContext.Object, new List<ContainerInfo> { container });
+
+                processInvoker.Verify(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    "stat",
+                    It.Is<string>(arguments => arguments.Contains("/var/run/docker.sock")),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<System.Text.Encoding>(),
+                    It.IsAny<CancellationToken>()),
+                    Times.Once);
             }
         }
     }

--- a/src/Test/L0/Worker/ContainerOperationProviderL0Base.cs
+++ b/src/Test/L0/Worker/ContainerOperationProviderL0Base.cs
@@ -134,5 +134,48 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
                 hc.EnqueueInstance<IProcessInvoker>(processInvoker);
             }
         }
+
+        protected Mock<IProcessInvoker> SetupProcessInvokerMockForVerification(TestHostContext hc)
+        {
+            var processInvoker = new Mock<IProcessInvoker>();
+            processInvoker
+                .Setup(x => x.ExecuteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<IDictionary<string, string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<Encoding>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, string, IDictionary<string, string>, bool, Encoding, CancellationToken>(
+                    (_, fileName, arguments, _, _, _, _) =>
+                    {
+                        string output = fileName switch
+                        {
+                            "whoami" => "testuser",
+                            "id" when arguments.StartsWith("-u") => "1000",
+                            "id" when arguments.StartsWith("-gn") => "testgroup",
+                            "id" when arguments.StartsWith("-g") => "1000",
+                            "node" when arguments.Contains("-v") => "v16.20.2",
+                            _ => null,
+                        };
+
+                        if (output != null)
+                        {
+                            processInvoker.Raise(
+                                x => x.OutputDataReceived += null,
+                                processInvoker.Object,
+                                new ProcessDataReceivedEventArgs(output));
+                        }
+                    })
+                .ReturnsAsync(0);
+
+            for (int i = 0; i < 10; i++)
+            {
+                hc.EnqueueInstance<IProcessInvoker>(processInvoker.Object);
+            }
+
+            return processInvoker;
+        }
     }
 }


### PR DESCRIPTION
### **Context**
Linux container jobs currently map  /var/run/docker.sock  when  mapDockerSocket  is omitted. This grants unnecessary Docker-daemon access to jobs that do not require Docker-in-container behavior. This change adopts least privilege while retaining explicit opt-in compatibility.

[AB#2443791](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2443791)

---

### **Description**
• Changes the unset  mapDockerSocket  default to  false  on all agent host OSes.
• Retains Docker socket access when pipelines explicitly set  mapDockerSocket: true .
• Aligns  TestHostContext  socket-mount behavior with production behavior.

---

### **Risk Assessment** (Medium)  
This is a Linux behavioral breaking change: container jobs that implicitly rely on Docker-from-inside-container will need  mapDockerSocket: true . Scope is limited to container jobs using the host Docker socket.

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
- Unit tests successfully run
- Validated on Linux agent

--- 

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Documentation Changes Required** (Yes)
Azure Pipelines container-job documentation should state that Docker socket mapping defaults to  false  and Docker-in-container jobs must explicitly set  mapDockerSocket: true.

---