### PR TITLE
Update CmdLineV2 task reference with new package GUID published

### DIFF
--- a/src/Misc/externals.sh
+++ b/src/Misc/externals.sh
@@ -376,5 +376,5 @@ fi
 
 if [[ "$L1_MODE" != "" || "$PRECACHE" != "" ]]; then
     # cmdline node20 task
-    acquireExternalTool "$CONTAINER_URL/l1Tasks/3b8784e0-6fc3-495e-9340-3c9dde4ce04f.zip" "Tasks" false dont_uncompress
+    acquireExternalTool "$CONTAINER_URL/l1Tasks/d0c4ac01-adbe-42b5-845a-b063e9213a8c.zip" "Tasks" false dont_uncompress
 fi

--- a/src/Test/L1/Worker/L1TestBase.cs
+++ b/src/Test/L1/Worker/L1TestBase.cs
@@ -129,9 +129,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
             {
                 Reference = new TaskStepDefinitionReference
                 {
-                    Id = Guid.Parse("3b8784e0-6fc3-495e-9340-3c9dde4ce04f"),
+                    Id = Guid.Parse("d0c4ac01-adbe-42b5-845a-b063e9213a8c"),
                     Name = "CmdLine",
-                    Version = "2.274.0"
+                    Version = "2.279.1"
                 },
                 Name = "CmdLine",
                 DisplayName = "CmdLine",
@@ -416,9 +416,9 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.L1.Worker
       },
       'type': 'task',
       'reference': {
-        'id': '3b8784e0-6fc3-495e-9340-3c9dde4ce04f',
+        'id': 'd0c4ac01-adbe-42b5-845a-b063e9213a8c',
         'name': 'CmdLine',
-        'version': '2.274.0'
+        'version': '2.279.1'
       },
       'id': '9c939e41-62c2-5605-5e05-fc3554afc9f5',
       'name': 'CmdLine',


### PR DESCRIPTION
### **Context**
[AB#2447421](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2447421)

---

### **Description**
A vulnerability is detected in the packaged CmdLineV2 task
To fix this we are packaging an updated version of the task which has been patched.
Related PRs
https://github.com/microsoft/azure-pipelines-tasks/pull/22430 - Task Update
https://mseng.visualstudio.com/AzureDevOps/_git/CIPlat.Externals/pullrequest/948174 - upload to blob storage

Verified locally it is downloading the right package
<img width="895" height="155" alt="image" src="https://github.com/user-attachments/assets/902e9f8d-e9fd-44e7-92e0-b96c8e3f1c82" />


---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No CI Checks only

--- 

### **Change Behind Feature Flag** (Yes / No)
Not behind a feature flag. Can't be placed behind a feature flag.

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
NA

---
### **Logging Added/Updated** (Yes/No)
NA

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
- Revert PR and unpin the agent if deployment is in progress

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.
