### PR TITLE
Rerun label checks when PR labels change

### DIFF
--- a/.github/labelChecker/index.js
+++ b/.github/labelChecker/index.js
@@ -1,18 +1,21 @@
-const rm = require('typed-rest-client/RestClient');
 const core = require('@actions/core');
 const github = require('@actions/github');
 
-async function main() {
+function main() {
     try {
         const issueTypes = ['bug', 'enhancement', 'misc', 'internal'];
         const pullRequestNumber = github.context.issue.number;
         console.log(`Running for PR: ${pullRequestNumber}\n`);
-        let rest = new rm.RestClient('labelChecker');
-        console.log('Getting label info\n');
-        let res = await rest.get(`https://api.github.com/repos/microsoft/azure-pipelines-agent/issues/${pullRequestNumber}/labels`);
-        console.log(`Labels: ${JSON.stringify(res.result)}`);
+
+        const pullRequest = github.context.payload && github.context.payload.pull_request;
+        const labels = pullRequest && pullRequest.labels;
+        if (!Array.isArray(labels)) {
+            throw new Error('The pull request event payload did not contain labels.');
+        }
+
+        console.log(`Labels: ${JSON.stringify(labels)}`);
         let labelCount = 0;
-        res.result.forEach(tag => {
+        labels.forEach(tag => {
             let name = tag.name.toLowerCase();
             if (issueTypes.indexOf(name) > -1) {
                 console.log(`Found tag: ${name}`);

--- a/.github/workflows/labelChecker.yml
+++ b/.github/workflows/labelChecker.yml
@@ -1,15 +1,22 @@
 # This workflow ensures that all PRs are correctly labeled
 
 name: LabelChecker
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: read
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - run: |
         cd .github/labelChecker
         npm install


### PR DESCRIPTION
### **Context**
 The LabelChecker required check did not rerun when labels were added or removed because the workflow used only the default `pull_request` activity types. This could leave the check result stale after a PR was correctly labeled.
 
 No related work item or GitHub issue.
 
 ---
 
 ### **Description**
 - Rerun LabelChecker when PRs are labeled or unlabeled, as well as when they are opened, synchronized, or reopened.
 - Read labels directly from the pull request event payload instead of making a separate GitHub API request.
 - Use read-only workflow permissions and prevent checkout credentials from being persisted.
 
 ---
 
 ### **Risk Assessment** (Low)
 The change is limited to PR validation workflow behavior. It preserves the existing accepted labels and validation rules.
 
 ---
 
 ### **Unit Tests Added or Updated** (No)
 The workflow script does not currently have a unit-test harness.
 
 ---
 
 ### **Additional Testing Performed**
 Validated the updated JavaScript with `node --check` and reviewed the workflow event configuration and permission settings.
 
 ---
 
 ### **Change Behind Feature Flag** (No)
 This is a repository CI workflow correction. It can be rolled back by reverting the commit.
 
 ---
 
 ### **Tech Design / Approach**
 The workflow now subscribes explicitly to `opened`, `synchronize`, `reopened`, `labeled`, and `unlabeled` pull request events. LabelChecker consumes `github.context.payload.pull_request.labels`, avoiding an unnecessary authenticated REST request.
 
 ---
 
 ### **Documentation Changes Required** (No)
 No user-facing or operational documentation changes are required.
 
 ---
 
 ### **Logging Added/Updated** (No)
 Existing workflow diagnostic output is retained. No sensitive values are logged.
 
 ---
 
 ### **Telemetry Added/Updated** (No)
 This repository workflow does not emit product telemetry.
 
 ---
 
 ### **Rollback Scenario and Process** (Yes)
 Revert the PR commit to restore the previous workflow triggers and label retrieval behavior.
 
 ---
 
 ### **Dependency Impact Assessed and Regression Tested** (Yes)
 No dependencies were added or updated. The change only removes the runtime use of the existing REST client from LabelChecker.