### PR TITLE
Fix agent package servicing URLs

### DIFF
--- a/src/Misc/InstallAgentPackage.template.xml
+++ b/src/Misc/InstallAgentPackage.template.xml
@@ -46,12 +46,12 @@
     </ServicingStep>
     <ServicingStep name="Add x64 Linux musl agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="linux-musl-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="linux-musl-x64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-musl-x64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM64 Linux musl agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="agent" platform="linux-musl-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="agent" platform="linux-musl-arm64" hashValue="<HASH_VALUE>" version="<AGENT_VERSION>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-musl-arm64-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add x64 Windows agent package" stepPerformer="DistributedTask" stepType="AddTaskPackage">

--- a/src/Misc/UpdateAgentPackage.template.xml
+++ b/src/Misc/UpdateAgentPackage.template.xml
@@ -64,7 +64,7 @@
     </ServicingStep>
     <ServicingStep name="Add ARM Linux agent package (without Node 6)" stepPerformer="DistributedTask" stepType="AddTaskPackage">
       <StepData>
-        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="vsts-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
+        <AddTaskPackageData packageType="pipelines-agent" platform="linux-arm" version="<AGENT_VERSION>" hashValue="<HASH_VALUE>" downloadUrl="https://download.agent.dev.azure.com/agent/<AGENT_VERSION>/pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" infoUrl="https://go.microsoft.com/fwlink/?LinkId=798199" filename="pipelines-agent-linux-arm-<AGENT_VERSION>.tar.gz" />
       </StepData>
     </ServicingStep>
     <ServicingStep name="Add ARM64 Linux agent package (without Node 6)" stepPerformer="DistributedTask" stepType="AddTaskPackage">

--- a/src/Test/L0/ServicingPackageTemplatesL0.cs
+++ b/src/Test/L0/ServicingPackageTemplatesL0.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Services.Agent.Tests
+{
+    public sealed class ServicingPackageTemplatesL0
+    {
+        [Theory]
+        [Trait("Level", "L0")]
+        [Trait("Category", "Common")]
+        [InlineData("InstallAgentPackage.template.xml")]
+        [InlineData("UpdateAgentPackage.template.xml")]
+        public void PackageNamesMatchTypeAndPlatform(string templateName)
+        {
+            const string testVersion = "0.0.0";
+            string templatePath = Path.Combine(TestUtil.GetSrcPath(), "Misc", templateName);
+            string template = File.ReadAllText(templatePath)
+                .Replace("<AGENT_VERSION>", testVersion)
+                .Replace("<HASH_VALUE>", "hash");
+            XElement[] packages = XDocument.Parse(template)
+                .Descendants("AddTaskPackageData")
+                .ToArray();
+
+            Assert.NotEmpty(packages);
+
+            foreach (XElement package in packages)
+            {
+                string packageType = package.Attribute("packageType").Value;
+                string platform = package.Attribute("platform").Value;
+                string filename = package.Attribute("filename").Value;
+                string downloadUrl = package.Attribute("downloadUrl").Value;
+                string filenamePrefix = packageType == "agent" ? "vsts-agent" : packageType;
+                string extension = platform.StartsWith("win-", StringComparison.Ordinal) ? ".zip" : ".tar.gz";
+                string expectedFilename = $"{filenamePrefix}-{platform}-{testVersion}{extension}";
+
+                Assert.Equal(expectedFilename, filename);
+                Assert.True(
+                    downloadUrl.EndsWith($"/{expectedFilename}", StringComparison.Ordinal),
+                    $"Download URL '{downloadUrl}' does not match package type '{packageType}' and platform '{platform}'.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### **Context**
The agent release pipeline copies the servicing templates into its generated Azure DevOps PR. Several hard-coded package references did not match their declared package type or platform, causing generated manifests to select the wrong archives.

---

### **Description**
Correct the `linux-musl-x64` and `linux-musl-arm64` download URLs in `InstallAgentPackage.template.xml`. Correct the `pipelines-agent` Linux ARM URL and filename in `UpdateAgentPackage.template.xml`. Add an L0 invariant test that validates package filenames and URL basenames against each entry's package type and platform.

---

### **Risk Assessment** (Low / Medium / High)
Low. The changes only correct package archive references in release servicing templates and add validation around their existing naming convention.

---

### **Unit Tests Added or Updated** (Yes / No)
Yes. Added `ServicingPackageTemplatesL0` coverage for both servicing templates.

---

### **Additional Testing Performed**
Ran the targeted L0 tests on .NET 8 for Windows x64.

---

### **Change Behind Feature Flag** (Yes / No)
No. This fixes incorrect release metadata and cannot be meaningfully feature-gated.

---

### **Tech Design / Approach**
No architectural change. The test derives the expected archive name from `packageType`, `platform`, and the platform-specific archive extension, then checks both `filename` and `downloadUrl`.

---

### **Documentation Changes Required** (Yes/No)
No.

---

### **Logging Added/Updated** (Yes/No)
No.

---

### **Telemetry Added/Updated** (Yes/No)
No.

---

### **Rollback Scenario and Process** (Yes/No)
Yes. Revert this PR to restore the previous servicing template references.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes. The invariant test covers every package entry in both affected templates.