### PR TITLE
Ignore proxy variables in ProcessHandler environment promotion

### DIFF
--- a/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandler.cs
+++ b/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandler.cs
@@ -344,7 +344,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                             //   "TF_BUILD" is set by ProcessInvoker.
                             //   "agent.jobstatus" is set by ???.
                             if (string.Equals(key, Constants.TFBuild, StringComparison.Ordinal)
-                                || string.Equals(key, Constants.Variables.Agent.JobStatus, StringComparison.Ordinal))
+                                || string.Equals(key, Constants.Variables.Agent.JobStatus, StringComparison.Ordinal)
+                                || ProcessHandlerHelper.IsProxyEnvironmentVariable(key))
                             {
                                 return;
                             }

--- a/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandlerHelper.cs
+++ b/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandlerHelper.cs
@@ -20,7 +20,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         {
             // Persisting an inherited proxy value into Agent.Worker can leak a stale proxy to later processes.
             return string.Equals(key, "HTTP_PROXY", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(key, "HTTPS_PROXY", StringComparison.OrdinalIgnoreCase);
+                || string.Equals(key, "HTTPS_PROXY", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(key, "NO_PROXY", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(key, "ALL_PROXY", StringComparison.OrdinalIgnoreCase);
         }
 
         public static (string, CmdTelemetry) ExpandCmdEnv(string inputArgs, Dictionary<string, string> environment)

--- a/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandlerHelper.cs
+++ b/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandlerHelper.cs
@@ -16,6 +16,13 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
         private const string _envPrefix = "%";
         private const string _envPostfix = "%";
 
+        public static bool IsProxyEnvironmentVariable(string key)
+        {
+            // Persisting an inherited proxy value into Agent.Worker can leak a stale proxy to later processes.
+            return string.Equals(key, "HTTP_PROXY", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(key, "HTTPS_PROXY", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static (string, CmdTelemetry) ExpandCmdEnv(string inputArgs, Dictionary<string, string> environment)
         {
             ArgUtil.NotNull(inputArgs, nameof(inputArgs));

--- a/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandlerV2.cs
+++ b/src/Agent.Worker/Handlers/ProcessHandler/ProcessHandlerV2.cs
@@ -428,7 +428,8 @@ namespace Microsoft.VisualStudio.Services.Agent.Worker.Handlers
                             //   "TF_BUILD" is set by ProcessInvoker.
                             //   "agent.jobstatus" is set by ???.
                             if (string.Equals(key, Constants.TFBuild, StringComparison.Ordinal)
-                                || string.Equals(key, Constants.Variables.Agent.JobStatus, StringComparison.Ordinal))
+                                || string.Equals(key, Constants.Variables.Agent.JobStatus, StringComparison.Ordinal)
+                                || ProcessHandlerHelper.IsProxyEnvironmentVariable(key))
                             {
                                 return;
                             }

--- a/src/Test/L0/Worker/Handlers/ProcessHandlerL0.cs
+++ b/src/Test/L0/Worker/Handlers/ProcessHandlerL0.cs
@@ -30,6 +30,8 @@ public class ProcessHandlerL0
     [InlineData("HTTP_PROXY")]
     [InlineData("http_proxy")]
     [InlineData("HtTpS_pRoXy")]
+    [InlineData("No_PrOxY")]
+    [InlineData("all_proxy")]
     [Trait("Level", "L0")]
     [Trait("Category", "Worker.Handlers")]
     public void IsProxyEnvironmentVariable_IsCaseInsensitive(string variable)
@@ -49,19 +51,29 @@ public class ProcessHandlerL0
     {
         const string httpProxy = "HTTP_PROXY";
         const string httpsProxy = "HTTPS_PROXY";
+        const string noProxy = "NO_PROXY";
+        const string allProxy = "ALL_PROXY";
         const string unrelatedVariable = "AZP_PROCESS_HANDLER_MODIFY_ENVIRONMENT_TEST";
         const string workerHttpProxy = "http://worker-http";
         const string workerHttpsProxy = "http://worker-https";
+        const string workerNoProxy = "worker.example.com";
+        const string workerAllProxy = "socks5://worker-all";
         string originalHttpProxy = Environment.GetEnvironmentVariable(httpProxy);
         string originalHttpsProxy = Environment.GetEnvironmentVariable(httpsProxy);
+        string originalNoProxy = Environment.GetEnvironmentVariable(noProxy);
+        string originalAllProxy = Environment.GetEnvironmentVariable(allProxy);
         string originalUnrelatedVariable = Environment.GetEnvironmentVariable(unrelatedVariable);
 
         try
         {
             Environment.SetEnvironmentVariable(httpProxy, null);
             Environment.SetEnvironmentVariable(httpsProxy, null);
+            Environment.SetEnvironmentVariable(noProxy, null);
+            Environment.SetEnvironmentVariable(allProxy, null);
             Environment.SetEnvironmentVariable("http_proxy", workerHttpProxy);
             Environment.SetEnvironmentVariable("HtTpS_pRoXy", workerHttpsProxy);
+            Environment.SetEnvironmentVariable("no_proxy", workerNoProxy);
+            Environment.SetEnvironmentVariable("AlL_pRoXy", workerAllProxy);
             Environment.SetEnvironmentVariable(unrelatedVariable, null);
 
             using var hostContext = CreateTestHostContext();
@@ -91,6 +103,8 @@ set {unrelatedVariable}=persisted");
             {
                 ["http_proxy"] = "http://task-http",
                 ["HtTpS_pRoXy"] = "http://task-https",
+                ["no_proxy"] = "task.example.com",
+                ["AlL_pRoXy"] = "socks5://task-all",
             };
             handler.RuntimeVariables = new(hostContext, new Dictionary<string, VariableValue>(), out _);
 
@@ -102,12 +116,16 @@ set {unrelatedVariable}=persisted");
 
             Assert.Equal(workerHttpProxy, Environment.GetEnvironmentVariable(httpProxy));
             Assert.Equal(workerHttpsProxy, Environment.GetEnvironmentVariable(httpsProxy));
+            Assert.Equal(workerNoProxy, Environment.GetEnvironmentVariable(noProxy));
+            Assert.Equal(workerAllProxy, Environment.GetEnvironmentVariable(allProxy));
             Assert.Equal("persisted", Environment.GetEnvironmentVariable(unrelatedVariable));
         }
         finally
         {
             Environment.SetEnvironmentVariable(httpProxy, originalHttpProxy);
             Environment.SetEnvironmentVariable(httpsProxy, originalHttpsProxy);
+            Environment.SetEnvironmentVariable(noProxy, originalNoProxy);
+            Environment.SetEnvironmentVariable(allProxy, originalAllProxy);
             Environment.SetEnvironmentVariable(unrelatedVariable, originalUnrelatedVariable);
         }
     }

--- a/src/Test/L0/Worker/Handlers/ProcessHandlerL0.cs
+++ b/src/Test/L0/Worker/Handlers/ProcessHandlerL0.cs
@@ -18,8 +18,100 @@ using System.Threading.Tasks;
 
 namespace Test.L0.Worker.Handlers;
 
+[CollectionDefinition("Worker proxy environment tests")]
+public class ProcessHandlerEnvironmentTestFixture
+{
+}
+
+[Collection("Worker proxy environment tests")]
 public class ProcessHandlerL0
 {
+    [Theory]
+    [InlineData("HTTP_PROXY")]
+    [InlineData("http_proxy")]
+    [InlineData("HtTpS_pRoXy")]
+    [Trait("Level", "L0")]
+    [Trait("Category", "Worker.Handlers")]
+    public void IsProxyEnvironmentVariable_IsCaseInsensitive(string variable)
+    {
+        Assert.True(ProcessHandlerHelper.IsProxyEnvironmentVariable(variable));
+        Assert.False(ProcessHandlerHelper.IsProxyEnvironmentVariable("AZP_UNRELATED_VARIABLE"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    [Trait("Level", "L0")]
+    [Trait("Category", "Worker.Handlers")]
+    [Trait("SkipOn", "linux")]
+    [Trait("SkipOn", "darwin")]
+    public async Task ModifyEnvironment_DoesNotPersistProxyVariables(bool useV2)
+    {
+        const string httpProxy = "HTTP_PROXY";
+        const string httpsProxy = "HTTPS_PROXY";
+        const string unrelatedVariable = "AZP_PROCESS_HANDLER_MODIFY_ENVIRONMENT_TEST";
+        const string workerHttpProxy = "http://worker-http";
+        const string workerHttpsProxy = "http://worker-https";
+        string originalHttpProxy = Environment.GetEnvironmentVariable(httpProxy);
+        string originalHttpsProxy = Environment.GetEnvironmentVariable(httpsProxy);
+        string originalUnrelatedVariable = Environment.GetEnvironmentVariable(unrelatedVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(httpProxy, null);
+            Environment.SetEnvironmentVariable(httpsProxy, null);
+            Environment.SetEnvironmentVariable("http_proxy", workerHttpProxy);
+            Environment.SetEnvironmentVariable("HtTpS_pRoXy", workerHttpsProxy);
+            Environment.SetEnvironmentVariable(unrelatedVariable, null);
+
+            using var hostContext = CreateTestHostContext();
+            using var processInvoker = new ProcessInvokerWrapper();
+            hostContext.EnqueueInstance<IProcessInvoker>(processInvoker);
+
+            using var targetScript = new TestScript(
+                testTemp: hostContext.GetDirectory(WellKnownDirectory.Temp),
+                scriptName: "modify-environment.cmd"
+            );
+            targetScript.WriteContent($@"
+@echo off
+set {unrelatedVariable}=persisted");
+
+            IProcessHandler handler = useV2 ? new ProcessHandlerV2() : new ProcessHandler();
+            handler.Initialize(hostContext);
+            handler.Data = new ProcessHandlerData()
+            {
+                Target = targetScript.ScriptPath,
+                ArgumentFormat = "",
+                DisableInlineExecution = false.ToString(),
+                ModifyEnvironment = true.ToString()
+            };
+            handler.Inputs = new();
+            handler.TaskDirectory = "";
+            handler.Environment = new()
+            {
+                ["http_proxy"] = "http://task-http",
+                ["HtTpS_pRoXy"] = "http://task-https",
+            };
+            handler.RuntimeVariables = new(hostContext, new Dictionary<string, VariableValue>(), out _);
+
+            var executionContext = CreateMockExecutionContext(hostContext);
+            executionContext.Setup(x => x.GetVariableValueOrDefault("AZP_75787_ENABLE_NEW_LOGIC")).Returns("false");
+            handler.ExecutionContext = executionContext.Object;
+
+            await handler.RunAsync();
+
+            Assert.Equal(workerHttpProxy, Environment.GetEnvironmentVariable(httpProxy));
+            Assert.Equal(workerHttpsProxy, Environment.GetEnvironmentVariable(httpsProxy));
+            Assert.Equal("persisted", Environment.GetEnvironmentVariable(unrelatedVariable));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(httpProxy, originalHttpProxy);
+            Environment.SetEnvironmentVariable(httpsProxy, originalHttpsProxy);
+            Environment.SetEnvironmentVariable(unrelatedVariable, originalUnrelatedVariable);
+        }
+    }
+
     [Fact]
     [Trait("Level", "L0")]
     [Trait("Category", "Worker.Handlers")]

--- a/src/Test/L0/Worker/JobExtensionL0.cs
+++ b/src/Test/L0/Worker/JobExtensionL0.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.Services.WebPlatform;
 
 namespace Microsoft.VisualStudio.Services.Agent.Tests.Worker
 {
+    [Collection("Worker proxy environment tests")]
     public sealed class JobExtensionL0
     {
         private class TestJobExtension : JobExtension


### PR DESCRIPTION
### **Context**
Fixes [AB#2456138](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2456138).

On Windows, `BatchScript@1` with `modifyEnvironment: true` captures the child environment and persists it into the long-running Agent.Worker process. Inherited proxy configuration values could therefore become stale Worker environment values inherited by later Agent.PluginHost processes.

---

### **Description**
Exclude the standard `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and `ALL_PROXY` variables, case-insensitively, from the `modifyEnvironment` persistence paths in both `ProcessHandler` and `ProcessHandlerV2`. All unrelated environment variables continue to persist unchanged.

This is intentionally a narrow mitigation: a genuine BatchScript change to any of these proxy variables is also not propagated through `modifyEnvironment`.

---

### **Risk Assessment** (Low)
The change affects only four named proxy variables in the Windows-only legacy ProcessHandler environment-promotion path. The exclusion is explicit and shared by V1 and V2; other variables retain existing behavior.

---

### **Unit Tests Added or Updated** (Yes)
Added focused Windows L0 coverage for both ProcessHandler versions, inherited HTTP/HTTPS/NO/ALL proxy values, case-insensitive matching, stale Worker value preservation, unrelated-variable persistence, and process-environment restoration.

---

### **Additional Testing Performed**
- Targeted `ProcessHandlerL0` tests: 11 passed
- Complete Windows net8.0 L0 suite: 1,444 passed, 2 platform skips

---

### **Change Behind Feature Flag** (No)
This is an intentionally unconditional mitigation for stale proxy inheritance; no new feature flag is introduced.

---

### **Tech Design / Approach**
A shared case-insensitive predicate identifies the four proxy variables, and both legacy handler implementations apply it alongside their existing special-variable exclusions. No environment capture protocol or process-launch plumbing changes are included.

---

### **Documentation Changes Required** (No)
The behavior is documented at the exclusion helper; no user documentation changes are required.

---

### **Logging Added/Updated** (No)
Existing environment-persistence logging remains unchanged.

---

### **Telemetry Added/Updated** (No)
No telemetry changes.

---

### **Rollback Scenario and Process** (Yes)
Revert these commits to restore proxy-variable propagation through `modifyEnvironment`.

---

### **Dependency Impact Assessed and Regression Tested** (Yes)
No dependency changes. Both ProcessHandler implementations and the complete Windows L0 suite were exercised.