### PR TITLE
Fix Windows artifact path matching

### DIFF
--- a/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
+++ b/src/Agent.Plugins/BuildArtifact/BuildArtifactPluginV1.cs
@@ -75,12 +75,6 @@ namespace Agent.Plugins.BuildArtifacts
         static readonly string buildVersionToDownloadSpecific = "specific";
         static readonly string buildVersionToDownloadLatestFromBranch = "latestFromBranch";
         static readonly string extractedTarsTempDir = "extracted_tars";
-        static readonly Options minimatchOptions = new Options()
-        {
-            Dot = true,
-            NoBrace = true,
-            AllowWindowsPaths = PlatformUtil.RunningOnWindows
-        };
 
         protected override async Task ProcessCommandInternalAsync(
             AgentTaskPluginExecutionContext context,
@@ -122,6 +116,8 @@ namespace Agent.Plugins.BuildArtifacts
                 new[] { "\n" },
                 StringSplitOptions.RemoveEmptyEntries
             );
+
+            var minimatchOptions = CreateMinimatchOptions(context);
 
             string[] tagsInput = tags.Split(
                 new[] { "," },
@@ -485,6 +481,20 @@ namespace Agent.Plugins.BuildArtifacts
             }
 
             return result;
+        }
+
+        internal static Options CreateMinimatchOptions(IKnobValueContext context)
+        {
+            ArgUtil.NotNull(context, nameof(context));
+
+            return new Options()
+            {
+                Dot = true,
+                NoBrace = true,
+                AllowWindowsPaths = PlatformUtil.RunningOnWindows,
+                NoCase = PlatformUtil.RunningOnWindows &&
+                    AgentKnobs.CaseInsensitiveArtifactMatchingFixEnabled.GetValue(context).AsBoolean()
+            };
         }
 
         private async Task<Guid> GetProjectIdAsync(AgentTaskPluginExecutionContext context, string projectName)

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -858,6 +858,12 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("DISABLE_RESOURCE_UTILIZATION_WARNINGS"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob CaseInsensitiveArtifactMatchingFixEnabled = new Knob(
+            nameof(CaseInsensitiveArtifactMatchingFixEnabled),
+            "Enables case-insensitive artifact matching on Windows.",
+            new PipelineFeatureSource(nameof(CaseInsensitiveArtifactMatchingFixEnabled)),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob Rosetta2Warning = new Knob(
             nameof(Rosetta2Warning),
             "Log warning when X64 Agent is used on a Apple Silicon device.",

--- a/src/Test/L0/KnobL0.cs
+++ b/src/Test/L0/KnobL0.cs
@@ -4,6 +4,8 @@
 using System;
 using Agent.Sdk;
 using Agent.Sdk.Knob;
+using Agent.Plugins.BuildArtifacts;
+using Microsoft.VisualStudio.Services.Agent.Util;
 using Microsoft.VisualStudio.Services.Agent.Worker;
 using Xunit;
 using Moq;
@@ -197,6 +199,30 @@ namespace Microsoft.VisualStudio.Services.Agent.Tests
             var knobValue = knob.GetValue(executionContext.Object);
 
             Assert.True(knobValue.AsBoolean());
+        }
+
+        [Fact]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        public void CaseInsensitiveArtifactMatchingUsesPipelineFeature()
+        {
+            var knobContext = new Mock<IKnobValueContext>();
+            knobContext
+                .Setup(x => x.GetVariableValueOrDefault("DistributedTask.Agent.CaseInsensitiveArtifactMatchingFixEnabled"))
+                .Returns((string)null);
+            knobContext
+                .Setup(x => x.GetScopedEnvironment())
+                .Returns(new LocalEnvironment());
+
+            var options = DownloadBuildArtifactTaskV1_0_0.CreateMinimatchOptions(knobContext.Object);
+            Assert.False(options.NoCase);
+
+            knobContext
+                .Setup(x => x.GetVariableValueOrDefault("DistributedTask.Agent.CaseInsensitiveArtifactMatchingFixEnabled"))
+                .Returns("true");
+
+            options = DownloadBuildArtifactTaskV1_0_0.CreateMinimatchOptions(knobContext.Object);
+            Assert.Equal(PlatformUtil.RunningOnWindows, options.NoCase);
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes Windows-only artifact exclusion matching so case-only path differences are handled consistently when the controlled rollout flag is enabled.

## Risk Assessment
Low - behavior is unchanged unless the flag is enabled, and the change applies only on Windows.

## Services affected
Azure Pipelines agent; Download Build Artifacts v1.

## How did you test it?
Added and ran focused L0 coverage for disabled and enabled flag behavior on Windows. Ran the supported agent build.

## How will you monitor the rollout
Monitor aggregate Download Build Artifacts task reliability and failure rates during staged enablement.

## How can the DRI rollback these changes?
Disable `DistributedTask.Agent.CaseInsensitiveArtifactMatchingFixEnabled`.