### PR TITLE
Don't delete the checkout target when the sources directory is empty

### DIFF
--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -187,34 +187,42 @@ namespace Agent.Plugins.Repository
             executionContext.Debug($"Repository requires to be placed at '{expectRepoPath}', current location is '{currentRepoPath}'");
             if (!string.Equals(currentRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), expectRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), IOUtil.FilePathStringComparison))
             {
-                executionContext.Output($"Repository is current at '{currentRepoPath}', move to '{expectRepoPath}'.");
-                var count = 1;
-                var staging = Path.Combine(tempDirectory, $"_{count}");
-                while (Directory.Exists(staging))
+                if (IsEmptyOrMissingDirectory(currentRepoPath))
                 {
-                    count++;
-                    staging = Path.Combine(tempDirectory, $"_{count}");
+                    executionContext.Output($"Repository source directory '{currentRepoPath}' is empty, nothing to move to '{expectRepoPath}'.");
+                    DeleteEmptySourceDirectoryThenCreate(executionContext, currentRepoPath, expectRepoPath);
                 }
-
-                try
+                else
                 {
-                    executionContext.Debug($"Move existing repository '{currentRepoPath}' to '{expectRepoPath}' via staging directory '{staging}'.");
-                    IOUtil.MoveDirectory(currentRepoPath, expectRepoPath, staging, CancellationToken.None);
-                }
-                catch (Exception ex)
-                {
-                    executionContext.Debug("Catch exception during repository move.");
-                    executionContext.Debug(ex.ToString());
-                    executionContext.Warning("Unable move and reuse existing repository to required location.");
+                    executionContext.Output($"Repository is current at '{currentRepoPath}', move to '{expectRepoPath}'.");
+                    var count = 1;
+                    var staging = Path.Combine(tempDirectory, $"_{count}");
+                    while (Directory.Exists(staging))
+                    {
+                        count++;
+                        staging = Path.Combine(tempDirectory, $"_{count}");
+                    }
 
                     try
                     {
-                        await IOUtil.DeleteDirectoryWithRetry(expectRepoPath, CancellationToken.None);
+                        executionContext.Debug($"Move existing repository '{currentRepoPath}' to '{expectRepoPath}' via staging directory '{staging}'.");
+                        IOUtil.MoveDirectory(currentRepoPath, expectRepoPath, staging, CancellationToken.None);
                     }
-                    catch (Exception ioEx)
+                    catch (Exception ex)
                     {
-                        executionContext.Output($"Unable to delete existing repository on required location: {ioEx.GetType()}");
-                        throw;
+                        executionContext.Debug("Catch exception during repository move.");
+                        executionContext.Debug(ex.ToString());
+                        executionContext.Warning("Unable move and reuse existing repository to required location.");
+
+                        try
+                        {
+                            await IOUtil.DeleteDirectoryWithRetry(expectRepoPath, CancellationToken.None);
+                        }
+                        catch (Exception ioEx)
+                        {
+                            executionContext.Output($"Unable to delete existing repository on required location: {ioEx.GetType()}");
+                            throw;
+                        }
                     }
                 }
 
@@ -230,6 +238,28 @@ namespace Agent.Plugins.Repository
 
             ISourceProvider sourceProvider = SourceProviderFactory.GetSourceProvider(repo.Type);
             await sourceProvider.GetSourceAsync(executionContext, repo, token);
+        }
+
+        private static bool IsEmptyOrMissingDirectory(string path)
+        {
+            return !Directory.Exists(path) || !Directory.EnumerateFileSystemEntries(path).Any();
+        }
+
+        private static void DeleteEmptySourceDirectoryThenCreate(AgentTaskPluginExecutionContext executionContext, string sourceDirectory, string directoryToCreate)
+        {
+            if (Directory.Exists(sourceDirectory))
+            {
+                try
+                {
+                    Directory.Delete(sourceDirectory, recursive: false);
+                }
+                catch (Exception ex)
+                {
+                    executionContext.Debug($"Unable to delete empty repository source directory '{sourceDirectory}': {ex.Message}");
+                }
+            }
+
+            Directory.CreateDirectory(directoryToCreate);
         }
     }
 

--- a/src/Agent.Plugins/RepositoryPlugin.cs
+++ b/src/Agent.Plugins/RepositoryPlugin.cs
@@ -187,10 +187,11 @@ namespace Agent.Plugins.Repository
             executionContext.Debug($"Repository requires to be placed at '{expectRepoPath}', current location is '{currentRepoPath}'");
             if (!string.Equals(currentRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), expectRepoPath.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), IOUtil.FilePathStringComparison))
             {
-                if (IsEmptyOrMissingDirectory(currentRepoPath))
+                if (IsEmptyOrMissingDirectory(executionContext, currentRepoPath))
                 {
                     executionContext.Output($"Repository source directory '{currentRepoPath}' is empty, nothing to move to '{expectRepoPath}'.");
-                    DeleteEmptySourceDirectoryThenCreate(executionContext, currentRepoPath, expectRepoPath);
+                    TryDeleteEmptyDirectory(executionContext, currentRepoPath);
+                    Directory.CreateDirectory(expectRepoPath);
                 }
                 else
                 {
@@ -240,26 +241,34 @@ namespace Agent.Plugins.Repository
             await sourceProvider.GetSourceAsync(executionContext, repo, token);
         }
 
-        private static bool IsEmptyOrMissingDirectory(string path)
+        private static bool IsEmptyOrMissingDirectory(AgentTaskPluginExecutionContext executionContext, string path)
         {
-            return !Directory.Exists(path) || !Directory.EnumerateFileSystemEntries(path).Any();
+            try
+            {
+                return !Directory.Exists(path) || !Directory.EnumerateFileSystemEntries(path).Any();
+            }
+            catch (Exception ex)
+            {
+                executionContext.Debug($"Unable to check whether repository source directory '{path}' is empty: {ex.Message}");
+                return false;
+            }
         }
 
-        private static void DeleteEmptySourceDirectoryThenCreate(AgentTaskPluginExecutionContext executionContext, string sourceDirectory, string directoryToCreate)
+        private static void TryDeleteEmptyDirectory(AgentTaskPluginExecutionContext executionContext, string directory)
         {
-            if (Directory.Exists(sourceDirectory))
+            if (!Directory.Exists(directory))
             {
-                try
-                {
-                    Directory.Delete(sourceDirectory, recursive: false);
-                }
-                catch (Exception ex)
-                {
-                    executionContext.Debug($"Unable to delete empty repository source directory '{sourceDirectory}': {ex.Message}");
-                }
+                return;
             }
 
-            Directory.CreateDirectory(directoryToCreate);
+            try
+            {
+                Directory.Delete(directory, recursive: false);
+            }
+            catch (Exception ex)
+            {
+                executionContext.Debug($"Unable to delete empty repository source directory '{directory}': {ex.Message}");
+            }
         }
     }
 

--- a/src/Test/L0/Plugin/RepositoryPluginL0.cs
+++ b/src/Test/L0/Plugin/RepositoryPluginL0.cs
@@ -436,7 +436,6 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
                 Directory.CreateDirectory(currentPath);
                 _executionContext.Inputs["Path"] = $"..{Path.DirectorySeparatorChar}test{Path.DirectorySeparatorChar}foo";
 
-
                 await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
 
                 var actualPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
@@ -537,6 +536,103 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
     
                     Assert.True(traceContent.Contains($"##vso[plugininternal.updaterepositorypath alias={repository.Alias};]{actualPath}"), $"Repo {repository.Alias} did not get updated to {actualPath}. CurrentPath = {currentPath}");
                 }
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Plugin")]
+        public async Task RepositoryPlugin_EmptySourceDirectory_KeepsExistingRepositoryAtTargetPath()
+        {
+            using (TestHostContext tc = new TestHostContext(this))
+            {
+                var trace = tc.GetTrace();
+                Setup(tc, allowWorkDirectory: "true");
+                var repository = _executionContext.Repositories.Single();
+
+                var currentPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+                Directory.CreateDirectory(currentPath);
+
+                var sharedPath = Path.Combine(tc.GetDirectory(WellKnownDirectory.Work), "shared", "myRepo");
+                Directory.CreateDirectory(Path.Combine(sharedPath, ".git"));
+                var existingFile = Path.Combine(sharedPath, ".git", "config");
+                File.WriteAllText(existingFile, "existing repository");
+
+                _executionContext.Inputs["Path"] = $"..{Path.DirectorySeparatorChar}shared{Path.DirectorySeparatorChar}myRepo";
+
+                await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
+
+                var actualPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+
+                Assert.Equal(sharedPath, actualPath);
+                Assert.True(Directory.Exists(actualPath));
+
+                Assert.True(File.Exists(existingFile), $"Existing repository at '{sharedPath}' was deleted.");
+                Assert.Equal("existing repository", File.ReadAllText(existingFile));
+
+                Assert.False(Directory.Exists(currentPath));
+
+                var traceContent = tc.GetTraceContent();
+
+                Assert.True(traceContent.Contains($"##vso[plugininternal.updaterepositorypath alias=myRepo;]{actualPath}"));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Plugin")]
+        public async Task RepositoryPlugin_NonEmptySourceDirectory_StillMovesToTargetPath()
+        {
+            using (TestHostContext tc = new TestHostContext(this))
+            {
+                var trace = tc.GetTrace();
+                Setup(tc, allowWorkDirectory: "true");
+                var repository = _executionContext.Repositories.Single();
+
+                var currentPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+                Directory.CreateDirectory(currentPath);
+                File.WriteAllText(Path.Combine(currentPath, "checkedout.txt"), "moved content");
+
+                var targetPath = Path.Combine(tc.GetDirectory(WellKnownDirectory.Work), "shared", "myRepo");
+                Directory.CreateDirectory(targetPath);
+                File.WriteAllText(Path.Combine(targetPath, "stale.txt"), "stale content");
+
+                _executionContext.Inputs["Path"] = $"..{Path.DirectorySeparatorChar}shared{Path.DirectorySeparatorChar}myRepo";
+
+                await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
+
+                var actualPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+
+                Assert.Equal(targetPath, actualPath);
+                Assert.False(Directory.Exists(currentPath));
+
+                Assert.True(File.Exists(Path.Combine(actualPath, "checkedout.txt")));
+                Assert.False(File.Exists(Path.Combine(actualPath, "stale.txt")));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Plugin")]
+        public async Task RepositoryPlugin_EmptySourceDirectory_TargetNestedUnderSource()
+        {
+            using (TestHostContext tc = new TestHostContext(this))
+            {
+                var trace = tc.GetTrace();
+                Setup(tc);
+                var repository = _executionContext.Repositories.Single();
+
+                var currentPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+                Directory.CreateDirectory(currentPath);
+
+                _executionContext.Inputs["Path"] = $"s{Path.DirectorySeparatorChar}nested";
+
+                await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
+
+                var actualPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+
+                Assert.Equal(Path.Combine(tc.GetDirectory(WellKnownDirectory.Work), "1", "s", "nested"), actualPath);
+                Assert.True(Directory.Exists(actualPath));
             }
         }
 

--- a/src/Test/L0/Plugin/RepositoryPluginL0.cs
+++ b/src/Test/L0/Plugin/RepositoryPluginL0.cs
@@ -581,6 +581,43 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests.Plugin
         [Fact]
         [Trait("Level", "L0")]
         [Trait("Category", "Plugin")]
+        public async Task RepositoryPlugin_MissingSourceDirectory_KeepsExistingRepositoryAtTargetPath()
+        {
+            using (TestHostContext tc = new TestHostContext(this))
+            {
+                var trace = tc.GetTrace();
+                Setup(tc, allowWorkDirectory: "true");
+                var repository = _executionContext.Repositories.Single();
+
+                var currentPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+                Assert.False(Directory.Exists(currentPath));
+
+                var sharedPath = Path.Combine(tc.GetDirectory(WellKnownDirectory.Work), "shared", "myRepo");
+                Directory.CreateDirectory(Path.Combine(sharedPath, ".git"));
+                var existingFile = Path.Combine(sharedPath, ".git", "config");
+                File.WriteAllText(existingFile, "existing repository");
+
+                _executionContext.Inputs["Path"] = $"..{Path.DirectorySeparatorChar}shared{Path.DirectorySeparatorChar}myRepo";
+
+                await _checkoutTask.RunAsync(_executionContext, CancellationToken.None);
+
+                var actualPath = repository.Properties.Get<string>(Pipelines.RepositoryPropertyNames.Path);
+
+                Assert.Equal(sharedPath, actualPath);
+                Assert.True(Directory.Exists(actualPath));
+
+                Assert.True(File.Exists(existingFile), $"Existing repository at '{sharedPath}' was deleted.");
+                Assert.Equal("existing repository", File.ReadAllText(existingFile));
+
+                var traceContent = tc.GetTraceContent();
+
+                Assert.True(traceContent.Contains($"##vso[plugininternal.updaterepositorypath alias=myRepo;]{actualPath}"));
+            }
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Plugin")]
         public async Task RepositoryPlugin_NonEmptySourceDirectory_StillMovesToTargetPath()
         {
             using (TestHostContext tc = new TestHostContext(this))


### PR DESCRIPTION
### **Context**
Fixes #5618.

With `AZP_AGENT_ALLOW_WORK_DIRECTORY_REPOSITORIES=true` a single clone can be shared between pipelines on a self-hosted agent (`path: ../shared/$(Build.Repository.Name)`, `clean: false`). The first run of any *new* pipeline definition deletes that shared repository and re-clones it from scratch, defeating some of the purpose of sharing it.

On a first run there is no tracking config yet, so `BuildDirectoryManager.PrepareDirectory` points the repository at the default sources directory and creates it empty. `RepositoryPlugin` then finds that the current path differs from the expected path and calls `IOUtil.MoveDirectory`, which deletes the destination before moving the source in. The freshly created empty directory replaces the populated shared repository, and checkout falls through to `git init` plus a full clone.

Related: #3498 reported the harmless-warning variant of the same first-run move.

---

### **Description**
Skip the move when the sources directory is empty or missing — there is nothing to relocate, so the move can only delete the destination. The repository path is retargeted and the source provider decides whether the existing content is reusable, which `GitSourceProvider` already does via `IsRepositoryOriginUrlMatch`: delete and re-clone on a mismatch, incremental fetch on a match.

The orphaned empty sources directory is then removed on a best-effort basis (non-recursive delete; a failure is traced and the directory left in place), and removed before the expected path is created, so the delete cannot interfere with an expected path nested inside the sources directory.

If the sources directory cannot be enumerated at all — access denied, for instance — the emptiness check reports "not empty" and the existing move path runs, so such a failure still surfaces as today's warning instead of failing the checkout task.

The existing move path is untouched when the sources directory has content.

---

### **Risk Assessment** (Low / Medium / High)
Low.

 - Only the empty-or-missing-sources-directory case changes, and there the old code had nothing to preserve: it deleted the expected path and moved an empty directory in, or — with the sources directory missing — threw out of MoveDirectory and deleted the expected path in the catch.
- The one difference a pipeline can observe is that the expected path is no longer emptied before GetSourceAsync runs. Both providers already handle pre-existing content: GitSourceProvider compares the origin URL and deletes on mismatch, TfsVCSourceProvider deletes and recreates the sources directory on a clean run.
- IOUtil.MoveDirectory is not modified, and the branch that calls it is unchanged, so a populated sources directory behaves exactly as before.

---

### **Unit Tests Added or Updated** (Yes / No)
Yes. Four tests in `RepositoryPluginL0`:

- `RepositoryPlugin_EmptySourceDirectory_KeepsExistingRepositoryAtTargetPath` — the reported bug: an empty sources directory must not delete a repository already at the requested path.
- `RepositoryPlugin_MissingSourceDirectory_KeepsExistingRepositoryAtTargetPath` — the state a previous run leaves behind: the sources directory is gone and the repository already sits at the requested path.
- `RepositoryPlugin_NonEmptySourceDirectory_StillMovesToTargetPath` — a populated sources directory is still relocated over the target.
- `RepositoryPlugin_EmptySourceDirectory_TargetNestedUnderSource` — the expected path resolves to a directory inside the sources directory.

---

### **Additional Testing Performed**
Full L0 suite on Windows (net8.0), before and after the change: 1468 → 1472 tests, with the 4 new ones passing. Confirmed across three runs.

---

### **Change Behind Feature Flag** (Yes / No)
No. Moving an empty directory onto a populated one has no outcome other than deleting the destination, so there is no prior behaviour worth keeping reachable behind a knob.

---

### **Tech Design / Approach**
Nothing to note.

---

### **Documentation Changes Required** (Yes/No)
No.

